### PR TITLE
Remove now-redundant note in cabal file

### DIFF
--- a/aeson.cabal
+++ b/aeson.cabal
@@ -24,11 +24,6 @@ description:
     For release notes, see
     <https://github.com/bos/aeson/blob/master/release-notes.markdown>
     .
-    /Note/: if you use GHCi or Template Haskell, please see the
-    @README@ file for important details about building this package,
-    and other packages that depend on it:
-    <https://github.com/bos/aeson#readme>
-    .
     Parsing performance on a late 2010 MacBook Pro (2.66GHz Core i7),
     for mostly-English tweets from Twitter's JSON search API:
     .


### PR DESCRIPTION
As of a0cfef2052acd373e2cbccb8166a12d7e6bba1f3 the README no longer contains the notes that the cabal file refers to.
