### PR TITLE
Utc offset fixes

### DIFF
--- a/Data/Aeson/Parser/Time.hs
+++ b/Data/Aeson/Parser/Time.hs
@@ -113,17 +113,22 @@ timeZone = do
   if ch == 'Z'
     then return Nothing
     else do
-      h0 <- twoDigits
-      m <- maybeSkip ':' *> twoDigits
-      let h | ch == '-' = negate h0
-            | otherwise = h0
-      case h * 60 + m of
-        off | off == 0 ->
+      h  <- twoDigits
+      mc <- peekChar
+      m  <- case mc of
+              Just c | c == ':'  -> anyChar *> twoDigits
+                     | isDigit c -> twoDigits
+              _ -> return 0
+      case () of
+        _ | h == 0 && m == 0 ->
               return Nothing
-            | off < -720 || off > 840 || m > 59 ->
+          | h > 23 || m > 59 ->
               fail "invalid time zone offset"
-            | otherwise ->
-              let !tz = Local.minutesToTimeZone off
+          | otherwise ->
+              let !absset = h * 60 + m
+                  !offset | ch == '-' = negate absset
+                          | otherwise = absset
+                  !tz = Local.minutesToTimeZone offset
               in return (Just tz)
 
 -- | Parse a date and time, of the form @YYYY-MM-DD HH:MM:SS@.
@@ -150,9 +155,7 @@ utcTime = do
 --
 -- The first space may instead be a @T@, and the second space is
 -- optional.  The @Z@ represents UTC.  The @Z@ may be replaced with a
--- time zone offset of the form @+0000@ or @-08:00@, where the first
--- two digits are hours, the @:@ is optional and the second two digits
--- are minutes.
+-- time zone offset of the form @±HH@ or @±HH:MM@.
 zonedTime :: Parser Local.ZonedTime
 zonedTime = Local.ZonedTime <$> localTime <*> (fromMaybe utc <$> timeZone)
 

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -107,15 +107,18 @@ utcTimeGood = do
   let ts6 = "2015-01-01T12:30:00.00+01:15" :: LT.Text
   let ts7 = "2015-01-01T12:30:00.00-0200" :: LT.Text
   let ts8 = "2015-01-01T22:00:00.00-03:00" :: LT.Text
+  let ts9 = "2015-01-01T22:00:00.00-04:30" :: LT.Text
   let (Just (t5 ::  UTCTime)) = parseWithAeson ts5
   let (Just (t6 ::  UTCTime)) = parseWithAeson ts6
   let (Just (t7 ::  UTCTime)) = parseWithAeson ts7
   let (Just (t8 ::  UTCTime)) = parseWithAeson ts8
+  let (Just (t9 ::  UTCTime)) = parseWithAeson ts9
   assertEqual "utctime" (parseWithRead "%FT%T%QZ" "2015-01-01T12:30:00.00Z") t5
   assertEqual "utctime" (parseWithRead "%FT%T%QZ" "2015-01-01T11:15:00.00Z") t6
   assertEqual "utctime" (parseWithRead "%FT%T%QZ" "2015-01-01T14:30:00Z") t7
   -- ts8 wraps around to the next day in UTC
   assertEqual "utctime" (parseWithRead "%FT%T%QZ" "2015-01-02T01:00:00Z") t8
+  assertEqual "utctime" (parseWithRead "%FT%T%QZ" "2015-01-02T02:30:00Z") t9
   where
     parseWithRead :: String -> LT.Text -> UTCTime
     parseWithRead f s =
@@ -136,6 +139,7 @@ utcTimeBad = do
   verifyFailParse "2015-01-01T12:30:00.00+00Z" -- no Zulu if offset given
   verifyFailParse "2015-01-01T12:30:00.00+00:00Z" -- no Zulu if offset given
   verifyFailParse "2015-01-03 12:13:00.Z" -- decimal at the end but no digits
+  verifyFailParse "2015-01-01 13:30:00-01:60" -- malformed offset
   where
     verifyFailParse (s :: LT.Text) =
       let (dec :: Maybe UTCTime) = decode . LT.encodeUtf8 $ (LT.concat ["\"", s, "\""]) in

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -102,8 +102,8 @@ utcTimeGood = do
   assertEqual "utctime" (parseWithRead "%FT%T%QZ" ts2) t2
   assertEqual "utctime" (parseWithRead "%F %T%QZ" ts3) t3
   assertEqual "utctime" (parseWithRead "%F %T%QZ" ts4) t4
-  -- timezones.  Both +HHMM and +HH:MM are allowed for timezone offset
-  let ts5 = "2015-01-01T12:30:00.00+0000" :: LT.Text
+  -- offsets.  ±HH, ±HHMM, and ±HH:MM are allowed for utc offset
+  let ts5 = "2015-01-01T12:30:00.00+00" :: LT.Text
   let ts6 = "2015-01-01T12:30:00.00+01:15" :: LT.Text
   let ts7 = "2015-01-01T12:30:00.00-0200" :: LT.Text
   let ts8 = "2015-01-01T22:00:00.00-03:00" :: LT.Text


### PR DESCRIPTION
The biggest problem here is that you have a sign error on the minutes component when the offset is negative,  which the test suite did not catch.   You may be interested in taking a look at [postgresql-simple's time test suite](https://github.com/lpsmith/postgresql-simple/blob/b4624db41048e42e993d3bea820e907a010fde00/test/Time.hs).

Also, as I understand ISO 8601:2004,  ±HHMM is not a valid syntax for specifying
a UTC offset in the context we are using it.   Only ±HH and ±HH:MM are
valid in the extended ISO 8601 syntax,   and ±HH is a commonly used variant.

I probably would weakly prefer to not accept ±HHMM, however,  because the
the ToJSON ZonedTime instance has been emitting this syntax since aeson
version 0.6.1.0 released on 2012-12-14,   our hands may well be tied on
this matter.

I can only hope that the older FromJSON instances will also accept ±HH and
±HH:MM,  so that we can fix the emitted syntax with minimal disruption,
but knowing the time library, this probably is not the case.