### PR TITLE
Fix for '_'-fields in generics.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ dist
 benchmarks/AesonEncode
 
 tests/qc
+/.project
+/.dist-buildwrapper

--- a/Data/Aeson/Generic.hs
+++ b/Data/Aeson/Generic.hs
@@ -145,12 +145,6 @@ toJSON = toJSON_generic
       where tyrep = typeOf . head . H.keys $ m
             remap f = Object . mapKeyVal (f . fromJust . cast) toJSON $ m
 
--- Skip leading '_' in field name so we can use keywords
--- etc. as field names.
-mungeField :: String -> Text
-mungeField ('_':cs) = pack cs
-mungeField cs       = pack cs
-
 toJSON_generic :: (Data a) => a -> Value
 toJSON_generic = generic
   where
@@ -183,7 +177,7 @@ toJSON_generic = generic
         encodeArgs c = encodeArgs' (constrFields c)
         encodeArgs' [] [j] = j
         encodeArgs' [] js  = Array . V.fromList $ js
-        encodeArgs' ns js  = object $ zip (map mungeField ns) js
+        encodeArgs' ns js  = object $ zip (map pack ns) js
 
 
 fromJSON :: (Data a) => Value -> Result a
@@ -320,7 +314,7 @@ parseJSON_generic j = generic
         -- Select the named fields from a JSON object.
         selectFields fjs = mapM sel
           where sel f = maybe (modFail "parseJSON" $ "field does not exist " ++
-                               f) return $ H.lookup (mungeField f) fjs
+                               f) return $ H.lookup (pack f) fjs
 
         -- Count how many arguments a constructor has.  The value x is
         -- used to determine what type the constructor returns.

--- a/aeson.cabal
+++ b/aeson.cabal
@@ -8,7 +8,10 @@ copyright:       (c) 2011 Bryan O'Sullivan
 author:          Bryan O'Sullivan <bos@serpentine.com>
 maintainer:      Bryan O'Sullivan <bos@serpentine.com>
 stability:       experimental
-tested-with:     GHC == 6.12.3, GHC == 7.0.4, GHC == 7.2.2
+tested-with:     
+                 GHC == 6.12.3,
+                 GHC == 7.0.4,
+                 GHC == 7.2.2
 synopsis:        Fast JSON parsing and encoding
 cabal-version:   >= 1.8
 homepage:        https://github.com/bos/aeson
@@ -151,6 +154,7 @@ test-suite tests
 
   build-depends:
     QuickCheck,
+    HUnit,
     aeson,
     attoparsec,
     base,
@@ -159,6 +163,7 @@ test-suite tests
     template-haskell,
     test-framework,
     test-framework-quickcheck2,
+    test-framework-hunit,
     text
 
 source-repository head

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -12,7 +12,9 @@ import Data.Data (Typeable, Data)
 import Data.Text (Text)
 import Test.Framework (Test, defaultMain, testGroup)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
+import Test.Framework.Providers.HUnit (testCase)
 import Test.QuickCheck (Arbitrary(..))
+import Test.HUnit (Assertion, (@=?))
 import qualified Data.Aeson.Generic as G
 import qualified Data.Attoparsec.Lazy as L
 import qualified Data.ByteString.Lazy.Char8 as L
@@ -150,6 +152,29 @@ tests = [
     , testProperty "Either Integer Integer" (toFromJSON :: Either Integer Integer -> Bool)
     ],
   testGroup "genericToFromJSON" [
-      testProperty "_UFoo" (genericToFromJSON :: UFoo -> Bool)
+      testProperty "_UFoo" (genericToFromJSON :: UFoo -> Bool),
+      testCase "Decode" caseSimpleGeneric
     ]
   ]
+  
+-- Generic
+
+data UAlone = UAlone {
+    _id :: Int,
+    st :: String
+} deriving (Show, Eq, Data, Typeable)
+
+data Solid = Solid {
+    _solId :: Int,
+    solId :: Int,
+    solTwo :: String
+} deriving (Show, Eq, Data, Typeable)
+
+caseSimpleGeneric :: Assertion
+caseSimpleGeneric = do
+    let rs = "{\"_solId\":1,\"solId\":5,\"solTwo\":\"a\"}"
+    let es = Solid {_solId=1, solId=5, solTwo="a"}
+    let ra = "{\"_id\":3,\"st\":\"s\"}"
+    let ea = UAlone {_id = 3, st = "s"}
+    Just es @=? (G.decode rs :: Maybe Solid) 
+    Just ea @=? (G.decode ra :: Maybe UAlone)


### PR DESCRIPTION
This fixes weird bug that comes in #29. All tests passed.

closes #53

Sorry about encoding. GitHub said that two symbols in different encoding is different. All what I do - remove `mungeField` function.

If you prefer your's encoding - I can correct it.
