### PR TITLE
small fix for compile error in Encode.hs

### DIFF
--- a/Data/Aeson/Encode.hs
+++ b/Data/Aeson/Encode.hs
@@ -71,7 +71,7 @@ string s = fromChar '"' `mappend` quote s `mappend` fromChar '"'
 fromNumber :: Number -> Builder
 fromNumber (I i) = integral i
 fromNumber (D d)
-    | isNaN d || isInfinite d = "null"
+    | isNaN d || isInfinite d = fromByteString "null"
     | otherwise               = double d
 
 -- | Efficiently serialize a JSON value as a lazy 'L.ByteString'.


### PR DESCRIPTION
"null" needed to be fromByteString "null" to fix this error:

Building aeson-0.3.2.10...
[5 of 7] Compiling Data.Aeson.Encode ( Data/Aeson/Encode.hs, dist/build/Data/Aeson/Encode.o )

Data/Aeson/Encode.hs:74:33:
    No instance for (Data.String.IsString Builder)
      arising from the literal `"null"'
    Possible fix:
      add an instance declaration for (Data.String.IsString Builder)
    In the expression: "null"
    In an equation for`fromNumber':
        fromNumber (D d)
          | isNaN d || isInfinite d = "null"
          | otherwise = double d
cabal: Error: some packages failed to install:
aeson-0.3.2.10 failed during the building phase. The exception was:
ExitFailure 1
