### PR TITLE
Add (.:!) and partially revert d0414be92ee6bf5b4c057978955b89d111767dab

### DIFF
--- a/Data/Aeson.hs
+++ b/Data/Aeson.hs
@@ -78,6 +78,7 @@ module Data.Aeson
     , foldable
     , (.:)
     , (.:?)
+    , (.:!)
     , (.!=)
     , object
     -- * Parsing

--- a/Data/Aeson/TH.hs
+++ b/Data/Aeson/TH.hs
@@ -101,7 +101,7 @@ import Data.Aeson.Types ( Value(..), Parser
                         , defaultTaggedObject
                         )
 import Data.Aeson.Types.Internal (Encoding(..))
-import Control.Monad       ( join, liftM2, return, mapM, fail )
+import Control.Monad       ( liftM2, return, mapM, fail )
 import Data.Bool           ( Bool(False, True), otherwise, (&&), not )
 import Data.Either         ( Either(Left, Right) )
 import Data.Eq             ( (==) )
@@ -960,7 +960,7 @@ instance OVERLAPPABLE_ (FromJSON a) => LookupField a where
           Just v  -> parseJSON v
 
 instance (FromJSON a) => LookupField (Maybe a) where
-    lookupField _ _ obj key = join <$> obj .:? key
+    lookupField _ _ = (.:?)
 
 unknownFieldFail :: String -> String -> String -> Parser fail
 unknownFieldFail tName rec key =

--- a/Data/Aeson/Types.hs
+++ b/Data/Aeson/Types.hs
@@ -55,6 +55,7 @@ module Data.Aeson.Types
     , foldable
     , (.:)
     , (.:?)
+    , (.:!)
     , (.!=)
     , object
 

--- a/Data/Aeson/Types/Generic.hs
+++ b/Data/Aeson/Types/Generic.hs
@@ -22,7 +22,7 @@
 module Data.Aeson.Types.Generic ( ) where
 
 import Control.Applicative ((<|>))
-import Control.Monad ((<=<), join)
+import Control.Monad ((<=<))
 import Control.Monad.ST (ST)
 import Data.Aeson.Encode.Builder (emptyArray_)
 import Data.Aeson.Encode.Functions (builder)
@@ -665,8 +665,8 @@ instance (Selector s, GFromJSON a) => FromRecord (S1 s a) where
 
 instance OVERLAPPING_ (Selector s, FromJSON a) =>
   FromRecord (S1 s (K1 i (Maybe a))) where
-    parseRecord _ (Just lab) obj = (M1 . K1) . join <$> obj .:? lab
-    parseRecord opts Nothing obj = (M1 . K1) . join <$> obj .:? pack label
+    parseRecord _ (Just lab) obj = (M1 . K1) <$> obj .:? lab
+    parseRecord opts Nothing obj = (M1 . K1) <$> obj .:? pack label
         where
           label = fieldLabelModifier opts $
                     selName (undefined :: t s (K1 i (Maybe a)) p)

--- a/Data/Aeson/Types/Instances.hs
+++ b/Data/Aeson/Types/Instances.hs
@@ -52,6 +52,7 @@ module Data.Aeson.Types.Instances
     , ifromJSON
     , (.:)
     , (.:?)
+    , (.:!)
     , (.!=)
     , tuple
     , (>*<)
@@ -1533,7 +1534,7 @@ ifromJSON = iparse parseJSON
 --
 -- This accessor is appropriate if the key and value /must/ be present
 -- in an object for it to be valid.  If the key and value are
--- optional, use '(.:?)' instead.
+-- optional, use '.:?' instead.
 (.:) :: (FromJSON a) => Object -> Text -> Parser a
 obj .: key = case H.lookup key obj of
                Nothing -> fail $ "key " ++ show key ++ " not present"
@@ -1549,15 +1550,26 @@ obj .: key = case H.lookup key obj of
 --
 -- This accessor is most useful if the key and value can be absent
 -- from an object without affecting its validity.  If the key and
--- value are mandatory, use '(.:)' instead.
+-- value are mandatory, use '.:' instead.
 (.:?) :: (FromJSON a) => Object -> Text -> Parser (Maybe a)
 obj .:? key = case H.lookup key obj of
+               Nothing -> pure Nothing
+               Just v  -> modifyFailure addKeyName
+                        $ parseJSON v <?> Key key
+  where
+    addKeyName = (("failed to parse field " <> unpack key <> ": ") <>)
+{-# INLINE (.:?) #-}
+
+-- | Like '.:?', but the resulting parser will fail,
+-- if the key is present but is 'Null'.
+(.:!) :: (FromJSON a) => Object -> Text -> Parser (Maybe a)
+obj .:! key = case H.lookup key obj of
                Nothing -> pure Nothing
                Just v  -> modifyFailure addKeyName
                         $ Just <$> parseJSON v <?> Key key
   where
     addKeyName = (("failed to parse field " <> unpack key <> ": ") <>)
-{-# INLINE (.:?) #-}
+{-# INLINE (.:!) #-}
 
 -- | Helper for use in combination with '.:?' to provide default
 -- values for optional JSON object fields.
@@ -1565,7 +1577,7 @@ obj .:? key = case H.lookup key obj of
 -- This combinator is most useful if the key and value can be absent
 -- from an object without affecting its validity and we know a default
 -- value to assign in that case.  If the key and value are mandatory,
--- use '(.:)' instead.
+-- use '.:' instead.
 --
 -- Example usage:
 --

--- a/aeson.cabal
+++ b/aeson.cabal
@@ -46,6 +46,7 @@ extra-source-files:
     benchmarks/Makefile
     benchmarks/Typed/*.hs
     benchmarks/json-data/*.json
+    include/overlapping-compat.h
     changelog.md
     examples/*.cabal
     examples/*.hs


### PR DESCRIPTION
Handle #83 by introducing `.:!` as @gregwebs proposed (I bikeshedded `.:??` to `.:!`). Fixes undocumented breaking change in `0.10`

Related: https://github.com/bos/aeson/issues/287