### PR TITLE
Added CompareWithJSON benchmark from issue: #56

### DIFF
--- a/benchmarks/CompareWithJSON.hs
+++ b/benchmarks/CompareWithJSON.hs
@@ -18,13 +18,13 @@ instance NFData J.JSValue where
   rnf (J.JSArray lst) = rnf lst
   rnf (J.JSObject o) = rnf o
 
-encodeJ :: J.JSObject J.JSValue -> Int
+encodeJ :: J.JSValue -> Int
 encodeJ = length . J.encode
 
 encodeA :: A.Value -> Int64
 encodeA = BL.length . A.encode
 
-decodeJ :: String -> J.JSObject J.JSValue
+decodeJ :: String -> J.JSValue
 decodeJ s =
   case J.decodeStrict s of
     J.Ok v -> v


### PR DESCRIPTION
My results on running this on `benchmarks/json-data/jp100.json` with GHC-7.4.1-rc1:

```
benchmarking decode/json
mean: 21.16657 ms, lb 20.40948 ms, ub 21.87215 ms, ci 0.950
std dev: 3.740378 ms, lb 3.458451 ms, ub 3.964592 ms, ci 0.950
variance introduced by outliers: 92.567%
variance is severely inflated by outliers

benchmarking decode/aeson
mean: 5.458151 ms, lb 5.246154 ms, ub 5.734707 ms, ci 0.950
std dev: 1.241663 ms, lb 1.011339 ms, ub 1.463769 ms, ci 0.950
found 20 outliers among 100 samples (20.0%)
  18 (18.0%) high severe
variance introduced by outliers: 95.722%
variance is severely inflated by outliers

benchmarking encode/json
mean: 1.329795 ms, lb 1.315440 ms, ub 1.375647 ms, ci 0.950
std dev: 117.6547 us, lb 35.56607 us, ub 259.4640 us, ci 0.950
found 7 outliers among 100 samples (7.0%)
  6 (6.0%) high severe
variance introduced by outliers: 74.847%
variance is severely inflated by outliers

benchmarking encode/aeson
mean: 2.087864 ms, lb 2.061921 ms, ub 2.121384 ms, ci 0.950
std dev: 150.1140 us, lb 127.2650 us, ub 201.8160 us, ci 0.950
found 24 outliers among 100 samples (24.0%)
  23 (23.0%) high mild
  1 (1.0%) high severe
variance introduced by outliers: 65.643%
variance is severely inflated by outliers
```
