### PR TITLE
Bump dependency on deepseq

### DIFF
--- a/aeson.cabal
+++ b/aeson.cabal
@@ -122,7 +122,7 @@ library
     blaze-textual >= 0.2.0.2,
     bytestring,
     containers,
-    deepseq < 1.2,
+    deepseq < 1.3,
     hashable >= 1.1.2.0,
     mtl,
     old-locale,


### PR DESCRIPTION
Some packages (e.g. the latest `containers`) require deepseq-1.2
