### PR TITLE
Default Time Format in FromJSON instance of ZonedTime

### DIFF
--- a/aeson.cabal
+++ b/aeson.cabal
@@ -1,5 +1,5 @@
 name:            aeson
-version:         0.6.1.1
+version:         0.6.1.0
 license:         BSD3
 license-file:    LICENSE
 category:        Text, Web, JSON


### PR DESCRIPTION
In the parsing of zoned times, the time format obtained from defaultTimeLocale is not tried. Many JSON files use this format ([Twitter created_at field](https://dev.twitter.com/docs/platform-objects/tweets), for example) and I think it should be in the list of time formats too.

I added the format in the simplest way. Not sure if any further changes are needed, but currently it works just fine.
