### PR TITLE
Strict Value fields

### DIFF
--- a/Data/Aeson/Types/Internal.hs
+++ b/Data/Aeson/Types/Internal.hs
@@ -157,10 +157,10 @@ type Object = Map Text Value
 type Array = Vector Value
 
 -- | A JSON value represented as a Haskell value.
-data Value = Object Object
-           | Array Array
-           | String Text
-           | Number Number
+data Value = Object !Object
+           | Array !Array
+           | String !Text
+           | Number !Number
            | Bool !Bool
            | Null
              deriving (Eq, Show, Typeable, Data)


### PR DESCRIPTION
This improves the running time of the `AesonParse` benchmarks.
I don't think there's a use-case for lazy fields.
Fixes #37
