### PR TITLE
Use a better version of camelTo

### DIFF
--- a/Data/Aeson/Types.hs
+++ b/Data/Aeson/Types.hs
@@ -62,6 +62,7 @@ module Data.Aeson.Types
     , Options(..)
     , SumEncoding(..)
     , camelTo
+    , camelTo2
     , defaultOptions
     , defaultTaggedObject
     ) where

--- a/Data/Aeson/Types/Internal.hs
+++ b/Data/Aeson/Types/Internal.hs
@@ -47,6 +47,7 @@ module Data.Aeson.Types.Internal
 
     -- * Used for changing CamelCase names into something else.
     , camelTo
+    , camelTo2
 
     -- * Other types
     , DotNetTime(..)
@@ -519,9 +520,24 @@ defaultTaggedObject = TaggedObject
 --   For use by Aeson template haskell calls.
 --
 --   > camelTo '_' 'CamelCaseAPI' == "camel_case_api"
---   > camelTo '_' 'CamelAPICase' == "camel_api_case"
 camelTo :: Char -> String -> String
-camelTo c = map toLower . go2 . go1
+camelTo c = lastWasCap True
+  where
+    lastWasCap :: Bool    -- ^ Previous was a capital letter
+              -> String  -- ^ The remaining string
+              -> String
+    lastWasCap _    []           = []
+    lastWasCap prev (x : xs)     = if isUpper x
+                                      then if prev
+                                             then toLower x : lastWasCap True xs
+                                             else c : toLower x : lastWasCap True xs
+                                      else x : lastWasCap False xs
+
+-- | Better version of 'camelTo'. Example where it works better:
+--
+--   > camelTo2 '_' 'CamelAPICase' == "camel_api_case"
+camelTo2 :: Char -> String -> String
+camelTo2 c = map toLower . go2 . go1
     where go1 "" = ""
           go1 (x:u:l:xs) | isUpper u && isLower l = x : c : u : l : go1 xs
           go1 (x:xs) = x : go1 xs

--- a/Data/Aeson/Types/Internal.hs
+++ b/Data/Aeson/Types/Internal.hs
@@ -535,6 +535,7 @@ camelTo c = lastWasCap True
 
 -- | Better version of 'camelTo'. Example where it works better:
 --
+--   > camelTo '_' 'CamelAPICase' == "camel_apicase"
 --   > camelTo2 '_' 'CamelAPICase' == "camel_api_case"
 camelTo2 :: Char -> String -> String
 camelTo2 c = map toLower . go2 . go1

--- a/Data/Aeson/Types/Internal.hs
+++ b/Data/Aeson/Types/Internal.hs
@@ -56,7 +56,7 @@ import Control.Applicative
 import Control.Monad
 import Control.DeepSeq (NFData(..))
 import Data.ByteString.Builder (Builder, char7, toLazyByteString)
-import Data.Char (toLower, isUpper)
+import Data.Char (toLower, isUpper, isLower)
 import Data.Scientific (Scientific)
 import Data.Hashable (Hashable(..))
 import Data.Data (Data)
@@ -519,15 +519,12 @@ defaultTaggedObject = TaggedObject
 --   For use by Aeson template haskell calls.
 --
 --   > camelTo '_' 'CamelCaseAPI' == "camel_case_api"
+--   > camelTo '_' 'CamelAPICase' == "camel_api_case"
 camelTo :: Char -> String -> String
-camelTo c = lastWasCap True
-  where
-    lastWasCap :: Bool    -- ^ Previous was a capital letter
-              -> String  -- ^ The remaining string
-              -> String
-    lastWasCap _    []           = []
-    lastWasCap prev (x : xs)     = if isUpper x
-                                      then if prev
-                                             then toLower x : lastWasCap True xs
-                                             else c : toLower x : lastWasCap True xs
-                                      else x : lastWasCap False xs
+camelTo c = map toLower . go2 . go1
+    where go1 "" = ""
+          go1 (x:u:l:xs) | isUpper u && isLower l = x : c : u : l : go1 xs
+          go1 (x:xs) = x : go1 xs
+          go2 "" = ""
+          go2 (l:u:xs) | isLower l && isUpper u = l : c : u : go2 xs
+          go2 (x:xs) = x : go2 xs

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -5,7 +5,7 @@ module UnitTests (ioTests, tests) where
 import Control.Monad (forM)
 import Data.Aeson (eitherDecode, encode, genericToJSON, genericToEncoding)
 import Data.Aeson.Encode (encodeToTextBuilder)
-import Data.Aeson.Types (ToJSON(..), Value, camelTo, defaultOptions)
+import Data.Aeson.Types (ToJSON(..), Value, camelTo, camelTo2, defaultOptions)
 import Data.Char (toUpper)
 import GHC.Generics (Generic)
 import Test.Framework (Test, testGroup)
@@ -21,6 +21,13 @@ tests = testGroup "unit" [
       testCase "camelTo" $ roundTripCamel "aName"
     , testCase "camelTo" $ roundTripCamel "another"
     , testCase "camelTo" $ roundTripCamel "someOtherName"
+    , testCase "camelTo" $
+        assertEqual "" "camel_apicase" (camelTo '_' "CamelAPICase")
+    , testCase "camelTo2" $ roundTripCamel2 "aName"
+    , testCase "camelTo2" $ roundTripCamel2 "another"
+    , testCase "camelTo2" $ roundTripCamel2 "someOtherName"
+    , testCase "camelTo2" $
+        assertEqual "" "camel_api_case" (camelTo2 '_' "CamelAPICase")
     ]
   , testGroup "encoding" [
       testCase "goodProducer" $ goodProducer
@@ -30,10 +37,13 @@ tests = testGroup "unit" [
 roundTripCamel :: String -> Assertion
 roundTripCamel name = assertEqual "" name (camelFrom '_' $ camelTo '_' name)
 
+roundTripCamel2 :: String -> Assertion
+roundTripCamel2 name = assertEqual "" name (camelFrom '_' $ camelTo2 '_' name)
 
+camelFrom :: Char -> String -> String
+camelFrom c s = let (p:ps) = split c s
+                in concat $ p : map capitalize ps
   where
-    camelFrom c s = let (p:ps) = split c s
-                    in concat $ p : map capitalize ps
     split c s = map L.unpack $ L.split c $ L.pack s
     capitalize t = toUpper (head t) : tail t
 


### PR DESCRIPTION
For example, it handles a case "CamelAPICase" into "camel_api_case"

I'm not sure if we should just change current camelTo, or deprecate it for a new function with different name.