### PR TITLE
Allow building with both the newer and older deepseq and containers

### DIFF
--- a/aeson.cabal
+++ b/aeson.cabal
@@ -102,6 +102,9 @@ flag developer
   description: operate in developer mode
   default: False
 
+flag old-deepseq-containers
+  default: False
+
 library
   exposed-modules:
     Data.Aeson
@@ -121,8 +124,6 @@ library
     blaze-builder >= 0.2.1.4,
     blaze-textual >= 0.2.0.2,
     bytestring,
-    containers,
-    deepseq < 1.2,
     hashable >= 1.1.2.0,
     mtl,
     old-locale,
@@ -132,6 +133,15 @@ library
     time,
     unordered-containers >= 0.1.3.0,
     vector >= 0.7
+
+  if flag(old-deepseq-containers)
+    build-depends:
+      containers < 0.4.2,
+      deepseq < 1.2
+  else
+    build-depends:
+      containers >= 0.4.2,
+      deepseq >= 1.2
 
   if flag(developer)
     ghc-options: -Werror


### PR DESCRIPTION
This is also the approach taken in the new `hackage-server`.

Fixes #28
