### PR TITLE
Ensure that years are encoded with at least 4 digits

### DIFF
--- a/Data/Aeson/Encode/Builder.hs
+++ b/Data/Aeson/Encode/Builder.hs
@@ -169,11 +169,19 @@ ascii8 cs = BP.liftFixedToBounded $ (const cs) >$<
 {-# INLINE ascii8 #-}
 
 day :: Day -> Builder
-day dd = B.integerDec y <>
+day dd = encodeYear y <>
          BP.primBounded (ascii6 ('-',(mh,(ml,('-',(dh,dl)))))) ()
   where (y,m,d)     = toGregorian dd
         !(T mh ml)  = twoDigits m
         !(T dh dl)  = twoDigits d
+        encodeYear y
+            | y >= 1000 = B.integerDec y
+            | y > 0 =
+                let (ab,c) = fromIntegral y `quotRem` 10
+                    (a,b)  = ab `quotRem` 10
+                in BP.primBounded (ascii4 ('0',(digit a,(digit b,digit c)))) ()
+            | otherwise =
+                error "Data.Aeson.Encode.Builder.day:  years BCE not supported"
 {-# INLINE day #-}
 
 timeOfDay :: TimeOfDay -> Builder


### PR DESCRIPTION
Not sure exactly how you want to handle this,  but a few factoids:

1.   ISO 8601 does specifically require four digits on the year,  though more than four digits are allowed "by agreement".   (Technically,  years with more than four digits must also be prefixed with `+`,  but this doesn't seem to be what anybody does;  everything I've seen just sends five or more digits without the leading plus sign.)

2.   It's also true that according to ISO 8601,  dates before 1582 can only be exchanged "by agreement",  but this grossly oversimplifies the shift between the Julian and Gregorian calendars (e.g. Greece finally switched only in 1923) and the proleptic Gregorian calendar is encouraged (as in, required by agreement of the data interchange partners,  otherwise it's not ISO 8601) by ISO 8601 and does appear to be what everybody is actually doing. 

3.  Although a syntax for dates BCE is prescribed by ISO 8601, by prefixing the year with `-`, few people seem to follow this,  nor does there appear to be a widely agreed-upon syntax.    For example, the time package will generate years with the ISO syntax,  but cannot parse the syntax it generates.    PostgreSQL appends `BC` to the end of the timestamp or date,  and can parse what it generates,  but also cannot parse the ISO syntax.

4.  There's a lot of disagreement over the year 0;  I'm not aware of all the issues other than that they exist.   Some people use it, others don't.   PostgreSQL doesn't,  the time package does;  astronomers tend to have a year 0,  historians mostly don't (but western historians also have to deal with Julian vs Gregorian,  though Mayan historians use the proleptic Gregorian calendar.)    ISO doesn't have much to say here,  other than what I've already said.

So I don't know what you want to do;  it doesn't appear to be an obvious "correct" answer here,  but at least this patch does avoid generating syntax that is expressly not ISO 8601, which is perhaps important.   (It could be critical if using the basic syntax,  as then `9990101` would be properly interpreted as the 101st day of the year 9990, rather than 999-01-01.  Thankfully the extended syntax has more redundancy.)