### PR TITLE
Fixed Data.Aeson.TH compilation warnings

### DIFF
--- a/Data/Aeson/TH.hs
+++ b/Data/Aeson/TH.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE NoImplicitPrelude, TemplateHaskell #-}
+{-# LANGUAGE CPP, NoImplicitPrelude, TemplateHaskell #-}
 
 {-|
 Module:      Data.Aeson.TH
@@ -140,13 +140,16 @@ import Data.Aeson.Types ( Value(..) )
 import Control.Applicative ( pure, (<$>), (<*>) )
 import Control.Monad       ( return, mapM, mzero, liftM2 )
 import Data.Bool           ( otherwise )
-import GHC.Base            ( Monad(..), String )
 import Data.Eq             ( (==) )
 import Data.Function       ( ($), (.), id )
 import Data.Functor        ( fmap )
 import Data.List           ( (++), foldl', map, zip, genericLength )
-import Prelude             ( (-), Integer, fromInteger, error )
+import Prelude             ( String, (-), Integer, error )
 import Text.Show           ( show )
+#if __GLASGOW_HASKELL__ < 700
+import Control.Monad       ( (>>=), fail )
+import Prelude             ( fromInteger )
+#endif
 -- from containers:
 import qualified Data.Map as M ( toList )
 -- from template-haskell:


### PR DESCRIPTION
A more permanent solution to get rid of the compilation warnings. I have made the imports of `(>>=)`, `fail` and `fromInteger` dependent on the GHC version. `String` is now imported from the Prelude, which should work with all GHC versions.

From the [release notes](http://haskell.org/ghc/docs/7.0.1/html/users_guide/release-7-0-1.html) of GHC 7.0.1:

> Rebinadble syntax now has its own extension, [RebindableSyntax](http://www.haskell.org/ghc/docs/7.0-latest/html/users_guide/syntax-extns.html#rebindable-syntax), and thus is no longer enabled by NoImplicitPrelude.

I have tested the change with 6.12.1, 7.0.4 and 7.2.1. All compile without warnings.
