### PR TITLE
Added eitherDecode and eitherDecode'

### DIFF
--- a/Data/Aeson.hs
+++ b/Data/Aeson.hs
@@ -16,6 +16,8 @@ module Data.Aeson
     -- * Encoding and decoding
       decode
     , decode'
+    , eitherDecode
+    , eitherDecode'
     , encode
     -- * Core JSON types
     , Value(..)
@@ -40,7 +42,7 @@ module Data.Aeson
     ) where
 
 import Data.Aeson.Encode (encode)
-import Data.Aeson.Parser.Internal (decodeWith, json, json')
+import Data.Aeson.Parser.Internal (decodeWith, eitherDecodeWith, json, json')
 import Data.Aeson.Types
 import qualified Data.ByteString.Lazy as L
 
@@ -63,3 +65,13 @@ decode = decodeWith json fromJSON
 decode' :: (FromJSON a) => L.ByteString -> Maybe a
 decode' = decodeWith json' fromJSON
 {-# INLINE decode' #-}
+
+-- | Like 'decode' but returns an error message when decoding fails.
+eitherDecode :: (FromJSON a) => L.ByteString -> Either String a
+eitherDecode = eitherDecodeWith json fromJSON
+{-# INLINE eitherDecode #-}
+
+-- | Like 'decode'' but returns an error message when decoding fails.
+eitherDecode' :: (FromJSON a) => L.ByteString -> Either String a
+eitherDecode' = eitherDecodeWith json' fromJSON
+{-# INLINE eitherDecode' #-}

--- a/Data/Aeson/Parser/Internal.hs
+++ b/Data/Aeson/Parser/Internal.hs
@@ -23,6 +23,7 @@ module Data.Aeson.Parser.Internal
     , value'
     -- * Helpers
     , decodeWith
+    , eitherDecodeWith
     ) where
 
 import Blaze.ByteString.Builder (fromByteString, toByteString)
@@ -237,6 +238,15 @@ decodeWith p to s =
                       _         -> Nothing
       _          -> Nothing
 {-# INLINE decodeWith #-}
+
+eitherDecodeWith :: Parser Value -> (Value -> Result a) -> L.ByteString -> Either String a
+eitherDecodeWith p to s =
+    case L.parse p s of
+      L.Done _ v -> case to v of
+                      Success a -> Right a
+                      Error msg -> Left msg
+      L.Fail _ _ msg -> Left msg
+{-# INLINE eitherDecodeWith #-}
 
 -- $lazy
 --


### PR DESCRIPTION
Hi Bryan,

When debugging REST API's that accept and return JSON it's really helpful to receive error messages why JSON decoding failed. The attached patch adds `eitherDecode` and `eitherDecode'` which are just like `decode` and `decode'` respectively but return an error message when decoding fails.

I'm not sure about the names yet but I couldn't think of something better.

Bas
