### PR TITLE
Add a flag to omit empty content fields when generating tagged objects

### DIFF
--- a/Data/Aeson/Types/Internal.hs
+++ b/Data/Aeson/Types/Internal.hs
@@ -371,6 +371,7 @@ data Options = Options
 data SumEncoding =
     TaggedObject { tagFieldName      :: String
                  , contentsFieldName :: String
+                 , omitEmptyContents :: Bool
                  }
     -- ^ A constructor will be encoded to an object with a field
     -- 'tagFieldName' which specifies the constructor tag (modified by
@@ -380,7 +381,9 @@ data SumEncoding =
     -- label as the 'tagFieldName'. Otherwise the tag gets overwritten
     -- by the encoded value of that field! If the constructor is not a
     -- record the encoded constructor contents will be stored under
-    -- the 'contentsFieldName' field.
+    -- the 'contentsFieldName' field. If the 'omitEmptyContents' field
+    -- is set, no contents field will be generated for nullary 
+    -- constructors when more than one constructors are present.
   | ObjectWithSingleField
     -- ^ A constructor will be encoded to an object with a single
     -- field named after the constructor tag (modified by the
@@ -419,12 +422,14 @@ defaultOptions = Options
 -- defaultTaggedObject = 'TaggedObject'
 --                       { 'tagFieldName'      = \"tag\"
 --                       , 'contentsFieldName' = \"contents\"
+--                       , 'omitEmptyContents' = False
 --                       }
 -- @
 defaultTaggedObject :: SumEncoding
 defaultTaggedObject = TaggedObject
                       { tagFieldName      = "tag"
                       , contentsFieldName = "contents"
+                      , omitEmptyContents = False
                       }
 
 -- | Converts from CamelCase to another lower case, interspersing

--- a/tests/Encoders.hs
+++ b/tests/Encoders.hs
@@ -38,6 +38,12 @@ thNullaryToJSONObjectWithSingleField = $(mkToJSON optsObjectWithSingleField ''Nu
 thNullaryParseJSONObjectWithSingleField :: Value -> Parser Nullary
 thNullaryParseJSONObjectWithSingleField = $(mkParseJSON optsObjectWithSingleField ''Nullary)
 
+thNullaryToJSONOmitEmptyContents :: Nullary -> Value
+thNullaryToJSONOmitEmptyContents = $(mkToJSON optsOmitEmptyContents ''Nullary)
+
+thNullaryParseJSONOmitEmptyContents :: Value -> Parser Nullary
+thNullaryParseJSONOmitEmptyContents = $(mkParseJSON optsOmitEmptyContents ''Nullary)
+
 gNullaryToJSONString :: Nullary -> Value
 gNullaryToJSONString = genericToJSON defaultOptions
 
@@ -65,6 +71,27 @@ gNullaryToJSONObjectWithSingleField = genericToJSON optsObjectWithSingleField
 gNullaryParseJSONObjectWithSingleField :: Value -> Parser Nullary
 gNullaryParseJSONObjectWithSingleField = genericParseJSON optsObjectWithSingleField
 
+gNullaryToJSONOmitEmptyContents :: Nullary -> Value
+gNullaryToJSONOmitEmptyContents = genericToJSON optsOmitEmptyContents
+
+gNullaryParseJSONOmitEmptyContents :: Value -> Parser Nullary
+gNullaryParseJSONOmitEmptyContents = genericParseJSON optsOmitEmptyContents
+
+--------------------------------------------------------------------------------
+-- OneConstructor encoders/decoders
+--------------------------------------------------------------------------------
+
+thOneConstructorToJSONOmitEmptyContents :: OneConstructor -> Value
+thOneConstructorToJSONOmitEmptyContents = $(mkToJSON optsOmitEmptyContents ''OneConstructor)
+
+thOneConstructorParseJSONOmitEmptyContents :: Value -> Parser OneConstructor
+thOneConstructorParseJSONOmitEmptyContents = $(mkParseJSON optsOmitEmptyContents ''OneConstructor)
+
+gOneConstructorToJSONOmitEmptyContents :: OneConstructor -> Value
+gOneConstructorToJSONOmitEmptyContents = genericToJSON optsOmitEmptyContents
+
+gOneConstructorParseJSONOmitEmptyContents :: Value -> Parser OneConstructor
+gOneConstructorParseJSONOmitEmptyContents = genericParseJSON optsOmitEmptyContents
 
 --------------------------------------------------------------------------------
 -- SomeType encoders/decoders
@@ -92,6 +119,11 @@ thSomeTypeToJSONObjectWithSingleField = $(mkToJSON optsObjectWithSingleField ''S
 thSomeTypeParseJSONObjectWithSingleField :: FromJSON a => Value -> Parser (SomeType a)
 thSomeTypeParseJSONObjectWithSingleField = $(mkParseJSON optsObjectWithSingleField ''SomeType)
 
+thSomeTypeToJSONOmitEmptyContents :: ToJSON a => SomeType a -> Value
+thSomeTypeToJSONOmitEmptyContents = $(mkToJSON optsOmitEmptyContents ''SomeType)
+
+thSomeTypeParseJSONOmitEmptyContents :: FromJSON a => Value -> Parser (SomeType a)
+thSomeTypeParseJSONOmitEmptyContents = $(mkParseJSON optsOmitEmptyContents ''SomeType)
 
 gSomeTypeToJSON2ElemArray :: ToJSON a => SomeType a -> Value
 gSomeTypeToJSON2ElemArray = genericToJSON opts2ElemArray
@@ -113,7 +145,11 @@ gSomeTypeToJSONObjectWithSingleField = genericToJSON optsObjectWithSingleField
 gSomeTypeParseJSONObjectWithSingleField :: FromJSON a => Value -> Parser (SomeType a)
 gSomeTypeParseJSONObjectWithSingleField = genericParseJSON optsObjectWithSingleField
 
+gSomeTypeToJSONOmitEmptyContents :: ToJSON a => SomeType a -> Value
+gSomeTypeToJSONOmitEmptyContents = genericToJSON optsOmitEmptyContents
 
+gSomeTypeParseJSONOmitEmptyContents :: FromJSON a => Value -> Parser (SomeType a)
+gSomeTypeParseJSONOmitEmptyContents = genericParseJSON optsOmitEmptyContents
 --------------------------------------------------------------------------------
 -- Approx encoders/decoders
 --------------------------------------------------------------------------------

--- a/tests/Options.hs
+++ b/tests/Options.hs
@@ -29,3 +29,8 @@ optsObjectWithSingleField = optsDefault
                             { allNullaryToStringTag = False
                             , sumEncoding           = ObjectWithSingleField
                             }
+
+optsOmitEmptyContents :: Options
+optsOmitEmptyContents = 
+    optsTaggedObject 
+    { sumEncoding = defaultTaggedObject { omitEmptyContents = True } }


### PR DESCRIPTION
This patch adds a flag to the SumEncoding option when generating JSON instances through Template Haskell or GHC Generics. The new flag prevents the generation of an empty contents field for nullary constructors in the presence of mixed constructors.

#### Motivating Example

```haskell
{-# LANGUAGE TemplateHaskell #-}
module Main where

import Data.Aeson
import Data.Aeson.TH

data A = A | B { value :: String }
    deriving Show

$(deriveJSON defaultOptions ''A)
```

This code will generate the following JSON data for A and B respectively:

`encode A`
```json
{
  "tag": "A",
  "contents": []
}
```
`encode (B "Hello World")`
```json
{
  "tag": "B",
  "value": "Hello World"
}
```

The contents field for the constructor **A** is redundant as nullary constructors do not have any arguments to encode. This information is available when generating the JSON instances. To produce cleaner JSON output, I added the `omitEmptyContents` field in the `SumEncoding` type.

#### New Behavior

```haskell
{-# LANGUAGE TemplateHaskell #-}
module Main where

import Data.Aeson
import Data.Aeson.TH

data A = A | B { value :: String }
    deriving Show

$(deriveJSON 
    defaultOptions{ sumEncoding = defaultTaggedObject{ omitEmptyContents = True } } 
    ''A
 )
```

Which will produce the following JSON data for A and B:

`encode A`
```json
{
  "tag": "A"
}
```
`encode (B "Hello World")`
```json
{
  "tag": "B",
  "value": "Hello World"
}
```

This new flag only works for union types where there are at least 2 constructors. A type with only 1 nullary constructor will be encoded to an empty array, which is the same behavior as before this patch. The `omitEmptyContents` flag defaults to `False` for backwards compatibility.

Any comments are appreciated.