### PR TITLE
DEPRECATE Data.Aeson.Generic

### DIFF
--- a/Data/Aeson/Generic.hs
+++ b/Data/Aeson/Generic.hs
@@ -13,8 +13,13 @@
 --
 -- This is based on the 'Text.JSON.Generic' package originally written
 -- by Lennart Augustsson.
+--
+-- /NOTE: This module is DEPRECATED!/
+--
+-- Please use 'genericFromJSON' or 'genericToJSON' from "Data.Aeson.Types" instead.
 
 module Data.Aeson.Generic
+    {-# DEPRECATED "Please use genericFromJSON or genericToJSON from Data.Aeson.Types instead" #-}
     (
       fromJSON
     , toJSON
@@ -23,8 +28,10 @@ module Data.Aeson.Generic
 import Data.Aeson.Types (Value, Result, genericFromJSON, genericToJSON)
 import Data.Data (Data)
 
+{-# DEPRECATED fromJSON "Please use Data.Aeson.Types.genericFromJSON instead." #-}
 fromJSON :: (Data a) => Value -> Result a
 fromJSON = genericFromJSON
 
+{-# DEPRECATED toJSON "Please use Data.Aeson.Types.genericToJSON instead." #-}
 toJSON :: (Data a) => a -> Value
 toJSON = genericToJSON


### PR DESCRIPTION
We can now use `genericFromJSON` or `genericToJSON` from `Data.Aeson.Types` instead.

In some later version the module could be removed.
