### PR TITLE
depends on text >= 0.11.1.0

### DIFF
--- a/aeson.cabal
+++ b/aeson.cabal
@@ -130,7 +130,7 @@ library
     old-locale,
     syb,
     template-haskell >= 2.4,
-    text >= 0.11.0.2,
+    text >= 0.11.1.0,
     time,
     unordered-containers >= 0.1.3.0,
     vector >= 0.7.1


### PR DESCRIPTION
for Data.Text.Lazy.Builder.RealFloat (Data/Aeson/Encode.hs)
