### PR TITLE
Fix #72.

### DIFF
--- a/Data/Aeson/Generic.hs
+++ b/Data/Aeson/Generic.hs
@@ -290,6 +290,7 @@ parseJSON_generic j = generic
         decodeArgs c0 = go (numConstrArgs (resType generic) c0) c0
                            (constrFields c0)
          where
+          go 0 c _        Null       = construct c []
           go 1 c []       jd         = construct c [jd] -- unary constructor
           go _ c []       (Array js) = construct c (V.toList js) -- no field names
           -- FIXME? We could allow reading an array into a constructor


### PR DESCRIPTION
Sometimes, it appears, Nullary constructors can be encoded as Null as
well as an empty array [not sure why one this!]. The Generic code, as of
49befcafc80a85b371a6e0e0d5ab4ad9b33d8778, fails when a Null is
passed for a nullary constructor. Add in a pattern match to fix this
issue.

See https://github.com/bos/aeson/issues/72
