### PR TITLE
Fix attoparsec dependency

### DIFF
--- a/aeson.cabal
+++ b/aeson.cabal
@@ -115,7 +115,7 @@ library
       Data.Aeson.Types.Generic
 
   build-depends:
-    attoparsec >= 0.8.6.1,
+    attoparsec >= 0.11.1.0,
     base == 4.*,
     bytestring,
     containers,


### PR DESCRIPTION
`Data.Aeson.Parser.Internal` uses `peekWord8'`, which is only available in
attoparsec >= 0.11.1.0.
