### PR TITLE
Add json path to parse error messages

### DIFF
--- a/Data/Aeson.hs
+++ b/Data/Aeson.hs
@@ -141,24 +141,28 @@ decodeStrict' :: (FromJSON a) => B.ByteString -> Maybe a
 decodeStrict' = decodeStrictWith jsonEOF' fromJSON
 {-# INLINE decodeStrict' #-}
 
+eitherFormatError :: Either (JSONPath, String) a -> Either String a
+eitherFormatError = either (Left . uncurry formatError) Right
+{-# INLINE eitherFormatError #-}
+
 -- | Like 'decode' but returns an error message when decoding fails.
 eitherDecode :: (FromJSON a) => L.ByteString -> Either String a
-eitherDecode = eitherDecodeWith jsonEOF fromJSON
+eitherDecode = eitherFormatError . eitherDecodeWith jsonEOF fromJSON
 {-# INLINE eitherDecode #-}
 
 -- | Like 'decodeStrict' but returns an error message when decoding fails.
 eitherDecodeStrict :: (FromJSON a) => B.ByteString -> Either String a
-eitherDecodeStrict = eitherDecodeStrictWith jsonEOF fromJSON
+eitherDecodeStrict = eitherFormatError . eitherDecodeStrictWith jsonEOF fromJSON
 {-# INLINE eitherDecodeStrict #-}
 
 -- | Like 'decode'' but returns an error message when decoding fails.
 eitherDecode' :: (FromJSON a) => L.ByteString -> Either String a
-eitherDecode' = eitherDecodeWith jsonEOF' fromJSON
+eitherDecode' = eitherFormatError . eitherDecodeWith jsonEOF' fromJSON
 {-# INLINE eitherDecode' #-}
 
 -- | Like 'decodeStrict'' but returns an error message when decoding fails.
 eitherDecodeStrict' :: (FromJSON a) => B.ByteString -> Either String a
-eitherDecodeStrict' = eitherDecodeStrictWith jsonEOF' fromJSON
+eitherDecodeStrict' = eitherFormatError . eitherDecodeStrictWith jsonEOF' fromJSON
 {-# INLINE eitherDecodeStrict' #-}
 
 -- $use

--- a/Data/Aeson/Types.hs
+++ b/Data/Aeson/Types.hs
@@ -32,6 +32,8 @@ module Data.Aeson.Types
     , parseMaybe
     , ToJSON(..)
     , modifyFailure
+    , JSONPath
+    , formatError
 
     -- ** Generic JSON classes
     , GFromJSON(..)

--- a/Data/Aeson/Types/Instances.hs
+++ b/Data/Aeson/Types/Instances.hs
@@ -72,7 +72,7 @@ import Data.Ratio (Ratio, (%), numerator, denominator)
 import Data.Text (Text, pack, unpack)
 import Data.Time (UTCTime, ZonedTime(..), TimeZone(..))
 import Data.Time.Format (FormatTime, formatTime, parseTime)
-import Data.Traversable (traverse)
+import Data.Traversable as Tr (sequence, traverse)
 import Data.Vector (Vector)
 import Data.Word (Word, Word8, Word16, Word32, Word64)
 import Foreign.Storable (Storable)
@@ -100,6 +100,9 @@ import Data.Time.Format (defaultTimeLocale, dateTimeFmt)
 #else
 import System.Locale (defaultTimeLocale, dateTimeFmt)
 #endif
+
+parseIndexedJSON :: FromJSON a => Int -> Value -> Parser a
+parseIndexedJSON idx value = parseJSON value <?> Index idx
 
 instance (ToJSON a) => ToJSON (Identity a) where
     toJSON (Identity a) = toJSON a
@@ -420,7 +423,7 @@ instance (ToJSON a) => ToJSON [a] where
       where commas = P.foldr (\v vs -> B.char7 ',' <> toEncoding v <> vs) mempty
 
 instance (FromJSON a) => FromJSON [a] where
-    parseJSON = withArray "[a]" $ mapM parseJSON . V.toList
+    parseJSON = withArray "[a]" $ Tr.sequence . zipWith parseIndexedJSON [0..] . V.toList
     {-# INLINE parseJSON #-}
 
 instance (Foldable t, ToJSON a) => ToJSON (t a) where
@@ -448,7 +451,7 @@ encodeVector xs
     where go v b = B.char7 ',' <> toEncoding v <> b
 
 instance (FromJSON a) => FromJSON (Vector a) where
-    parseJSON = withArray "Vector a" $ V.mapM parseJSON
+    parseJSON = withArray "Vector a" $ V.mapM (uncurry parseIndexedJSON) . V.indexed
     {-# INLINE parseJSON #-}
 
 vectorToJSON :: (VG.Vector v a, ToJSON a) => v a -> Value
@@ -456,7 +459,7 @@ vectorToJSON = Array . V.map toJSON . V.convert
 {-# INLINE vectorToJSON #-}
 
 vectorParseJSON :: (FromJSON a, VG.Vector w a) => String -> Value -> Parser (w a)
-vectorParseJSON s = withArray s $ fmap V.convert . V.mapM parseJSON
+vectorParseJSON s = withArray s $ fmap V.convert . V.mapM (uncurry parseIndexedJSON) . V.indexed
 {-# INLINE vectorParseJSON #-}
 
 instance (Storable a, ToJSON a) => ToJSON (VS.Vector a) where
@@ -563,7 +566,7 @@ encodePair k v = toEncoding k <> B.char7 ':' <> toEncoding v
 
 instance (FromJSON v) => FromJSON (M.Map Text v) where
     parseJSON = withObject "Map Text a" $
-                  fmap (H.foldrWithKey M.insert M.empty) . traverse parseJSON
+                  fmap (H.foldrWithKey M.insert M.empty) . H.traverseWithKey (\k v -> parseJSON v <?> Key k)
 
 instance (ToJSON v) => ToJSON (M.Map LT.Text v) where
     toJSON = Object . mapHashKeyVal LT.toStrict toJSON
@@ -588,7 +591,7 @@ instance (ToJSON v) => ToJSON (H.HashMap Text v) where
     toEncoding = encodeWithKey H.foldrWithKey
 
 instance (FromJSON v) => FromJSON (H.HashMap Text v) where
-    parseJSON = withObject "HashMap Text a" $ traverse parseJSON
+    parseJSON = withObject "HashMap Text a" $ H.traverseWithKey (\k v -> parseJSON v <?> Key k)
 
 instance (ToJSON v) => ToJSON (H.HashMap LT.Text v) where
     toJSON = Object . mapKeyVal LT.toStrict toJSON
@@ -711,6 +714,9 @@ instance FromJSON UTCTime where
           _      -> fail "could not parse ISO-8601 date"
     {-# INLINE parseJSON #-}
 
+parseJSONElemAtIndex :: FromJSON a => Int -> Vector Value -> Parser a
+parseJSONElemAtIndex idx ary = parseJSON (V.unsafeIndex ary idx) <?> Index idx
+
 instance (ToJSON a, ToJSON b) => ToJSON (a,b) where
     toJSON (a,b) = Array $ V.create $ do
                      mv <- VM.unsafeNew 2
@@ -727,8 +733,8 @@ instance (FromJSON a, FromJSON b) => FromJSON (a,b) where
     parseJSON = withArray "(a,b)" $ \ab ->
         let n = V.length ab
         in if n == 2
-             then (,) <$> parseJSON (V.unsafeIndex ab 0)
-                      <*> parseJSON (V.unsafeIndex ab 1)
+             then (,) <$> parseJSONElemAtIndex 0 ab
+                      <*> parseJSONElemAtIndex 1 ab
              else fail $ "cannot unpack array of length " ++
                          show n ++ " into a pair"
     {-# INLINE parseJSON #-}
@@ -751,9 +757,9 @@ instance (FromJSON a, FromJSON b, FromJSON c) => FromJSON (a,b,c) where
     parseJSON = withArray "(a,b,c)" $ \abc ->
         let n = V.length abc
         in if n == 3
-             then (,,) <$> parseJSON (V.unsafeIndex abc 0)
-                       <*> parseJSON (V.unsafeIndex abc 1)
-                       <*> parseJSON (V.unsafeIndex abc 2)
+             then (,,) <$> parseJSONElemAtIndex 0 abc
+                       <*> parseJSONElemAtIndex 1 abc
+                       <*> parseJSONElemAtIndex 2 abc
              else fail $ "cannot unpack array of length " ++
                           show n ++ " into a 3-tuple"
     {-# INLINE parseJSON #-}
@@ -779,10 +785,10 @@ instance (FromJSON a, FromJSON b, FromJSON c, FromJSON d) =>
     parseJSON = withArray "(a,b,c,d)" $ \abcd ->
         let n = V.length abcd
         in if n == 4
-             then (,,,) <$> parseJSON (V.unsafeIndex abcd 0)
-                        <*> parseJSON (V.unsafeIndex abcd 1)
-                        <*> parseJSON (V.unsafeIndex abcd 2)
-                        <*> parseJSON (V.unsafeIndex abcd 3)
+             then (,,,) <$> parseJSONElemAtIndex 0 abcd
+                        <*> parseJSONElemAtIndex 1 abcd
+                        <*> parseJSONElemAtIndex 2 abcd
+                        <*> parseJSONElemAtIndex 3 abcd
              else fail $ "cannot unpack array of length " ++
                          show n ++ " into a 4-tuple"
     {-# INLINE parseJSON #-}
@@ -811,11 +817,11 @@ instance (FromJSON a, FromJSON b, FromJSON c, FromJSON d, FromJSON e) =>
     parseJSON = withArray "(a,b,c,d,e)" $ \abcde ->
         let n = V.length abcde
         in if n == 5
-             then (,,,,) <$> parseJSON (V.unsafeIndex abcde 0)
-                         <*> parseJSON (V.unsafeIndex abcde 1)
-                         <*> parseJSON (V.unsafeIndex abcde 2)
-                         <*> parseJSON (V.unsafeIndex abcde 3)
-                         <*> parseJSON (V.unsafeIndex abcde 4)
+             then (,,,,) <$> parseJSONElemAtIndex 0 abcde
+                         <*> parseJSONElemAtIndex 1 abcde
+                         <*> parseJSONElemAtIndex 2 abcde
+                         <*> parseJSONElemAtIndex 3 abcde
+                         <*> parseJSONElemAtIndex 4 abcde
              else fail $ "cannot unpack array of length " ++
                          show n ++ " into a 5-tuple"
     {-# INLINE parseJSON #-}
@@ -846,12 +852,12 @@ instance (FromJSON a, FromJSON b, FromJSON c, FromJSON d, FromJSON e,
     parseJSON = withArray "(a,b,c,d,e,f)" $ \abcdef ->
         let n = V.length abcdef
         in if n == 6
-             then (,,,,,) <$> parseJSON (V.unsafeIndex abcdef 0)
-                          <*> parseJSON (V.unsafeIndex abcdef 1)
-                          <*> parseJSON (V.unsafeIndex abcdef 2)
-                          <*> parseJSON (V.unsafeIndex abcdef 3)
-                          <*> parseJSON (V.unsafeIndex abcdef 4)
-                          <*> parseJSON (V.unsafeIndex abcdef 5)
+             then (,,,,,) <$> parseJSONElemAtIndex 0 abcdef
+                          <*> parseJSONElemAtIndex 1 abcdef
+                          <*> parseJSONElemAtIndex 2 abcdef
+                          <*> parseJSONElemAtIndex 3 abcdef
+                          <*> parseJSONElemAtIndex 4 abcdef
+                          <*> parseJSONElemAtIndex 5 abcdef
              else fail $ "cannot unpack array of length " ++
                          show n ++ " into a 6-tuple"
     {-# INLINE parseJSON #-}
@@ -884,13 +890,13 @@ instance (FromJSON a, FromJSON b, FromJSON c, FromJSON d, FromJSON e,
     parseJSON = withArray "(a,b,c,d,e,f,g)" $ \abcdefg ->
         let n = V.length abcdefg
         in if n == 7
-             then (,,,,,,) <$> parseJSON (V.unsafeIndex abcdefg 0)
-                           <*> parseJSON (V.unsafeIndex abcdefg 1)
-                           <*> parseJSON (V.unsafeIndex abcdefg 2)
-                           <*> parseJSON (V.unsafeIndex abcdefg 3)
-                           <*> parseJSON (V.unsafeIndex abcdefg 4)
-                           <*> parseJSON (V.unsafeIndex abcdefg 5)
-                           <*> parseJSON (V.unsafeIndex abcdefg 6)
+             then (,,,,,,) <$> parseJSONElemAtIndex 0 abcdefg
+                           <*> parseJSONElemAtIndex 1 abcdefg
+                           <*> parseJSONElemAtIndex 2 abcdefg
+                           <*> parseJSONElemAtIndex 3 abcdefg
+                           <*> parseJSONElemAtIndex 4 abcdefg
+                           <*> parseJSONElemAtIndex 5 abcdefg
+                           <*> parseJSONElemAtIndex 6 abcdefg
              else fail $ "cannot unpack array of length " ++
                          show n ++ " into a 7-tuple"
     {-# INLINE parseJSON #-}
@@ -929,14 +935,14 @@ instance (FromJSON a, FromJSON b, FromJSON c, FromJSON d, FromJSON e,
            then fail $ "cannot unpack array of length " ++
                        show n ++ " into an 8-tuple"
            else (,,,,,,,)
-                <$> parseJSON (V.unsafeIndex ary 0)
-                <*> parseJSON (V.unsafeIndex ary 1)
-                <*> parseJSON (V.unsafeIndex ary 2)
-                <*> parseJSON (V.unsafeIndex ary 3)
-                <*> parseJSON (V.unsafeIndex ary 4)
-                <*> parseJSON (V.unsafeIndex ary 5)
-                <*> parseJSON (V.unsafeIndex ary 6)
-                <*> parseJSON (V.unsafeIndex ary 7)
+                <$> parseJSONElemAtIndex 0 ary
+                <*> parseJSONElemAtIndex 1 ary
+                <*> parseJSONElemAtIndex 2 ary
+                <*> parseJSONElemAtIndex 3 ary
+                <*> parseJSONElemAtIndex 4 ary
+                <*> parseJSONElemAtIndex 5 ary
+                <*> parseJSONElemAtIndex 6 ary
+                <*> parseJSONElemAtIndex 7 ary
     {-# INLINE parseJSON #-}
 
 instance (ToJSON a, ToJSON b, ToJSON c, ToJSON d, ToJSON e, ToJSON f,
@@ -975,15 +981,15 @@ instance (FromJSON a, FromJSON b, FromJSON c, FromJSON d, FromJSON e,
            then fail $ "cannot unpack array of length " ++
                        show n ++ " into a 9-tuple"
            else (,,,,,,,,)
-                <$> parseJSON (V.unsafeIndex ary 0)
-                <*> parseJSON (V.unsafeIndex ary 1)
-                <*> parseJSON (V.unsafeIndex ary 2)
-                <*> parseJSON (V.unsafeIndex ary 3)
-                <*> parseJSON (V.unsafeIndex ary 4)
-                <*> parseJSON (V.unsafeIndex ary 5)
-                <*> parseJSON (V.unsafeIndex ary 6)
-                <*> parseJSON (V.unsafeIndex ary 7)
-                <*> parseJSON (V.unsafeIndex ary 8)
+                <$> parseJSONElemAtIndex 0 ary
+                <*> parseJSONElemAtIndex 1 ary
+                <*> parseJSONElemAtIndex 2 ary
+                <*> parseJSONElemAtIndex 3 ary
+                <*> parseJSONElemAtIndex 4 ary
+                <*> parseJSONElemAtIndex 5 ary
+                <*> parseJSONElemAtIndex 6 ary
+                <*> parseJSONElemAtIndex 7 ary
+                <*> parseJSONElemAtIndex 8 ary
     {-# INLINE parseJSON #-}
 
 instance (ToJSON a, ToJSON b, ToJSON c, ToJSON d, ToJSON e, ToJSON f,
@@ -1025,16 +1031,16 @@ instance (FromJSON a, FromJSON b, FromJSON c, FromJSON d, FromJSON e,
            then fail $ "cannot unpack array of length " ++
                        show n ++ " into a 10-tuple"
            else (,,,,,,,,,)
-                <$> parseJSON (V.unsafeIndex ary 0)
-                <*> parseJSON (V.unsafeIndex ary 1)
-                <*> parseJSON (V.unsafeIndex ary 2)
-                <*> parseJSON (V.unsafeIndex ary 3)
-                <*> parseJSON (V.unsafeIndex ary 4)
-                <*> parseJSON (V.unsafeIndex ary 5)
-                <*> parseJSON (V.unsafeIndex ary 6)
-                <*> parseJSON (V.unsafeIndex ary 7)
-                <*> parseJSON (V.unsafeIndex ary 8)
-                <*> parseJSON (V.unsafeIndex ary 9)
+                <$> parseJSONElemAtIndex 0 ary
+                <*> parseJSONElemAtIndex 1 ary
+                <*> parseJSONElemAtIndex 2 ary
+                <*> parseJSONElemAtIndex 3 ary
+                <*> parseJSONElemAtIndex 4 ary
+                <*> parseJSONElemAtIndex 5 ary
+                <*> parseJSONElemAtIndex 6 ary
+                <*> parseJSONElemAtIndex 7 ary
+                <*> parseJSONElemAtIndex 8 ary
+                <*> parseJSONElemAtIndex 9 ary
     {-# INLINE parseJSON #-}
 
 instance (ToJSON a, ToJSON b, ToJSON c, ToJSON d, ToJSON e, ToJSON f,
@@ -1079,17 +1085,17 @@ instance (FromJSON a, FromJSON b, FromJSON c, FromJSON d, FromJSON e,
            then fail $ "cannot unpack array of length " ++
                        show n ++ " into an 11-tuple"
            else (,,,,,,,,,,)
-                <$> parseJSON (V.unsafeIndex ary 0)
-                <*> parseJSON (V.unsafeIndex ary 1)
-                <*> parseJSON (V.unsafeIndex ary 2)
-                <*> parseJSON (V.unsafeIndex ary 3)
-                <*> parseJSON (V.unsafeIndex ary 4)
-                <*> parseJSON (V.unsafeIndex ary 5)
-                <*> parseJSON (V.unsafeIndex ary 6)
-                <*> parseJSON (V.unsafeIndex ary 7)
-                <*> parseJSON (V.unsafeIndex ary 8)
-                <*> parseJSON (V.unsafeIndex ary 9)
-                <*> parseJSON (V.unsafeIndex ary 10)
+                <$> parseJSONElemAtIndex 0 ary
+                <*> parseJSONElemAtIndex 1 ary
+                <*> parseJSONElemAtIndex 2 ary
+                <*> parseJSONElemAtIndex 3 ary
+                <*> parseJSONElemAtIndex 4 ary
+                <*> parseJSONElemAtIndex 5 ary
+                <*> parseJSONElemAtIndex 6 ary
+                <*> parseJSONElemAtIndex 7 ary
+                <*> parseJSONElemAtIndex 8 ary
+                <*> parseJSONElemAtIndex 9 ary
+                <*> parseJSONElemAtIndex 10 ary
     {-# INLINE parseJSON #-}
 
 instance (ToJSON a, ToJSON b, ToJSON c, ToJSON d, ToJSON e, ToJSON f,
@@ -1136,18 +1142,18 @@ instance (FromJSON a, FromJSON b, FromJSON c, FromJSON d, FromJSON e,
            then fail $ "cannot unpack array of length " ++
                        show n ++ " into a 12-tuple"
            else (,,,,,,,,,,,)
-                <$> parseJSON (V.unsafeIndex ary 0)
-                <*> parseJSON (V.unsafeIndex ary 1)
-                <*> parseJSON (V.unsafeIndex ary 2)
-                <*> parseJSON (V.unsafeIndex ary 3)
-                <*> parseJSON (V.unsafeIndex ary 4)
-                <*> parseJSON (V.unsafeIndex ary 5)
-                <*> parseJSON (V.unsafeIndex ary 6)
-                <*> parseJSON (V.unsafeIndex ary 7)
-                <*> parseJSON (V.unsafeIndex ary 8)
-                <*> parseJSON (V.unsafeIndex ary 9)
-                <*> parseJSON (V.unsafeIndex ary 10)
-                <*> parseJSON (V.unsafeIndex ary 11)
+                <$> parseJSONElemAtIndex 0 ary
+                <*> parseJSONElemAtIndex 1 ary
+                <*> parseJSONElemAtIndex 2 ary
+                <*> parseJSONElemAtIndex 3 ary
+                <*> parseJSONElemAtIndex 4 ary
+                <*> parseJSONElemAtIndex 5 ary
+                <*> parseJSONElemAtIndex 6 ary
+                <*> parseJSONElemAtIndex 7 ary
+                <*> parseJSONElemAtIndex 8 ary
+                <*> parseJSONElemAtIndex 9 ary
+                <*> parseJSONElemAtIndex 10 ary
+                <*> parseJSONElemAtIndex 11 ary
     {-# INLINE parseJSON #-}
 
 instance (ToJSON a, ToJSON b, ToJSON c, ToJSON d, ToJSON e, ToJSON f,
@@ -1197,19 +1203,19 @@ instance (FromJSON a, FromJSON b, FromJSON c, FromJSON d, FromJSON e,
            then fail $ "cannot unpack array of length " ++
                        show n ++ " into a 13-tuple"
            else (,,,,,,,,,,,,)
-                <$> parseJSON (V.unsafeIndex ary 0)
-                <*> parseJSON (V.unsafeIndex ary 1)
-                <*> parseJSON (V.unsafeIndex ary 2)
-                <*> parseJSON (V.unsafeIndex ary 3)
-                <*> parseJSON (V.unsafeIndex ary 4)
-                <*> parseJSON (V.unsafeIndex ary 5)
-                <*> parseJSON (V.unsafeIndex ary 6)
-                <*> parseJSON (V.unsafeIndex ary 7)
-                <*> parseJSON (V.unsafeIndex ary 8)
-                <*> parseJSON (V.unsafeIndex ary 9)
-                <*> parseJSON (V.unsafeIndex ary 10)
-                <*> parseJSON (V.unsafeIndex ary 11)
-                <*> parseJSON (V.unsafeIndex ary 12)
+                <$> parseJSONElemAtIndex 0 ary
+                <*> parseJSONElemAtIndex 1 ary
+                <*> parseJSONElemAtIndex 2 ary
+                <*> parseJSONElemAtIndex 3 ary
+                <*> parseJSONElemAtIndex 4 ary
+                <*> parseJSONElemAtIndex 5 ary
+                <*> parseJSONElemAtIndex 6 ary
+                <*> parseJSONElemAtIndex 7 ary
+                <*> parseJSONElemAtIndex 8 ary
+                <*> parseJSONElemAtIndex 9 ary
+                <*> parseJSONElemAtIndex 10 ary
+                <*> parseJSONElemAtIndex 11 ary
+                <*> parseJSONElemAtIndex 12 ary
     {-# INLINE parseJSON #-}
 
 instance (ToJSON a, ToJSON b, ToJSON c, ToJSON d, ToJSON e, ToJSON f,
@@ -1261,20 +1267,20 @@ instance (FromJSON a, FromJSON b, FromJSON c, FromJSON d, FromJSON e,
            then fail $ "cannot unpack array of length " ++
                        show n ++ " into a 14-tuple"
            else (,,,,,,,,,,,,,)
-                <$> parseJSON (V.unsafeIndex ary 0)
-                <*> parseJSON (V.unsafeIndex ary 1)
-                <*> parseJSON (V.unsafeIndex ary 2)
-                <*> parseJSON (V.unsafeIndex ary 3)
-                <*> parseJSON (V.unsafeIndex ary 4)
-                <*> parseJSON (V.unsafeIndex ary 5)
-                <*> parseJSON (V.unsafeIndex ary 6)
-                <*> parseJSON (V.unsafeIndex ary 7)
-                <*> parseJSON (V.unsafeIndex ary 8)
-                <*> parseJSON (V.unsafeIndex ary 9)
-                <*> parseJSON (V.unsafeIndex ary 10)
-                <*> parseJSON (V.unsafeIndex ary 11)
-                <*> parseJSON (V.unsafeIndex ary 12)
-                <*> parseJSON (V.unsafeIndex ary 13)
+                <$> parseJSONElemAtIndex 0 ary
+                <*> parseJSONElemAtIndex 1 ary
+                <*> parseJSONElemAtIndex 2 ary
+                <*> parseJSONElemAtIndex 3 ary
+                <*> parseJSONElemAtIndex 4 ary
+                <*> parseJSONElemAtIndex 5 ary
+                <*> parseJSONElemAtIndex 6 ary
+                <*> parseJSONElemAtIndex 7 ary
+                <*> parseJSONElemAtIndex 8 ary
+                <*> parseJSONElemAtIndex 9 ary
+                <*> parseJSONElemAtIndex 10 ary
+                <*> parseJSONElemAtIndex 11 ary
+                <*> parseJSONElemAtIndex 12 ary
+                <*> parseJSONElemAtIndex 13 ary
     {-# INLINE parseJSON #-}
 
 instance (ToJSON a, ToJSON b, ToJSON c, ToJSON d, ToJSON e, ToJSON f,
@@ -1328,21 +1334,21 @@ instance (FromJSON a, FromJSON b, FromJSON c, FromJSON d, FromJSON e,
            then fail $ "cannot unpack array of length " ++
                        show n ++ " into a 15-tuple"
            else (,,,,,,,,,,,,,,)
-                <$> parseJSON (V.unsafeIndex ary 0)
-                <*> parseJSON (V.unsafeIndex ary 1)
-                <*> parseJSON (V.unsafeIndex ary 2)
-                <*> parseJSON (V.unsafeIndex ary 3)
-                <*> parseJSON (V.unsafeIndex ary 4)
-                <*> parseJSON (V.unsafeIndex ary 5)
-                <*> parseJSON (V.unsafeIndex ary 6)
-                <*> parseJSON (V.unsafeIndex ary 7)
-                <*> parseJSON (V.unsafeIndex ary 8)
-                <*> parseJSON (V.unsafeIndex ary 9)
-                <*> parseJSON (V.unsafeIndex ary 10)
-                <*> parseJSON (V.unsafeIndex ary 11)
-                <*> parseJSON (V.unsafeIndex ary 12)
-                <*> parseJSON (V.unsafeIndex ary 13)
-                <*> parseJSON (V.unsafeIndex ary 14)
+                <$> parseJSONElemAtIndex 0 ary
+                <*> parseJSONElemAtIndex 1 ary
+                <*> parseJSONElemAtIndex 2 ary
+                <*> parseJSONElemAtIndex 3 ary
+                <*> parseJSONElemAtIndex 4 ary
+                <*> parseJSONElemAtIndex 5 ary
+                <*> parseJSONElemAtIndex 6 ary
+                <*> parseJSONElemAtIndex 7 ary
+                <*> parseJSONElemAtIndex 8 ary
+                <*> parseJSONElemAtIndex 9 ary
+                <*> parseJSONElemAtIndex 10 ary
+                <*> parseJSONElemAtIndex 11 ary
+                <*> parseJSONElemAtIndex 12 ary
+                <*> parseJSONElemAtIndex 13 ary
+                <*> parseJSONElemAtIndex 14 ary
     {-# INLINE parseJSON #-}
 
 instance ToJSON a => ToJSON (Dual a) where
@@ -1437,7 +1443,7 @@ fromJSON = parse parseJSON
 (.:) :: (FromJSON a) => Object -> Text -> Parser a
 obj .: key = case H.lookup key obj of
                Nothing -> fail $ "key " ++ show key ++ " not present"
-               Just v  -> parseJSON v
+               Just v  -> parseJSON v <?> Key key
 {-# INLINE (.:) #-}
 
 -- | Retrieve the value associated with the given key of an 'Object'.
@@ -1450,7 +1456,7 @@ obj .: key = case H.lookup key obj of
 (.:?) :: (FromJSON a) => Object -> Text -> Parser (Maybe a)
 obj .:? key = case H.lookup key obj of
                Nothing -> pure Nothing
-               Just v  -> parseJSON v
+               Just v  -> parseJSON v <?> Key key
 {-# INLINE (.:?) #-}
 
 -- | Helper for use in combination with '.:?' to provide default

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -49,28 +49,28 @@ toParseJSON :: (Arbitrary a, Eq a, Show a) =>
                (Value -> Parser a) -> (a -> Value) -> a -> Property
 toParseJSON parsejson tojson x =
     case parse parsejson . tojson $ x of
-      Error msg  -> failure "parse" msg x
-      Success x' -> x === x'
+      Error path msg -> failure "parse" (formatError path msg) x
+      Success x'     -> x === x'
 
 roundTrip :: (FromJSON a, ToJSON a, Show a) =>
              (a -> a -> Property) -> a -> a -> Property
 roundTrip eq _ i =
     case fmap fromJSON . L.parse value . encode . toJSON $ i of
-      L.Done _ (Success v) -> v `eq` i
-      L.Done _ (Error err) -> failure "fromJSON" err i
-      L.Fail _ _ err       -> failure "parse" err i
+      L.Done _ (Success v)      -> v `eq` i
+      L.Done _ (Error path err) -> failure "fromJSON" (formatError path err) i
+      L.Fail _ _ err            -> failure "parse" err i
 
 roundTripEq :: (Eq a, FromJSON a, ToJSON a, Show a) => a -> a -> Property
 roundTripEq x y = roundTrip (===) x y
 
 toFromJSON :: (Arbitrary a, Eq a, FromJSON a, ToJSON a, Show a) => a -> Property
 toFromJSON x = case fromJSON (toJSON x) of
-                Error err  -> failure "fromJSON" err x
-                Success x' -> x === x'
+                Error path err -> failure "fromJSON" (formatError path err) x
+                Success x'     -> x === x'
 
 modifyFailureProp :: String -> String -> Bool
 modifyFailureProp orig added =
-    result == Error (added ++ orig)
+    result == Error [] (added ++ orig)
   where
     parser = const $ modifyFailure (added ++) $ fail orig
     result :: Result ()

--- a/tests/Properties/ZonedTime.hs
+++ b/tests/Properties/ZonedTime.hs
@@ -43,8 +43,8 @@ zonedTimeToJSON = testGroup "ZonedTime" [
     test format f = testProperty format go
       where
         go t = case fromJSON (toJSON' format t) of
-                 Error msg  -> failure "fromJSON"  msg t
-                 Success t' -> t' === f t
+                 Error path msg -> failure "fromJSON" (formatError path msg) t
+                 Success t'     -> t' === f t
 
 clearTimeZone :: ZonedTime -> ZonedTime
 clearTimeZone t = t { zonedTimeZone = TimeZone 0 False "" }


### PR DESCRIPTION
Every time you parse some JSON and get error message, it is very painful to track where the error is because existing error messages do not point to the place in JSON where parse error occured. JSON *syntax* errors are reported from Attoparsec parser and it gives position. But JSON *conversion* errors have no support for tracking position/context so quality of error messages is poor.

This change adds json path to error message:
1. Parser tracks current JSON path (in reverse order)
2. An `<?>` operation is added to annotate Parser with JSON context (JSON path). This operation is named after Attoparsec's `<?>` which serves similar purpose.
3. Built-in FromJSON instances are updated to provide context information
4. `.:` and `.:?` operations automatically add context information.

Context is reported in form of [JSON-Path](https://code.google.com/p/json-path/) expression e.g. `$.store.book[0].title`:
```
> eitherDecode storeJsonString :: Either String Store
Left "Error in \"$.store.book[0]\": key \"title\" not present"
```

Caveats:
1. There is no tests for error message yet. I believe those should be done in normal xUnit assertion style instead of QuickCheck property style.
2. Only first error is reported. Further work can include supporting collection of error messages and reporting all of them at once. This can be useful e.g. for validating HTTP JSON requests and reporting all errors at once for displaying them to user on a web form.