### PR TITLE
Add ToJSON and FromJSON instances for NominalDiffTime

### DIFF
--- a/Data/Aeson/Types/Instances.hs
+++ b/Data/Aeson/Types/Instances.hs
@@ -77,7 +77,7 @@ import Data.Maybe (fromMaybe)
 import Data.Monoid (Dual(..), First(..), Last(..))
 import Data.Ratio (Ratio, (%), numerator, denominator)
 import Data.Text (Text, pack, unpack)
-import Data.Time (Day, LocalTime, UTCTime, ZonedTime)
+import Data.Time (Day, LocalTime, UTCTime, ZonedTime, NominalDiffTime)
 import Data.Time.Format (FormatTime, formatTime, parseTime)
 import Data.Traversable as Tr (sequence, traverse)
 import Data.Vector (Vector)
@@ -748,6 +748,21 @@ stringEncoding = String . T.decodeLatin1 . L.toStrict . encode
 
 instance FromJSON UTCTime where
     parseJSON = withText "UTCTime" (Time.run Time.utcTime)
+
+instance ToJSON NominalDiffTime where
+    toJSON = Number . realToFrac
+    {-# INLINE toJSON #-}
+
+    toEncoding = Encoding . E.number . realToFrac
+    {-# INLINE toEncoding #-}
+
+-- | /WARNING:/ Only parse lengths of time from trusted input
+-- since an attacker could easily fill up the memory of the target
+-- system by specifying a scientific number with a big exponent like
+-- @1e1000000000@.
+instance FromJSON NominalDiffTime where
+    parseJSON = withScientific "NominalDiffTime" $ pure . realToFrac
+    {-# INLINE parseJSON #-}
 
 parseJSONElemAtIndex :: FromJSON a => Int -> Vector Value -> Parser a
 parseJSONElemAtIndex idx ary = parseJSON (V.unsafeIndex ary idx) <?> Index idx

--- a/tests/Instances.hs
+++ b/tests/Instances.hs
@@ -8,8 +8,10 @@ import Data.Function (on)
 import Control.Monad
 import Test.QuickCheck (Arbitrary(..), Gen, choose, oneof, elements)
 import Data.Time.Clock (DiffTime, UTCTime(..), picosecondsToDiffTime)
+import Data.Fixed (Pico)
 import Data.Time (ZonedTime(..), LocalTime(..), TimeZone(..),
-                  hoursToTimeZone, Day(..), TimeOfDay(..))
+                  hoursToTimeZone, Day(..), TimeOfDay(..),
+                  NominalDiffTime)
 import qualified Data.Text as T
 import qualified Data.Map as Map
 import Data.Text (Text)
@@ -48,6 +50,9 @@ instance Arbitrary DotNetTime where
 
 instance Arbitrary ZonedTime where
     arbitrary = liftM2 ZonedTime arbitrary arbitrary
+
+instance Arbitrary NominalDiffTime where
+    arbitrary = realToFrac <$> (arbitrary :: Gen Pico)
 
 deriving instance Eq ZonedTime
 

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -9,7 +9,7 @@ import Data.Aeson.Parser (value)
 import Data.Aeson.Types
 import Data.ByteString.Builder (toLazyByteString)
 import Data.Int (Int8)
-import Data.Time (Day, LocalTime, UTCTime, ZonedTime)
+import Data.Time (Day, LocalTime, UTCTime, ZonedTime, NominalDiffTime)
 import Encoders
 import Instances ()
 import Test.Framework (Test, testGroup)
@@ -124,6 +124,7 @@ tests = testGroup "properties" [
     , testProperty "LocalTime" $ roundTripEq (undefined :: LocalTime)
     , testProperty "UTCTime" $ roundTripEq (undefined :: UTCTime)
     , testProperty "ZonedTime" $ roundTripEq (undefined :: ZonedTime)
+    , testProperty "NominalDiffTime" $ roundTripEq (undefined :: NominalDiffTime)
     , testGroup "ghcGenerics" [
         testProperty "OneConstructor" $ roundTripEq OneConstructor
       , testProperty "Product2" $ roundTripEq (undefined :: Product2 Int Bool)


### PR DESCRIPTION
This serializes NominalDiffTime as a number of seconds, which sounds like a sensible encoding for a "length of time" thing to me.

I have a feeling that this instance isn't present due to some reason other than simply being not implemented, but my search of any discussions resulted in nothing -- sorry if that's indeed the case.