### PR TITLE
Add (<.:>), which is like (.:) but traverses through the JSON according to the given path

### DIFF
--- a/Data/Aeson/Types.hs
+++ b/Data/Aeson/Types.hs
@@ -37,6 +37,7 @@ module Data.Aeson.Types
     , (.:)
     , (.:?)
     , (.!=)
+    , (<.:>)
     , object
     ) where
 


### PR DESCRIPTION
This patch adds a `(<.:>)` function which is a traversal version of `(.:)`. That is, instead of taking one key, it takes a list of keys and traverses the JSON until it gets to the end.

I used it here: https://github.com/mike-burns/github/blob/master/Github/Data.hs#L358-L361

For this JSON: https://api.github.com/repos/thoughtbot/paperclip/pulls
