### PR TITLE
Fixed typos in documentation. ('-' and 'Coord')

### DIFF
--- a/Data/Aeson.hs
+++ b/Data/Aeson.hs
@@ -128,13 +128,13 @@ eitherDecode' = eitherDecodeWith json' fromJSON
 -- > data Person = Person
 -- >     { name :: Text
 -- >     , age  :: Int
--- >     } deriving Show-
+-- >     } deriving Show
 --
 -- To decode data, we need to define a 'FromJSON' instance:
 --
 -- > {-# LANGUAGE OverloadedStrings #-}
 -- >
--- > instance FromJSON Coord where
+-- > instance FromJSON Person where
 -- >     parseJSON (Object v) = Person <$>
 -- >                            v .: "name" <*>
 -- >                            v .: "age"


### PR DESCRIPTION
- Is there supposed to be a "-" after Show? I had to remove it in order to compile my example.
- Clearly "Coord" is from one of the example applications and got missed in a copy-paste. It should be an instance for Person.

(this is my first pull request, so let me know if anything looks fishy)

Cheers!
