### PR TITLE
Test the version of template haskell, not GHC

### DIFF
--- a/Data/Aeson/TH.hs
+++ b/Data/Aeson/TH.hs
@@ -872,7 +872,7 @@ valueConName Null       = "Null"
 applyCon :: Name -> [Name] -> Q [Pred]
 applyCon con typeNames = return (map apply typeNames)
   where apply t =
-#if __GLASGOW_HASKELL__ >= 709
+#if MIN_VERSION_template_haskell(2,10,0)
           AppT (ConT con) (VarT t)
 #else
           ClassP con [VarT t]


### PR DESCRIPTION
This is more portable between compilers as well as between variants on GHC (ex: HaLVM is building off of head so GHC appears as 7.8.3 while TH is 2.10).
