### PR TITLE
Fix "incomplete input" from decodeStrictWith

### DIFF
--- a/Data/Aeson/Parser/Internal.hs
+++ b/Data/Aeson/Parser/Internal.hs
@@ -259,11 +259,9 @@ decodeWith p to s =
 decodeStrictWith :: Parser Value -> (Value -> Result a) -> B.ByteString
                  -> Maybe a
 decodeStrictWith p to s =
-    case A.parse p s of
-      A.Done _ v -> case to v of
-                      Success a -> Just a
-                      _         -> Nothing
-      _          -> Nothing
+    case either Error to (A.parseOnly p s) of
+      Success a -> Just a
+      Error _ -> Nothing
 {-# INLINE decodeStrictWith #-}
 
 eitherDecodeWith :: Parser Value -> (Value -> Result a) -> L.ByteString


### PR DESCRIPTION
As described and demo'd in #167, `decodeStrict` and `decodeStrict'` treat incomplete input as a failure. This is similar to #142, which fixed the same issue with the `eitherDecodeStrict` variants.
