### PR TITLE
Allow Null values for String fields

### DIFF
--- a/Data/Aeson/Types.hs
+++ b/Data/Aeson/Types.hs
@@ -397,6 +397,7 @@ instance ToJSON [Char] where
 
 instance FromJSON [Char] where
     parseJSON (String t) = pure (T.unpack t)
+    parseJSON Null       = pure ""
     parseJSON v          = typeMismatch "String" v
     {-# INLINE parseJSON #-}
 


### PR DESCRIPTION
The JSON that github sends (over AMQP) for push notifications includes
null values for string fields sometimes.
