### PR TITLE
edited Data.Aeson.Encoding,  

### DIFF
--- a/Data/Aeson/Encode.hs
+++ b/Data/Aeson/Encode.hs
@@ -71,7 +71,7 @@ string s = fromChar '"' `mappend` quote s `mappend` fromChar '"'
 fromNumber :: Number -> Builder
 fromNumber (I i) = integral i
 fromNumber (D d)
-    | isNaN d || isInfinite d = "null"
+    | isNaN d || isInfinite d = fromByteString "null"
     | otherwise               = double d
 
 -- | Efficiently serialize a JSON value as a lazy 'L.ByteString'.


### PR DESCRIPTION
ghc complains "null" is not a Builder; 
but fromByteString "null" is a Builder
