### PR TITLE
Support deriving data families with Template Haskell

### DIFF
--- a/Data/Aeson/TH.hs
+++ b/Data/Aeson/TH.hs
@@ -49,6 +49,20 @@ d = Record { testOne = 3.14159
 >>> fromJSON (toJSON d) == Success d
 > True
 
+This also works for data family instances, but instead of passing in the data
+family name (with double quotes), we pass in a data family instance
+constructor (with a single quote):
+
+@
+data family DF a
+data instance DF Int = DF1 Int
+                     | DF2 Int Int
+                     deriving Eq
+
+$('deriveJSON' 'defaultOptions' 'DF1)
+-- Alternatively, one could pass 'DF2 instead
+@
+
 Please note that you can derive instances for tuples using the following syntax:
 
 @
@@ -125,7 +139,7 @@ import qualified Data.Vector.Mutable as VM ( unsafeNew, unsafeWrite )
 --------------------------------------------------------------------------------
 
 -- | Generates both 'ToJSON' and 'FromJSON' instance declarations for the given
--- data type.
+-- data type or data family instance constructor.
 --
 -- This is a convienience function which is equivalent to calling both
 -- 'deriveToJSON' and 'deriveFromJSON'.
@@ -154,7 +168,8 @@ instance (ToJSON a) ⇒ ToJSON Foo where ...
 The above (ToJSON a) constraint is not necessary and perhaps undesirable.
 -}
 
--- | Generates a 'ToJSON' instance declaration for the given data type.
+-- | Generates a 'ToJSON' instance declaration for the given data type or
+-- data family instance constructor.
 deriveToJSON :: Options
              -- ^ Encoding options.
              -> Name
@@ -183,15 +198,15 @@ deriveToJSON opts name =
         (instanceCxt, instanceType) =
             buildTypeInstance name' ''ToJSON tvbs mbTys
 
--- | Generates a lambda expression which encodes the given data type as a
--- 'Value'.
+-- | Generates a lambda expression which encodes the given data type or
+-- data family instance constructor as a 'Value'.
 mkToJSON :: Options -- ^ Encoding options.
          -> Name -- ^ Name of the type to encode.
          -> Q Exp
 mkToJSON opts name = withType name (\_ _ cons _ -> consToValue opts cons)
 
--- | Generates a lambda expression which encodes the given data type
--- as a JSON string.
+-- | Generates a lambda expression which encodes the given data type or
+-- data family instance constructor as a JSON string.
 mkToEncoding :: Options -- ^ Encoding options.
              -> Name -- ^ Name of the type to encode.
              -> Q Exp
@@ -537,7 +552,8 @@ argsToEncoding opts multiCons (ForallC _ _ con) =
 -- FromJSON
 --------------------------------------------------------------------------------
 
--- | Generates a 'FromJSON' instance declaration for the given data type.
+-- | Generates a 'FromJSON' instance declaration for the given data type or
+-- data family instance constructor.
 deriveFromJSON :: Options
                -- ^ Encoding options.
                -> Name
@@ -562,7 +578,7 @@ deriveFromJSON opts name =
             buildTypeInstance name' ''FromJSON tvbs mbTys
 
 -- | Generates a lambda expression which parses the JSON encoding of the given
--- data type.
+-- data type or data family instance constructor.
 mkParseJSON :: Options -- ^ Encoding options.
             -> Name -- ^ Name of the encoded type.
             -> Q Exp

--- a/aeson.cabal
+++ b/aeson.cabal
@@ -95,7 +95,7 @@ library
     mtl,
     scientific >= 0.3.1 && < 0.4,
     syb,
-    template-haskell >= 2.4,
+    template-haskell >= 2.7,
     text >= 1.1.1.0,
     transformers,
     unordered-containers >= 0.2.5.0,
@@ -117,6 +117,8 @@ test-suite tests
   hs-source-dirs: tests
   main-is:        Tests.hs
   other-modules:
+    DataFamilies.Encoders
+    DataFamilies.Types
     Encoders
     Functions
     Instances

--- a/tests/DataFamilies/Encoders.hs
+++ b/tests/DataFamilies/Encoders.hs
@@ -1,0 +1,114 @@
+{-# Language TemplateHaskell #-}
+
+module DataFamilies.Encoders where
+
+import Data.Aeson.TH
+import Data.Aeson.Types
+import Options
+import DataFamilies.Types
+
+--------------------------------------------------------------------------------
+-- Nullary encoders/decoders
+--------------------------------------------------------------------------------
+
+thNullaryToJSONString :: Nullary Int -> Value
+thNullaryToJSONString = $(mkToJSON defaultOptions 'C1)
+
+thNullaryToEncodingString :: Nullary Int -> Encoding
+thNullaryToEncodingString = $(mkToEncoding defaultOptions 'C2)
+
+thNullaryParseJSONString :: Value -> Parser (Nullary Int)
+thNullaryParseJSONString = $(mkParseJSON defaultOptions 'C3)
+
+
+thNullaryToJSON2ElemArray :: Nullary Int -> Value
+thNullaryToJSON2ElemArray = $(mkToJSON opts2ElemArray 'C1)
+
+thNullaryToEncoding2ElemArray :: Nullary Int -> Encoding
+thNullaryToEncoding2ElemArray = $(mkToEncoding opts2ElemArray 'C2)
+
+thNullaryParseJSON2ElemArray :: Value -> Parser (Nullary Int)
+thNullaryParseJSON2ElemArray = $(mkParseJSON opts2ElemArray 'C3)
+
+
+thNullaryToJSONTaggedObject :: Nullary Int -> Value
+thNullaryToJSONTaggedObject = $(mkToJSON optsTaggedObject 'C1)
+
+thNullaryToEncodingTaggedObject :: Nullary Int -> Encoding
+thNullaryToEncodingTaggedObject = $(mkToEncoding optsTaggedObject 'C2)
+
+thNullaryParseJSONTaggedObject :: Value -> Parser (Nullary Int)
+thNullaryParseJSONTaggedObject = $(mkParseJSON optsTaggedObject 'C3)
+
+
+thNullaryToJSONObjectWithSingleField :: Nullary Int -> Value
+thNullaryToJSONObjectWithSingleField =
+  $(mkToJSON optsObjectWithSingleField 'C1)
+
+thNullaryToEncodingObjectWithSingleField :: Nullary Int -> Encoding
+thNullaryToEncodingObjectWithSingleField =
+  $(mkToEncoding optsObjectWithSingleField 'C2)
+
+thNullaryParseJSONObjectWithSingleField :: Value -> Parser (Nullary Int)
+thNullaryParseJSONObjectWithSingleField = $(mkParseJSON optsObjectWithSingleField 'C3)
+
+
+--------------------------------------------------------------------------------
+-- SomeType encoders/decoders
+--------------------------------------------------------------------------------
+
+thSomeTypeToJSON2ElemArray :: SomeType c () Int -> Value
+thSomeTypeToJSON2ElemArray = $(mkToJSON opts2ElemArray 'Nullary)
+
+thSomeTypeToEncoding2ElemArray :: SomeType c () Int -> Encoding
+thSomeTypeToEncoding2ElemArray = $(mkToEncoding opts2ElemArray 'Unary)
+
+thSomeTypeParseJSON2ElemArray :: Value -> Parser (SomeType c () Int)
+thSomeTypeParseJSON2ElemArray = $(mkParseJSON opts2ElemArray 'Product)
+
+
+thSomeTypeToJSONTaggedObject :: SomeType c () Int -> Value
+thSomeTypeToJSONTaggedObject = $(mkToJSON optsTaggedObject 'Record)
+
+thSomeTypeToEncodingTaggedObject :: SomeType c () Int -> Encoding
+thSomeTypeToEncodingTaggedObject = $(mkToEncoding optsTaggedObject 'Nullary)
+
+thSomeTypeParseJSONTaggedObject :: Value -> Parser (SomeType c () Int)
+thSomeTypeParseJSONTaggedObject = $(mkParseJSON optsTaggedObject 'Unary)
+
+
+thSomeTypeToJSONObjectWithSingleField :: SomeType c () Int -> Value
+thSomeTypeToJSONObjectWithSingleField =
+  $(mkToJSON optsObjectWithSingleField 'Product)
+
+thSomeTypeToEncodingObjectWithSingleField :: SomeType c () Int -> Encoding
+thSomeTypeToEncodingObjectWithSingleField =
+  $(mkToEncoding optsObjectWithSingleField 'Record)
+
+thSomeTypeParseJSONObjectWithSingleField :: Value -> Parser (SomeType c () Int)
+thSomeTypeParseJSONObjectWithSingleField =
+  $(mkParseJSON optsObjectWithSingleField 'Nullary)
+
+
+--------------------------------------------------------------------------------
+-- Approx encoders/decoders
+--------------------------------------------------------------------------------
+
+thApproxToJSONUnwrap :: Approx String -> Value
+thApproxToJSONUnwrap = $(mkToJSON optsUnwrapUnaryRecords 'Approx)
+
+thApproxToEncodingUnwrap :: Approx String -> Encoding
+thApproxToEncodingUnwrap = $(mkToEncoding optsUnwrapUnaryRecords 'Approx)
+
+thApproxParseJSONUnwrap :: Value -> Parser (Approx String)
+thApproxParseJSONUnwrap = $(mkParseJSON optsUnwrapUnaryRecords 'Approx)
+
+
+thApproxToJSONDefault :: Approx String -> Value
+thApproxToJSONDefault = $(mkToJSON defaultOptions 'Approx)
+
+thApproxToEncodingDefault :: Approx String -> Encoding
+thApproxToEncodingDefault = $(mkToEncoding defaultOptions 'Approx)
+
+thApproxParseJSONDefault :: Value -> Parser (Approx String)
+thApproxParseJSONDefault = $(mkParseJSON defaultOptions 'Approx)

--- a/tests/DataFamilies/Instances.hs
+++ b/tests/DataFamilies/Instances.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE FlexibleInstances, TemplateHaskell, TypeFamilies #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module DataFamilies.Instances where
+
+import Control.Applicative
+import Data.Aeson.TH
+import DataFamilies.Types
+import Test.QuickCheck (Arbitrary(..), elements, oneof)
+import Prelude
+
+instance (Arbitrary a) => Arbitrary (Approx a) where
+    arbitrary = Approx <$> arbitrary
+
+instance Arbitrary (Nullary Int) where
+    arbitrary = elements [C1, C2, C3]
+
+instance Arbitrary a => Arbitrary (SomeType c () a) where
+    arbitrary = oneof [ pure Nullary
+                      , Unary   <$> arbitrary
+                      , Product <$> arbitrary <*> arbitrary <*> arbitrary
+                      , Record  <$> arbitrary <*> arbitrary <*> arbitrary
+                      ]
+
+deriveJSON defaultOptions 'C1
+deriveJSON defaultOptions 'Nullary
+deriveJSON defaultOptions 'Approx

--- a/tests/DataFamilies/Properties.hs
+++ b/tests/DataFamilies/Properties.hs
@@ -1,0 +1,72 @@
+module DataFamilies.Properties (tests) where
+
+import DataFamilies.Encoders
+import DataFamilies.Instances ()
+
+import Properties hiding (tests)
+
+import Test.Framework (Test, testGroup)
+import Test.Framework.Providers.QuickCheck2 (testProperty)
+
+--------------------------------------------------------------------------------
+
+tests :: Test
+tests = testGroup "data families" [
+  testGroup "template-haskell" [
+      testGroup "toJSON" [
+        testGroup "Nullary" [
+            testProperty "string" (isString . thNullaryToJSONString)
+          , testProperty "2ElemArray" (is2ElemArray . thNullaryToJSON2ElemArray)
+          , testProperty "TaggedObject" (isTaggedObjectValue . thNullaryToJSONTaggedObject)
+          , testProperty "ObjectWithSingleField" (isObjectWithSingleField . thNullaryToJSONObjectWithSingleField)
+
+          , testGroup "roundTrip" [
+              testProperty "string" (toParseJSON thNullaryParseJSONString thNullaryToJSONString)
+            , testProperty "2ElemArray" (toParseJSON thNullaryParseJSON2ElemArray thNullaryToJSON2ElemArray)
+            , testProperty "TaggedObject" (toParseJSON thNullaryParseJSONTaggedObject thNullaryToJSONTaggedObject)
+            , testProperty "ObjectWithSingleField" (toParseJSON thNullaryParseJSONObjectWithSingleField thNullaryToJSONObjectWithSingleField)
+            ]
+        ]
+      , testGroup "SomeType" [
+          testProperty "2ElemArray" (is2ElemArray . thSomeTypeToJSON2ElemArray)
+        , testProperty "TaggedObject" (isTaggedObject . thSomeTypeToJSONTaggedObject)
+        , testProperty "ObjectWithSingleField" (isObjectWithSingleField . thSomeTypeToJSONObjectWithSingleField)
+        , testGroup "roundTrip" [
+            testProperty "2ElemArray" (toParseJSON thSomeTypeParseJSON2ElemArray thSomeTypeToJSON2ElemArray)
+          , testProperty "TaggedObject" (toParseJSON thSomeTypeParseJSONTaggedObject thSomeTypeToJSONTaggedObject)
+          , testProperty "ObjectWithSingleField" (toParseJSON thSomeTypeParseJSONObjectWithSingleField thSomeTypeToJSONObjectWithSingleField)
+          ]
+       , testGroup "Approx" [
+            testProperty "string"                (isString                . thApproxToJSONUnwrap)
+          , testProperty "ObjectWithSingleField" (isObjectWithSingleField . thApproxToJSONDefault)
+          , testGroup "roundTrip" [
+                testProperty "string"                (toParseJSON thApproxParseJSONUnwrap  thApproxToJSONUnwrap)
+              , testProperty "ObjectWithSingleField" (toParseJSON thApproxParseJSONDefault thApproxToJSONDefault)
+            ]
+          ]
+        ]
+      ]
+    , testGroup "toEncoding" [
+        testProperty "NullaryString" $
+        thNullaryToJSONString `sameAs` thNullaryToEncodingString
+      , testProperty "Nullary2ElemArray" $
+        thNullaryToJSON2ElemArray `sameAs` thNullaryToEncoding2ElemArray
+      , testProperty "NullaryTaggedObject" $
+        thNullaryToJSONTaggedObject `sameAs` thNullaryToEncodingTaggedObject
+      , testProperty "NullaryObjectWithSingleField" $
+        thNullaryToJSONObjectWithSingleField `sameAs`
+        thNullaryToEncodingObjectWithSingleField
+      , testProperty "ApproxUnwrap" $
+        thApproxToJSONUnwrap `sameAs` thApproxToEncodingUnwrap
+      , testProperty "ApproxDefault" $
+        thApproxToJSONDefault `sameAs` thApproxToEncodingDefault
+      , testProperty "SomeType2ElemArray" $
+        thSomeTypeToJSON2ElemArray `sameAsV` thSomeTypeToEncoding2ElemArray
+      , testProperty "SomeTypeTaggedObject" $
+        thSomeTypeToJSONTaggedObject `sameAsV` thSomeTypeToEncodingTaggedObject
+      , testProperty "SomeTypeObjectWithSingleField" $
+        thSomeTypeToJSONObjectWithSingleField `sameAsV`
+        thSomeTypeToEncodingObjectWithSingleField
+      ]
+    ]
+  ]

--- a/tests/DataFamilies/Types.hs
+++ b/tests/DataFamilies/Types.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, TypeFamilies #-}
+
+module DataFamilies.Types where
+
+import Types (ApproxEq(..))
+
+data family Nullary a
+data instance Nullary Int  = C1 | C2 | C3 deriving (Eq, Show)
+data instance Nullary Char = C4           deriving (Eq, Show)
+
+data family SomeType a b c
+data instance SomeType c () a = Nullary
+                              | Unary Int
+                              | Product String (Maybe Char) a
+                              | Record { testOne   :: Double
+                                       , testTwo   :: Maybe Bool
+                                       , testThree :: Maybe a
+                                       } deriving (Eq, Show)
+
+data family Approx a
+newtype instance Approx a = Approx { fromApprox :: a }
+    deriving (Show, ApproxEq, Num)
+
+instance (ApproxEq a) => Eq (Approx a) where
+    Approx a == Approx b = a =~ b

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings, RecordWildCards, ScopedTypeVariables #-}
 
-module Properties (tests) where
+module Properties where
 
 import Data.Aeson (eitherDecode)
 import Data.Aeson.Encode (encode, encodeToBuilder)

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -1,10 +1,11 @@
 module Main (main) where
 
 import Test.Framework (defaultMain)
+import qualified DataFamilies.Properties as DF
 import qualified Properties
 import qualified UnitTests
 
 main :: IO ()
 main = do
     ioTests <- UnitTests.ioTests
-    defaultMain (Properties.tests : UnitTests.tests : ioTests)
+    defaultMain (DF.tests : Properties.tests : UnitTests.tests : ioTests)


### PR DESCRIPTION
`Data.Aeson.TH` currently only supports plain data types. This pull request extends the Template Haskell engine to allow deriving data family instances.

Since it is impractical to pass an entire data instance's type (e.g., `Family Int a`) to Template Haskell, this works by passing in the name of a data family instance constuctor to `deriveJSON`/`mk-`/etc., which infers the instance it corresponds to:

```haskell
data family DF a
data instance DF Int = DF1 Int
                     | DF2 Int Int
                     deriving Eq

$(deriveJSON defaultOptions 'DF1)
-- Alternatively, one could pass 'DF2 instead
```