### PR TITLE
Update import location of scientificBuilder for v0.3.0.0

### DIFF
--- a/Data/Aeson/Encode.hs
+++ b/Data/Aeson/Encode.hs
@@ -29,9 +29,10 @@ module Data.Aeson.Encode
 
 import Data.Aeson.Types (Value(..))
 import Data.Monoid (mappend)
-import Data.Scientific (Scientific, coefficient, base10Exponent, scientificBuilder)
+import Data.Scientific (Scientific, coefficient, base10Exponent)
 import Data.Text.Lazy.Builder
 import Data.Text.Lazy.Builder.Int (decimal)
+import Data.Text.Lazy.Builder.Scientific (scientificBuilder)
 import Numeric (showHex)
 import qualified Data.HashMap.Strict as H
 import qualified Data.Text as T

--- a/aeson.cabal
+++ b/aeson.cabal
@@ -103,7 +103,7 @@ library
     hashable >= 1.1.2.0,
     mtl,
     old-locale,
-    scientific >= 0.2,
+    scientific >= 0.3,
     syb,
     template-haskell >= 2.4,
     text >= 1.1.1.0,


### PR DESCRIPTION
Data.Scientific changed the location of `scientificBuilder` with v0.3.0.0. This updates the required version and fixes the import.
