### PR TITLE
Use MonadPlus in (.:?) to produce whatever empty value is needed instead of always producing a Nothing on failure. This way (.:?) can be re-used for lists, Maybe, or whatever other MonadPlus you desire.

### DIFF
--- a/Data/Aeson/Types/Class.hs
+++ b/Data/Aeson/Types/Class.hs
@@ -40,6 +40,7 @@ module Data.Aeson.Types.Class
     ) where
 
 import Control.Applicative ((<$>), (<*>), pure)
+import Control.Monad (MonadPlus(..), mzero)
 import Data.Aeson.Functions
 import Data.Aeson.Types.Internal
 import Data.Attoparsec.Char8 (Number(..))
@@ -735,15 +736,17 @@ obj .: key = case H.lookup key obj of
 {-# INLINE (.:) #-}
 
 -- | Retrieve the value associated with the given key of an 'Object'.
--- The result is 'Nothing' if the key is not present, or 'empty' if
--- the value cannot be converted to the desired type.
+-- If the key is not present the result is decided by 'mzero'; it is 'Nothing'
+-- when a 'Maybe' is desired, '[]' when a list is desired, and so on.  The
+-- result is 'empty' if the  key is present but the value cannot be converted
+-- to the desired type.
 --
 -- This accessor is most useful if the key and value can be absent
 -- from an object without affecting its validity.  If the key and
 -- value are mandatory, use '(.:)' instead.
-(.:?) :: (FromJSON a) => Object -> Text -> Parser (Maybe a)
+(.:?) :: (FromJSON (m a), MonadPlus m) => Object -> Text -> Parser (m a)
 obj .:? key = case H.lookup key obj of
-               Nothing -> pure Nothing
+               Nothing -> pure mzero
                Just v  -> parseJSON v
 {-# INLINE (.:?) #-}
 


### PR DESCRIPTION
I've used this a few times in my libraries to produce lists or Maybes, as needed.

Here's an example (I had named it `(.:<)` in my code so as not to conflict with Aeson's, but have since changed that locally): https://github.com/mike-burns/github/blob/master/Github/Data.hs#L36
