### PR TITLE
make the key show up in the error message

### DIFF
--- a/Data/Aeson/Types/Instances.hs
+++ b/Data/Aeson/Types/Instances.hs
@@ -1527,7 +1527,10 @@ ifromJSON = iparse parseJSON
 (.:) :: (FromJSON a) => Object -> Text -> Parser a
 obj .: key = case H.lookup key obj of
                Nothing -> fail $ "key " ++ show key ++ " not present"
-               Just v  -> parseJSON v <?> Key key
+               Just v  -> modifyFailure addKeyName
+                        $ parseJSON v <?> Key key
+  where
+    addKeyName = (("failed to parse field " <> unpack key <> ": ") <>)
 {-# INLINE (.:) #-}
 
 -- | Retrieve the value associated with the given key of an 'Object'.
@@ -1540,7 +1543,10 @@ obj .: key = case H.lookup key obj of
 (.:?) :: (FromJSON a) => Object -> Text -> Parser (Maybe a)
 obj .:? key = case H.lookup key obj of
                Nothing -> pure Nothing
-               Just v  -> Just <$> parseJSON v <?> Key key
+               Just v  -> modifyFailure addKeyName
+                        $ Just <$> parseJSON v <?> Key key
+  where
+    addKeyName = (("failed to parse field " <> unpack key <> ": ") <>)
 {-# INLINE (.:?) #-}
 
 -- | Helper for use in combination with '.:?' to provide default


### PR DESCRIPTION
I have added this as an override to a couple projects already. We get a lot of reports from users confused about why their JSON/YAML did not parse because it doesn't tell them the key that failed.

Feel free to modify the format of the error message to your liking. The important thing is just to have the key in there somehow.