### PR TITLE
Make all cabal flags manual

### DIFF
--- a/aeson.cabal
+++ b/aeson.cabal
@@ -72,6 +72,7 @@ extra-source-files:
 flag developer
   description: operate in developer mode
   default: False
+  manual: True
 
 flag blaze-builder
   description: Use blaze-builder instead of bytestring >= 0.10


### PR DESCRIPTION
This means that dependency solver's job is easier (it doesn't need to
consider the opposite flag setting) and it means that cabal cannot
automatically switch these flags (which I don't think happened in the
past, but it's theoretically possible).
