### PR TITLE
Drop even more ByteString related instances

### DIFF
--- a/Data/Aeson/Functions.hs
+++ b/Data/Aeson/Functions.hs
@@ -12,17 +12,9 @@ module Data.Aeson.Functions
     , hashMapKey
     , mapKeyVal
     , mapKey
-    -- * String conversions
-    , decode
-    , strict
-    , lazy
     ) where
 
 import Data.Hashable (Hashable)
-import Data.Text (Text)
-import Data.Text.Encoding (decodeUtf8, encodeUtf8)
-import qualified Data.ByteString as B
-import qualified Data.ByteString.Lazy as L
 import qualified Data.HashMap.Strict as H
 import qualified Data.Map as M
 
@@ -48,15 +40,3 @@ mapKeyVal fk kv = H.foldrWithKey (\k v -> H.insert (fk k) (kv v)) H.empty
 mapKey :: (Eq k2, Hashable k2) => (k1 -> k2) -> H.HashMap k1 v -> H.HashMap k2 v
 mapKey fk = mapKeyVal fk id
 {-# INLINE mapKey #-}
-
-strict :: L.ByteString -> Text
-strict = decode . B.concat . L.toChunks
-{-# INLINE strict #-}
-
-lazy :: Text -> L.ByteString
-lazy = L.fromChunks . (:[]) . encodeUtf8
-{-# INLINE lazy #-}
-
-decode :: B.ByteString -> Text
-decode = decodeUtf8
-{-# INLINE decode #-}

--- a/Data/Aeson/Generic.hs
+++ b/Data/Aeson/Generic.hs
@@ -30,7 +30,7 @@ module Data.Aeson.Generic
 import Control.Applicative ((<$>))
 import Control.Arrow (first)
 import Control.Monad.State.Strict
-import Data.Aeson.Functions hiding (decode)
+import Data.Aeson.Functions
 import Data.Aeson.Types hiding (FromJSON(..), ToJSON(..), fromJSON)
 import Data.Attoparsec.Number (Number)
 import Data.Generics
@@ -39,14 +39,11 @@ import Data.Int (Int8, Int16, Int32, Int64)
 import Data.IntSet (IntSet)
 import Data.Maybe (fromJust)
 import Data.Text (Text, pack, unpack)
-import Data.Text.Encoding (encodeUtf8)
 import Data.Time.Clock (UTCTime)
 import Data.Word (Word, Word8, Word16, Word32, Word64)
 import Data.Aeson.Parser.Internal (decodeWith, json, json')
 import qualified Data.Aeson.Encode as E
-import qualified Data.Aeson.Functions as F
 import qualified Data.Aeson.Types as T
-import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as L
 import qualified Data.HashMap.Strict as H
 import qualified Data.Map as Map
@@ -127,8 +124,6 @@ toJSON = toJSON_generic
       | tyrep == typeOf DT.empty = remap id
       | tyrep == typeOf LT.empty = remap LT.toStrict
       | tyrep == typeOf ""       = remap pack
-      | tyrep == typeOf B.empty  = remap F.decode
-      | tyrep == typeOf L.empty  = remap strict
       | otherwise = modError "toJSON" $
                              "cannot convert map keyed by type " ++ show tyrep
       where tyrep = typeOf . head . Map.keys $ m
@@ -138,8 +133,6 @@ toJSON = toJSON_generic
       | tyrep == typeOf DT.empty = remap id
       | tyrep == typeOf LT.empty = remap LT.toStrict
       | tyrep == typeOf ""       = remap pack
-      | tyrep == typeOf B.empty  = remap F.decode
-      | tyrep == typeOf L.empty  = remap strict
       | otherwise = modError "toJSON" $
                              "cannot convert map keyed by type " ++ show tyrep
       where tyrep = typeOf . head . H.keys $ m
@@ -235,8 +228,6 @@ parseJSON j = parseJSON_generic j
         | tyrep == typeOf DT.empty = process id
         | tyrep == typeOf LT.empty = process LT.fromStrict
         | tyrep == typeOf ""       = process DT.unpack
-        | tyrep == typeOf B.empty  = process encodeUtf8
-        | tyrep == typeOf L.empty  = process lazy
         | otherwise = myFail
         where
           process f = maybe myFail return . cast =<< parseWith f
@@ -252,8 +243,6 @@ parseJSON j = parseJSON_generic j
         | tyrep == typeOf DT.empty = process id
         | tyrep == typeOf LT.empty = process LT.fromStrict
         | tyrep == typeOf ""       = process DT.unpack
-        | tyrep == typeOf B.empty  = process encodeUtf8
-        | tyrep == typeOf L.empty  = process lazy
         | otherwise = myFail
       where
         process f = maybe myFail return . cast =<< parseWith f

--- a/Data/Aeson/Types/Class.hs
+++ b/Data/Aeson/Types/Class.hs
@@ -61,7 +61,6 @@ import Data.Maybe (fromMaybe)
 import Data.Monoid (Dual(..), First(..), Last(..), mappend)
 import Data.Ratio (Ratio)
 import Data.Text (Text, pack, unpack)
-import Data.Text.Encoding (encodeUtf8)
 import Data.Time (UTCTime, ZonedTime(..), TimeZone(..))
 import Data.Time.Format (FormatTime, formatTime, parseTime)
 import Data.Traversable (traverse)
@@ -70,8 +69,6 @@ import Data.Vector (Vector)
 import Data.Word (Word, Word8, Word16, Word32, Word64)
 import Foreign.Storable (Storable)
 import System.Locale (defaultTimeLocale, dateTimeFmt)
-import qualified Data.ByteString as B
-import qualified Data.ByteString.Lazy as LB
 import qualified Data.HashMap.Strict as H
 import qualified Data.HashSet as HashSet
 import qualified Data.IntMap as IntMap
@@ -568,18 +565,6 @@ instance (ToJSON v) => ToJSON (M.Map String v) where
 instance (FromJSON v) => FromJSON (M.Map String v) where
     parseJSON = fmap (hashMapKey unpack) . parseJSON
 
-instance (ToJSON v) => ToJSON (M.Map B.ByteString v) where
-    toJSON = Object . mapHashKeyVal decode toJSON
-
-instance (FromJSON v) => FromJSON (M.Map B.ByteString v) where
-    parseJSON = fmap (hashMapKey encodeUtf8) . parseJSON
-
-instance (ToJSON v) => ToJSON (M.Map LB.ByteString v) where
-    toJSON = Object . mapHashKeyVal strict toJSON
-
-instance (FromJSON v) => FromJSON (M.Map LB.ByteString v) where
-    parseJSON = fmap (hashMapKey lazy) . parseJSON
-
 instance (ToJSON v) => ToJSON (H.HashMap Text v) where
     toJSON = Object . H.map toJSON
     {-# INLINE toJSON #-}
@@ -598,18 +583,6 @@ instance (ToJSON v) => ToJSON (H.HashMap String v) where
 
 instance (FromJSON v) => FromJSON (H.HashMap String v) where
     parseJSON = fmap (mapKey unpack) . parseJSON
-
-instance (ToJSON v) => ToJSON (H.HashMap B.ByteString v) where
-    toJSON = Object . mapKeyVal decode toJSON
-
-instance (FromJSON v) => FromJSON (H.HashMap B.ByteString v) where
-    parseJSON = fmap (mapKey encodeUtf8) . parseJSON
-
-instance (ToJSON v) => ToJSON (H.HashMap LB.ByteString v) where
-    toJSON = Object . mapKeyVal strict toJSON
-
-instance (FromJSON v) => FromJSON (H.HashMap LB.ByteString v) where
-    parseJSON = fmap (mapKey lazy) . parseJSON
 
 instance ToJSON Value where
     toJSON a = a


### PR DESCRIPTION
This follows up on 9ee73f303cacb8ae by removing some more ByteString
related instances as suggested by @basvandijk in #126.
