### PR TITLE
Added new accessor with default value

### DIFF
--- a/Data/Aeson.hs
+++ b/Data/Aeson.hs
@@ -30,6 +30,7 @@ module Data.Aeson
     , (.=)
     , (.:)
     , (.:?)
+    , (.:/)
     , object
     -- * Parsing
     , json

--- a/Data/Aeson/Types.hs
+++ b/Data/Aeson/Types.hs
@@ -35,6 +35,7 @@ module Data.Aeson.Types
     , (.=)
     , (.:)
     , (.:?)
+    , (.:/)
     , object
     ) where
 

--- a/Data/Aeson/Types/Class.hs
+++ b/Data/Aeson/Types/Class.hs
@@ -33,6 +33,7 @@ module Data.Aeson.Types.Class
     , fromJSON
     , (.:)
     , (.:?)
+    , (.:/)
     , (.=)
     , typeMismatch
     ) where
@@ -706,6 +707,20 @@ obj .:? key = case M.lookup key obj of
                Nothing -> pure Nothing
                Just v  -> parseJSON v
 {-# INLINE (.:?) #-}
+
+-- | Retrieve the value associated with the given key of an 'Object'.
+-- The result is a default value if the key is not present, or 'empty' 
+-- if the value cannot be converted to the desired type.
+--
+-- This accessor is most useful if the key and value can be absent 
+-- from an object without affecting its validity and we know a 
+-- default value to assign in that case.  If the key and value 
+-- are mandatory, use '(.:)' instead.
+(.:/) :: (FromJSON a) => Object -> (Text, a) -> Parser a
+obj .:/ (key, val) = case M.lookup key obj of
+               Nothing -> pure val
+               Just v  -> parseJSON v
+{-# INLINE (.:/) #-}
 
 
 -- | Fail parsing due to a type mismatch, with a descriptive message.


### PR DESCRIPTION
Hi, I just added a new accessor (.:/) that allow to assign a default value in case the key is not present in the JSON.

Example:

``` haskell
data Coord { x :: Double, y :: Double }

instance FromJSON Coord where
   parseJSON (Object v) = Coord <$>
                         v .:/ ("x", 0.0) <*>
                         v .:/ ("y", 0.0)

-- A non-Object value is of the wrong type, so use mzero to fail.
   parseJSON _          = mzero

```

I added the code need to use, and documentation, but I don't know if the operator name is well chosen.

Thanks, Luis
