### PR TITLE
Fix .:? behavior for #83

### DIFF
--- a/Data/Aeson/TH.hs
+++ b/Data/Aeson/TH.hs
@@ -94,8 +94,8 @@ import qualified Data.Aeson.Encode.Functions as E
 import qualified Data.Aeson as A
 -- from base:
 import Control.Applicative ( pure, (<$>), (<*>) )
-import Control.Monad       ( return, mapM, liftM2, fail )
-import Data.Bool           ( Bool(False, True), otherwise, (&&) , not)
+import Control.Monad       ( return, mapM, liftM2, fail, join )
+import Data.Bool           ( Bool(False, True), otherwise, (&&), not )
 import Data.Eq             ( (==) )
 import Data.Function       ( ($), (.) )
 import Data.Functor        ( fmap )
@@ -940,7 +940,7 @@ instance (FromJSON a) => LookupField a where
           Just v  -> parseJSON v
 
 instance (FromJSON a) => LookupField (Maybe a) where
-    lookupField _ _ = (.:?)
+    lookupField _ _ obj key = join <$> obj .:? key
 
 unknownFieldFail :: String -> String -> String -> Parser fail
 unknownFieldFail tName rec key =

--- a/Data/Aeson/Types/Generic.hs
+++ b/Data/Aeson/Types/Generic.hs
@@ -20,7 +20,7 @@
 module Data.Aeson.Types.Generic ( ) where
 
 import Control.Applicative ((<*>), (<$>), (<|>), pure)
-import Control.Monad ((<=<))
+import Control.Monad ((<=<), join)
 import Control.Monad.ST (ST)
 import Data.Aeson.Types.Instances
 import Data.Aeson.Types.Internal
@@ -656,8 +656,8 @@ instance (Selector s, GFromJSON a) => FromRecord (S1 s a) where
     {-# INLINE parseRecord #-}
 
 instance (Selector s, FromJSON a) => FromRecord (S1 s (K1 i (Maybe a))) where
-    parseRecord _ (Just lab) obj = (M1 . K1) <$> obj .:? lab
-    parseRecord opts Nothing obj = (M1 . K1) <$> obj .:? pack label
+    parseRecord _ (Just lab) obj = (M1 . K1) . join <$> obj .:? lab
+    parseRecord opts Nothing obj = (M1 . K1) . join <$> obj .:? pack label
         where
           label = fieldLabelModifier opts $
                     selName (undefined :: t s (K1 i (Maybe a)) p)

--- a/Data/Aeson/Types/Instances.hs
+++ b/Data/Aeson/Types/Instances.hs
@@ -1525,7 +1525,7 @@ obj .: key = case H.lookup key obj of
 (.:?) :: (FromJSON a) => Object -> Text -> Parser (Maybe a)
 obj .:? key = case H.lookup key obj of
                Nothing -> pure Nothing
-               Just v  -> parseJSON v <?> Key key
+               Just v  -> Just <$> parseJSON v <?> Key key
 {-# INLINE (.:?) #-}
 
 -- | Helper for use in combination with '.:?' to provide default


### PR DESCRIPTION
This commit fixes the .:? operator and correspondingly changes parsing code to preserve JSON roundtrip properties.