### PR TITLE
Fix JSON instance for UTCTime to yield a valid ISO8601 string

### DIFF
--- a/Data/Aeson/Types/Instances.hs
+++ b/Data/Aeson/Types/Instances.hs
@@ -500,11 +500,8 @@ instance FromJSON ZonedTime where
     parseJSON v = typeMismatch "ZonedTime" v
 
 instance ToJSON UTCTime where
-    toJSON t = String (pack (str ++ z : "Z"))
-      where (str,(x:y:_)) = splitAt 22 $
-                            formatTime defaultTimeLocale "%FT%T.%q" t
-            z | y < '5'   = x
-              | otherwise = succ x
+    toJSON t = String (pack (take 23 str ++ "Z"))
+      where str = formatTime defaultTimeLocale "%FT%T.%q" t
     {-# INLINE toJSON #-}
 
 instance FromJSON UTCTime where


### PR DESCRIPTION
The current code does not yield a valid ISO8601 format string when the third fractional digit is `9` and the fourth digit is larger than `5`, since `succ '9' == ':'`. The following ghci session illustrates the issue

``` haskell
> :set -XOverloadedStrings
> import Data.Aeson
> import Data.Time
> fmap show (decode "[ \"2014-01-06T02:50:34.0296Z\" ]" :: Maybe [UTCTime])
Just "[2014-01-06 02:50:34.0296 UTC]"
> fmap encode (decode "[ \"2014-01-06T02:50:34.0296Z\" ]" :: Maybe [UTCTime])
Just "[\"2014-01-06T02:50:34.02:Z\"]"
```

With this patch the value is simply truncated to milliseconds by rounding down.
