### PR TITLE
Remove upper bound on deepseq

### DIFF
--- a/Data/Aeson/Types.hs
+++ b/Data/Aeson/Types.hs
@@ -41,6 +41,7 @@ module Data.Aeson.Types
 
 import Control.Applicative
 import Control.DeepSeq (NFData(..))
+import Control.DeepSeq.Containers ()
 import Control.Monad (MonadPlus(..), ap)
 import Data.Aeson.Functions
 import Data.Attoparsec.Char8 (Number(..))

--- a/aeson.cabal
+++ b/aeson.cabal
@@ -1,5 +1,5 @@
 name:            aeson
-version:         0.3.2.12
+version:         0.3.2.13
 license:         BSD3
 license-file:    LICENSE
 category:        Text, Web, JSON
@@ -119,7 +119,8 @@ library
     blaze-textual >= 0.2.0.2,
     bytestring,
     containers,
-    deepseq < 1.2,
+    deepseq,
+    containers-deepseq,
     hashable >= 1.1.2.0,
     mtl,
     old-locale,


### PR DESCRIPTION
The upper bound on deepseq is a bit of an annoyance, as it forces us into cabal dependency hell all the time. This patch uses containers-deepseq to keep the NFData instance of Map even with deepseq 1.2. The instance definitions are taken directly from deepseq 1.1, so there should be no change in behavior.
