### PR TITLE
Optimize and fix integer overflow in subsecond parsing.

### DIFF
--- a/Data/Aeson/Parser/Time.hs
+++ b/Data/Aeson/Parser/Time.hs
@@ -20,7 +20,7 @@ module Data.Aeson.Parser.Time
     , zonedTime
     ) where
 
-import Control.Applicative ((<$>), (<|>), empty)
+import Control.Applicative ((<$>), (<*>), (<*), (*>))
 import Control.Monad (when, void)
 import Data.Attoparsec.Text as A
 import Data.Bits ((.&.))

--- a/Data/Aeson/Types/Instances.hs
+++ b/Data/Aeson/Types/Instances.hs
@@ -55,7 +55,7 @@ module Data.Aeson.Types.Instances
     , typeMismatch
     ) where
 
-import Control.Applicative ((<$>), (<*>), (<|>), pure, empty)
+import Control.Applicative ((<$>), (<*>), pure)
 import qualified Data.Aeson.Encode.Builder as E
 import qualified Data.ByteString.Builder as B
 import Data.Aeson.Functions


### PR DESCRIPTION
It turns out that since base-4.7,  `Data.Fixed` exports the `MkFixed` constructor,  so we can be protected against future representation changes and we can also support older bases safely with `unsafeCoerce`.

@bos

~~~
benchmarking UTCTime/whole
time                 30.15 μs   (30.11 μs .. 30.21 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 30.16 μs   (30.11 μs .. 30.30 μs)
std dev              224.0 ns   (84.93 ns .. 474.5 ns)

benchmarking UTCTime/fractional
time                 39.88 μs   (39.80 μs .. 40.00 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 39.91 μs   (39.87 μs .. 39.97 μs)
std dev              157.1 ns   (119.1 ns .. 214.0 ns)

benchmarking ZonedTime/whole
time                 22.09 μs   (22.08 μs .. 22.11 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 22.10 μs   (22.08 μs .. 22.11 μs)
std dev              45.45 ns   (35.74 ns .. 56.10 ns)

benchmarking ZonedTime/fractional
time                 34.88 μs   (34.86 μs .. 34.90 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 34.90 μs   (34.89 μs .. 34.92 μs)
std dev              56.17 ns   (42.32 ns .. 83.73 ns)
~~~

@lpsmith
~~~
benchmarking UTCTime/whole
time                 31.05 μs   (30.96 μs .. 31.22 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 31.02 μs   (30.99 μs .. 31.12 μs)
std dev              168.9 ns   (53.15 ns .. 346.4 ns)

benchmarking UTCTime/fractional
time                 35.70 μs   (35.65 μs .. 35.79 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 35.71 μs   (35.65 μs .. 35.84 μs)
std dev              272.4 ns   (107.1 ns .. 507.9 ns)

benchmarking ZonedTime/whole
time                 23.63 μs   (23.58 μs .. 23.68 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 23.52 μs   (23.47 μs .. 23.60 μs)
std dev              214.7 ns   (147.7 ns .. 348.7 ns)

benchmarking ZonedTime/fractional
time                 27.34 μs   (27.32 μs .. 27.37 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 27.37 μs   (27.35 μs .. 27.47 μs)
std dev              157.0 ns   (42.22 ns .. 323.7 ns)
~~~
