### PR TITLE
Use the Builder from bytestring >= 0.10

### DIFF
--- a/aeson.cabal
+++ b/aeson.cabal
@@ -91,6 +91,10 @@ flag developer
   description: operate in developer mode
   default: False
 
+flag blaze-builder
+  description: Use blaze-builder instead of bytestring >= 0.10
+  default: False
+
 library
   exposed-modules:
     Data.Aeson
@@ -115,7 +119,6 @@ library
   build-depends:
     attoparsec >= 0.8.6.1,
     base == 4.*,
-    blaze-builder >= 0.2.1.4,
     bytestring,
     containers,
     deepseq,
@@ -128,6 +131,12 @@ library
     time,
     unordered-containers >= 0.1.3.0,
     vector >= 0.7.1
+
+  if flag(blaze-builder)
+    build-depends: blaze-builder >= 0.2.1.4
+    cpp-options: -DUSE_BLAZE_BUILDER
+  else
+    build-depends: bytestring >= 0.10
 
   if flag(developer)
     ghc-options: -Werror


### PR DESCRIPTION
`bytestring` >= 0.10 provides its own `Builder`. This patch makes `aeson` use that `Builder` but if users don't have `bytestring` >= 0.10 they can configure the package with `-fblaze-builder` which enables `aeson` to be build with `blaze-builder` and older versions of `bytestring`.

The motivation for this patch is that this makes it easier to propose `aeson` for the Haskell Platform because `blaze-builder` is not in the HP.
