### PR TITLE
Added test modules to 'other-modules' section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ cabal.sandbox.config
 
 *.o
 *.hi
+*.nix
 
 benchmarks/AesonEncode
 

--- a/aeson.cabal
+++ b/aeson.cabal
@@ -117,6 +117,8 @@ test-suite tests
   hs-source-dirs: tests
   main-is:        Tests.hs
   other-modules:
+    DataFamilies.Properties
+    DataFamilies.Instances
     DataFamilies.Encoders
     DataFamilies.Types
     Encoders


### PR DESCRIPTION
`cabal unpack aeson` had some missing modules which caused the test project to be unable to build.  