### PR TITLE
Fixed issue #163.

### DIFF
--- a/Data/Aeson/Types/Instances.hs
+++ b/Data/Aeson/Types/Instances.hs
@@ -204,8 +204,15 @@ instance HasResolution a => ToJSON (Fixed a) where
     toJSON = Number . realToFrac
     {-# INLINE toJSON #-}
 
+scientificToFixed :: HasResolution a => Scientific -> Fixed a
+scientificToFixed x =
+  let (c, e) = (coefficient x, base10Exponent x)
+   in if e < 0
+    then fromIntegral c / 10^(-e)
+    else fromIntegral (c * 10^e)
+
 instance HasResolution a => FromJSON (Fixed a) where
-    parseJSON = withScientific "Fixed" $ pure . realToFrac
+    parseJSON = withScientific "Fixed" $ pure . scientificToFixed
     {-# INLINE parseJSON #-}
 
 instance ToJSON Int where

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -9,6 +9,7 @@ import Test.QuickCheck (Arbitrary(..))
 import qualified Data.Vector as V
 import qualified Data.Attoparsec.Lazy as L
 import qualified Data.ByteString.Lazy.Char8 as L
+import Data.Fixed
 import qualified Data.Text as T
 import qualified Data.HashMap.Strict as H
 import Data.Time.Clock (UTCTime(..))
@@ -124,6 +125,13 @@ tests = [
   testGroup "toFromJSON" [
       testProperty "Integer" (toFromJSON :: Integer -> Bool)
     , testProperty "Double" (toFromJSON :: Double -> Bool)
+    , testProperty "Fixed0" (toFromJSON :: Fixed E0 -> Bool)
+    , testProperty "Fixed1" (toFromJSON :: Fixed E1 -> Bool)
+    , testProperty "Fixed2" (toFromJSON :: Fixed E2 -> Bool)
+    , testProperty "Fixed3" (toFromJSON :: Fixed E3 -> Bool)
+    , testProperty "Fixed6" (toFromJSON :: Fixed E6 -> Bool)
+    , testProperty "Fixed9" (toFromJSON :: Fixed E9 -> Bool)
+    , testProperty "Fixed12" (toFromJSON :: Fixed E12 -> Bool)
     , testProperty "Maybe Integer" (toFromJSON :: Maybe Integer -> Bool)
     , testProperty "Either Integer Double" (toFromJSON :: Either Integer Double -> Bool)
     , testProperty "Either Integer Integer" (toFromJSON :: Either Integer Integer -> Bool)


### PR DESCRIPTION
See #163.

This fixes it by converting the 'Scientific' itself instead of going through a Double.

By the way, this is a relatively high-priority issue, since it's affecting the $$$ parsing in network-bitcoin, and people are seeing the wrong amount of money. Would you mind doing a x.y.z+1 release in the near future?

Related issue: https://github.com/wowus/network-bitcoin/issues/10
