### PR TITLE
Fix cabal-install for GHC 7.8;  better support for GHC < 7.8

### DIFF
--- a/Data/Aeson/Encode.hs
+++ b/Data/Aeson/Encode.hs
@@ -19,14 +19,9 @@
 module Data.Aeson.Encode
     ( encode
 
-#if MIN_VERSION_bytestring(0,10,4)
     -- * Encoding to Builders
     , encodeToByteStringBuilder
     , encodeToTextBuilder
-#else
-    -- * Encoding to Text Builders
-    , encodeToTextBuilder
-#endif
 
     -- * Deprecated
     , fromValue
@@ -42,18 +37,7 @@ import qualified Data.HashMap.Strict as H
 import qualified Data.Text as T
 import qualified Data.Vector as V
 
-#if MIN_VERSION_bytestring(0,10,4)
 import Data.Aeson.Encode.ByteString (encode, encodeToByteStringBuilder)
-#else
-import Data.Aeson.Types (ToJSON(toJSON))
-import qualified Data.ByteString.Lazy    as BL
-import qualified Data.Text.Lazy.Builder  as TLB
-import qualified Data.Text.Lazy.Encoding as TLE
-
--- | Encode a JSON 'Value' as a UTF-8 encoded 'BL.ByteString'.
-encode :: ToJSON a => a -> BL.ByteString
-encode = TLE.encodeUtf8 . TLB.toLazyText . encodeToTextBuilder . toJSON
-#endif
 
 -- | Encode a JSON 'Value' to a 'Builder', which can be embedded efficiently
 -- in a text-based protocol.

--- a/Data/Aeson/Parser/Internal.hs
+++ b/Data/Aeson/Parser/Internal.hs
@@ -28,18 +28,8 @@ module Data.Aeson.Parser.Internal
     , eitherDecodeStrictWith
     ) where
 
-#if defined(USE_BLAZE_BUILDER)
-import Blaze.ByteString.Builder (Builder, fromByteString, toByteString)
-import Blaze.ByteString.Builder.Char.Utf8 (fromChar)
-import Blaze.ByteString.Builder.Word (fromWord8)
-#else
-#if MIN_VERSION_bytestring(0,10,2)
 import Data.ByteString.Builder
-#else
-import Data.ByteString.Lazy.Builder
-#endif
   (Builder, byteString, toLazyByteString, charUtf8, word8)
-#endif
 
 import Control.Applicative ((*>), (<$>), (<*), liftA2, pure)
 import Data.Aeson.Types (Result(..), Value(..))
@@ -331,21 +321,6 @@ jsonEOF = json <* skipSpace <* endOfInput
 jsonEOF' :: Parser Value
 jsonEOF' = json' <* skipSpace <* endOfInput
 
-#if defined(USE_BLAZE_BUILDER)
-byteString :: ByteString -> Builder
-byteString = fromByteString
-{-# INLINE byteString #-}
-
-charUtf8 :: Char -> Builder
-charUtf8 = fromChar
-{-# INLINE charUtf8 #-}
-
-word8 :: Word8 -> Builder
-word8 = fromWord8
-{-# INLINE word8 #-}
-
-#else
 toByteString :: Builder -> ByteString
 toByteString = L.toStrict . toLazyByteString
 {-# INLINE toByteString #-}
-#endif

--- a/aeson.cabal
+++ b/aeson.cabal
@@ -1,5 +1,5 @@
 name:            aeson
-version:         0.7.0.0
+version:         0.7.0.1
 license:         BSD3
 license-file:    LICENSE
 category:        Text, Web, JSON
@@ -96,14 +96,7 @@ library
     Data.Aeson.Types.Class
     Data.Aeson.Types.Instances
     Data.Aeson.Types.Internal
-
-  if flag(new-bytestring-builder)
-    other-modules: Data.Aeson.Encode.ByteString
-    build-depends: bytestring >= 0.10.4.0,
-                   text >= 1.1.0.0
-  else
-    build-depends: bytestring < 0.10.4.0,
-                   text >= 0.11.1.0
+    Data.Aeson.Encode.ByteString
 
   if impl(ghc >= 7.2.1)
     cpp-options: -DGENERICS
@@ -111,9 +104,13 @@ library
     other-modules:
       Data.Aeson.Types.Generic
 
+  if impl(ghc < 7.8)
+    build-depends: bytestring-builder
+
   build-depends:
     attoparsec >= 0.11.1.0,
     base == 4.*,
+    bytestring,
     containers,
     deepseq,
     hashable >= 1.1.2.0,
@@ -124,13 +121,8 @@ library
     time,
     unordered-containers >= 0.1.3.0,
     vector >= 0.7.1,
-    scientific >= 0.2
-
-  if flag(blaze-builder)
-    build-depends: blaze-builder >= 0.2.1.4
-    cpp-options: -DUSE_BLAZE_BUILDER
-  else
-    build-depends: bytestring >= 0.10
+    scientific >= 0.2,
+    text >= 1.1.1.0
 
   if flag(developer)
     ghc-options: -Werror


### PR DESCRIPTION
Proposed fix for #177.  This does have the downside that it would
immediately require text-1.1,  which might cause for some people
committed to older versions of the Haskell Platform.
