### PR TITLE
Move skipSpace from value callsite to inside the definitions of value and value'

### DIFF
--- a/Data/Aeson/Parser/Internal.hs
+++ b/Data/Aeson/Parser/Internal.hs
@@ -109,7 +109,7 @@ object_' = {-# SCC "object_'" #-} do
 objectValues :: Parser Text -> Parser Value -> Parser (H.HashMap Text Value)
 objectValues str val = do
   skipSpace
-  let pair = liftA2 (,) (str <* skipSpace) (char ':' *> skipSpace *> val)
+  let pair = liftA2 (,) (str <* skipSpace) (char ':' *> val)
   H.fromList <$> commaSeparated pair CLOSE_CURLY
 {-# INLINE objectValues #-}
 
@@ -154,6 +154,7 @@ arrayValues val = do
 -- to preserve interoperability and security.
 value :: Parser Value
 value = do
+  skipSpace
   w <- A.peekWord8'
   case w of
     DOUBLE_QUOTE  -> A.anyWord8 *> (String <$> jstring_)
@@ -169,6 +170,7 @@ value = do
 -- | Strict version of 'value'. See also 'json''.
 value' :: Parser Value
 value' = do
+  skipSpace
   w <- A.peekWord8'
   case w of
     DOUBLE_QUOTE  -> do


### PR DESCRIPTION
A three-liner for addressing: https://github.com/bos/aeson/issues/215#issuecomment-52565616

I tested this with the following file:

    module Main where
    
    import Data.Text
    import Control.Lens
    import Data.Aeson.Lens
    
    main = print $ (pack " {}") ^?! _Object

I don't know the Haskell testing frameworks well enough to add the test to the project. If anyone could give me some basic direction on the matter, I would add them.