### PR TITLE
Encode ZonedTime into an unambiguously ISO 8601 compliant syntax

### DIFF
--- a/Data/Aeson/Encode/Builder.hs
+++ b/Data/Aeson/Encode/Builder.hs
@@ -208,7 +208,7 @@ timeOfDay64 (TOD h m s0)
 timeZone :: TimeZone -> Builder
 timeZone (TimeZone off _ _)
   | off == 0  = B.char7 'Z'
-  | otherwise = BP.primBounded (ascii5 (s,(hh,(hl,(mh,ml))))) ()
+  | otherwise = BP.primBounded (ascii6 (s,(hh,(hl,(':',(mh,ml)))))) ()
   where !s         = if off < 0 then '-' else '+'
         !(T hh hl) = twoDigits h
         !(T mh ml) = twoDigits m


### PR DESCRIPTION
Again,  the `±HHMM` syntax that is currently being used appears to only be ISO 8601 compliant when it's used in the context of the basic syntax,  in which case you'd have to produce something that looks like `20150722T140827-0400` instead of `2015-07-22T14:08:27-0400`.   By using `±HH:MM` instead,  there's no question that you are fully within the scope of ISO 8601.