### PR TITLE
Data.Aeson.Types.Instances: fix UTCTime for years outside of [0, 9999]

### DIFF
--- a/Data/Aeson/Types/Instances.hs
+++ b/Data/Aeson/Types/Instances.hs
@@ -493,8 +493,9 @@ instance FromJSON ZonedTime where
     parseJSON v = typeMismatch "ZonedTime" v
 
 instance ToJSON UTCTime where
-    toJSON t = String (pack (take 23 str ++ "Z"))
-      where str = formatTime defaultTimeLocale "%FT%T.%q" t
+    toJSON t = String $ pack $ formatTime defaultTimeLocale format t
+      where
+        format = "%FT%T." ++ formatMillis t ++ "Z"
     {-# INLINE toJSON #-}
 
 instance FromJSON UTCTime where


### PR DESCRIPTION
∙ "take 23" is a dubious way to truncate to millisecond accuracy.
∙ instance ToJSON ZonedTime had it right, so copypasta from it.

```
*Data.Aeson> import Data.Time
*Data.Aeson Data.Time> encode $ UTCTime (fromGregorian 100000 1 1) 0
"\"100000-01-01T00:00:00.0Z\""
```
