### PR TITLE
Avoid (10 ^ e) on fromScientific

### DIFF
--- a/Data/Aeson/Encode.hs
+++ b/Data/Aeson/Encode.hs
@@ -29,10 +29,9 @@ module Data.Aeson.Encode
 
 import Data.Aeson.Types (Value(..))
 import Data.Monoid (mappend)
-import Data.Scientific (Scientific, coefficient, base10Exponent)
+import Data.Scientific (FPFormat(..), Scientific, base10Exponent)
 import Data.Text.Lazy.Builder
-import Data.Text.Lazy.Builder.Int (decimal)
-import Data.Text.Lazy.Builder.Scientific (scientificBuilder)
+import Data.Text.Lazy.Builder.Scientific (formatScientificBuilder)
 import Numeric (showHex)
 import qualified Data.HashMap.Strict as H
 import qualified Data.Text as T
@@ -97,11 +96,11 @@ string s = {-# SCC "string" #-} singleton '"' <> quote s <> singleton '"'
         where h = showHex (fromEnum c) ""
 
 fromScientific :: Scientific -> Builder
-fromScientific s
-    | e < 0     = scientificBuilder s
-    | otherwise = decimal (coefficient s * 10 ^ e)
+fromScientific s = formatScientificBuilder format prec s
   where
-    e = base10Exponent s
+    (format, prec)
+      | base10Exponent s < 0 = (Generic, Nothing)
+      | otherwise            = (Fixed,   Just 0)
 
 (<>) :: Builder -> Builder -> Builder
 (<>) = mappend


### PR DESCRIPTION
@basvandijk [noted that fromScientific used `10 ^ e`](https://github.com/bos/aeson/issues/246#issuecomment-93599848).  This operation could lead to a DOS due to a large exponent.

This PR changes the implementation to always use `formatScientificBuilder`, even when `base10Exponent s >= 0`.  The code from the scientific package already takes care when pretty printing huge numbers.

Note that using just `scientificBuilder` wouldn't be enough since we'd change the formatting of large integers to that of a large `Double`.  This commit does not change the output format at all, and all tests are green.