### PR TITLE
Fix time encoding bugs

### DIFF
--- a/Data/Aeson/Encode/Builder.hs
+++ b/Data/Aeson/Encode/Builder.hs
@@ -23,6 +23,7 @@ module Data.Aeson.Encode.Builder
     , text
     , string
     , unquoted
+    , quote
     , number
     , day
     , localTime
@@ -98,6 +99,10 @@ text t = B.char8 '"' <> unquoted t <> B.char8 '"'
 -- | Encode a JSON string, without enclosing quotes.
 unquoted :: T.Text -> Builder
 unquoted t = TE.encodeUtf8BuilderEscaped escapeAscii t
+
+-- | Add quotes surrounding a builder
+quote :: Builder -> Builder
+quote b = B.char8 '"' <> b <> B.char8 '"'
 
 -- | Encode a JSON string.
 string :: String -> Builder

--- a/Data/Aeson/Types/Instances.hs
+++ b/Data/Aeson/Types/Instances.hs
@@ -713,14 +713,14 @@ instance FromJSON DotNetTime where
 
 instance ToJSON Day where
     toJSON       = stringEncoding
-    toEncoding z = Encoding (E.day z)
+    toEncoding z = Encoding (E.quote $ E.day z)
 
 instance FromJSON Day where
     parseJSON = withText "Day" (Time.run Time.day)
 
 instance ToJSON LocalTime where
     toJSON       = stringEncoding
-    toEncoding z = Encoding (E.localTime z)
+    toEncoding z = Encoding (E.quote $ E.localTime z)
 
 instance FromJSON LocalTime where
     parseJSON = withText "LocalTime" (Time.run Time.localTime)
@@ -728,7 +728,7 @@ instance FromJSON LocalTime where
 instance ToJSON ZonedTime where
     toJSON = stringEncoding
 
-    toEncoding z = Encoding (E.zonedTime z)
+    toEncoding z = Encoding (E.quote $ E.zonedTime z)
 
 formatMillis :: (FormatTime t) => t -> String
 formatMillis = take 3 . formatTime defaultTimeLocale "%q"
@@ -739,11 +739,11 @@ instance FromJSON ZonedTime where
 instance ToJSON UTCTime where
     toJSON = stringEncoding
 
-    toEncoding t = Encoding (E.utcTime t)
+    toEncoding t = Encoding (E.quote $ E.utcTime t)
 
 -- | Encode something to a JSON string.
 stringEncoding :: (ToJSON a) => a -> Value
-stringEncoding = String . T.decodeLatin1 . L.toStrict . encode
+stringEncoding = String . T.dropAround (== '"') . T.decodeLatin1 . L.toStrict . encode
 {-# INLINE stringEncoding #-}
 
 instance FromJSON UTCTime where


### PR DESCRIPTION
Time datatype were being encoded without surround quotation marks, which did not yield valid JSON. This fixes the bug, and also fixes the tests, which were not catching this bug.

This fixes #298