### PR TITLE
Fix lazy I/O leak and trailing garbage ignore bug in decode functions

### DIFF
--- a/Data/Aeson.hs
+++ b/Data/Aeson.hs
@@ -76,7 +76,7 @@ module Data.Aeson
     ) where
 
 import Data.Aeson.Encode (encode)
-import Data.Aeson.Parser.Internal (decodeWith, eitherDecodeWith, json, json')
+import Data.Aeson.Parser.Internal (decodeWith, eitherDecodeWith, jsonEOF, json, jsonEOF', json')
 import Data.Aeson.Types
 import qualified Data.ByteString.Lazy as L
 
@@ -87,7 +87,7 @@ import qualified Data.ByteString.Lazy as L
 -- This function parses immediately, but defers conversion.  See
 -- 'json' for details.
 decode :: (FromJSON a) => L.ByteString -> Maybe a
-decode = decodeWith json fromJSON
+decode = decodeWith jsonEOF fromJSON
 {-# INLINE decode #-}
 
 -- | Efficiently deserialize a JSON value from a lazy 'L.ByteString'.
@@ -97,17 +97,17 @@ decode = decodeWith json fromJSON
 -- This function parses and performs conversion immediately.  See
 -- 'json'' for details.
 decode' :: (FromJSON a) => L.ByteString -> Maybe a
-decode' = decodeWith json' fromJSON
+decode' = decodeWith jsonEOF' fromJSON
 {-# INLINE decode' #-}
 
 -- | Like 'decode' but returns an error message when decoding fails.
 eitherDecode :: (FromJSON a) => L.ByteString -> Either String a
-eitherDecode = eitherDecodeWith json fromJSON
+eitherDecode = eitherDecodeWith jsonEOF fromJSON
 {-# INLINE eitherDecode #-}
 
 -- | Like 'decode'' but returns an error message when decoding fails.
 eitherDecode' :: (FromJSON a) => L.ByteString -> Either String a
-eitherDecode' = eitherDecodeWith json' fromJSON
+eitherDecode' = eitherDecodeWith jsonEOF' fromJSON
 {-# INLINE eitherDecode' #-}
 
 -- $use

--- a/Data/Aeson/Parser/Internal.hs
+++ b/Data/Aeson/Parser/Internal.hs
@@ -15,11 +15,11 @@
 module Data.Aeson.Parser.Internal
     (
     -- * Lazy parsers
-      json
+      json, jsonEOF
     , value
     , jstring
     -- * Strict parsers
-    , json'
+    , json', jsonEOF'
     , value'
     -- * Helpers
     , decodeWith
@@ -271,3 +271,13 @@ eitherDecodeWith p to s =
 -- The 'json'' and 'value'' parsers combine identification with
 -- conversion.  They consume more CPU cycles up front, but have a
 -- smaller memory footprint.
+
+-- | Parse a top-level JSON value followed by optional whitespace and
+-- end-of-input.  See also: 'json'.
+jsonEOF :: Parser Value
+jsonEOF = json <* skipSpace <* endOfInput
+
+-- | Parse a top-level JSON value followed by optional whitespace and
+-- end-of-input.  See also: 'json''.
+jsonEOF' :: Parser Value
+jsonEOF' = json' <* skipSpace <* endOfInput


### PR DESCRIPTION
The decode family of functions ignore the rest-of-bytestring immediately following the JSON in the string.

This causes 2 problems:

1) Any time a file/string is decoded, any trailing garbage after the JSON will be completely ignored.  Even mismatched braces could cause a JSON to be early-terminated (without a syntax error) and some of the JSON content can be silently ignored.

2) When using lazy I/O to generate the bytestring, the bytestring will _never_ be fully read, which will mean that even fully forcing the decode result, the file handle will necessarily leak (until GC kills the bytestring).
