### PR TITLE
Export 'camelTo' function and fix its tests

### DIFF
--- a/Data/Aeson/Types.hs
+++ b/Data/Aeson/Types.hs
@@ -60,6 +60,7 @@ module Data.Aeson.Types
     -- * Generic and TH encoding configuration
     , Options(..)
     , SumEncoding(..)
+    , camelTo
     , defaultOptions
     , defaultTaggedObject
     ) where

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -5,10 +5,11 @@ import Data.Aeson (eitherDecode)
 import Data.Aeson.Encode
 import Data.Aeson.Parser (value)
 import Data.Aeson.Types
+import Data.Char (toUpper)
 import Test.Framework (Test, defaultMain, testGroup)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
 import Test.Framework.Providers.HUnit (testCase)
-import Test.HUnit                     (assertFailure, assertEqual)
+import Test.HUnit                     (Assertion, assertFailure, assertEqual)
 import Test.QuickCheck (Arbitrary(..))
 import qualified Data.Vector as V
 import qualified Data.Attoparsec.Lazy as L
@@ -28,13 +29,14 @@ import Data.Int
 import qualified Data.Map as Map
 #endif
 
-{-
-roundTripCaml :: String -> Bool
-roundTripCaml s = s == (camlFrom '_' $ camlTo '_' s)
+
+roundTripCamel :: String -> Assertion
+roundTripCamel name = assertEqual "" name (camelFrom '_' $ camelTo '_' name)
   where
-    camlFrom :: Char -> String -> String
-    camlFrom c = concatMap capitalize $ split c
--}
+    camelFrom c s = let (p:ps) = split c s
+                    in concat $ p : map capitalize ps
+    split c s = map L.unpack $ L.split c $ L.pack s
+    capitalize t = toUpper (head t) : tail t
 
 encodeDouble :: Double -> Double -> Bool
 encodeDouble num denom
@@ -116,10 +118,11 @@ tests = [
       testProperty "encodeDouble" encodeDouble
     , testProperty "encodeInteger" encodeInteger
     ],
-  -- testGroup "camlCase" [
-  --     testProperty "camlTo" $ roundTripCaml "AnApiMethod"
-  --   , testProperty "camlTo" $ roundTripCaml "anotherMethodType"
-  --   ],
+   testGroup "camelCase" [
+      testCase "camelTo" $ roundTripCamel "aName"
+    , testCase "camelTo" $ roundTripCamel "another"
+    , testCase "camelTo" $ roundTripCamel "someOtherName"
+    ],
   testGroup "roundTrip" [
       testProperty "Bool" $ roundTripEq True
     , testProperty "Double" $ roundTripEq (1 :: Approx Double)


### PR DESCRIPTION
This function was added as part of #155, but never seems to have been exported. Looking at the tests for it, there seems to be a typo - the test uses "camlTo" - so it seems unlikely that it ever worked or even compiled. The test has been commented out in a more recent pull request, but indeed if I check out version 0.7.0.0 and run `cabal test`, I get

tests/Properties.hs:27:40: Not in scope: ‘camlTo’

This pull request exports the function from Data.Aeson.Types and fixes the tests.
