### PR TITLE
depends on unordered-containers 0.2.3.0 for HashMap Data instance

### DIFF
--- a/aeson.cabal
+++ b/aeson.cabal
@@ -122,7 +122,7 @@ library
     syb,
     template-haskell >= 2.4,
     time,
-    unordered-containers >= 0.1.3.0,
+    unordered-containers >= 0.2.3.0,
     vector >= 0.7.1,
     scientific >= 0.2
 


### PR DESCRIPTION
Data instance for HashMap, which only seems to appear in 0.2.3.0, but
aeson's current dependency is only on 0.1.3.0.

Data instance for HashMap

I could only reproduce this error when trying to install lens and aeson as I described in #182

Installing version 4.0 of lens after fixing this bug uncovers a lens bug. That bug is caused because cpphs is a dependency, but not listed in the cabal file. @edwardk told me he was pushing an update however so that lens no longer depends on cpphs.

After merging this change in, lens and aeson should be able to coexist a little better ;)
