### PR TITLE
Add throwDecode family of decoding functions

### DIFF
--- a/aeson.cabal
+++ b/aeson.cabal
@@ -90,6 +90,7 @@ library
     containers,
     deepseq,
     dlist >= 0.2,
+    exceptions >= 0.8,
     ghc-prim >= 0.2,
     hashable >= 1.1.2.0,
     mtl,


### PR DESCRIPTION
I find myself often reimplementing those to use with web apis:

```hs
req <- makeTheRequest
res <- httpLbs req mgr
throwDecode (responseBody res)
```