### PR TITLE
Parse HH:MM time in zonedTime and utcTime

### DIFF
--- a/Data/Aeson/Parser/Time.hs
+++ b/Data/Aeson/Parser/Time.hs
@@ -62,12 +62,12 @@ twoDigits = do
   let c2d c = ord c .&. 15
   return $! c2d a * 10 + c2d b
 
--- | Parse a time of the form @HH:MM:SS[.SSS]@.
+-- | Parse a time of the form @HH:MM[:SS[.SSS]]@.
 timeOfDay :: Parser Local.TimeOfDay
 timeOfDay = do
-  h <- twoDigits <* char ':'
-  m <- twoDigits <* char ':'
-  s <- seconds
+  h <- twoDigits
+  m <- char ':' *> twoDigits
+  s <- option 0 (char ':' *> seconds)
   if h < 24 && m < 60 && s < 61
     then return (Local.TimeOfDay h m s)
     else fail "invalid time"
@@ -120,9 +120,9 @@ timeZone = do
               let !tz = Local.minutesToTimeZone off
               in return (Just tz)
 
--- | Parse a date and time, of the form @YYYY-MM-DD HH:MM:SS@.
--- The space may be replaced with a @T@.  The number of seconds may be
--- followed by a fractional component.
+-- | Parse a date and time, of the form @YYYY-MM-DD HH:MM[:SS[.SSS]]@.
+-- The space may be replaced with a @T@.  The number of seconds is optional
+-- and may be followed by a fractional component.
 localTime :: Parser Local.LocalTime
 localTime = Local.LocalTime <$> day <* daySep <*> timeOfDay
   where daySep = satisfy (\c -> c == 'T' || c == ' ')
@@ -140,7 +140,9 @@ utcTime = do
 
 -- | Parse a date with time zone info. Acceptable formats:
 --
+-- @YYYY-MM-DD HH:MM Z@
 -- @YYYY-MM-DD HH:MM:SS Z@
+-- @YYYY-MM-DD HH:MM:SS.SSS Z@
 --
 -- The first space may instead be a @T@, and the second space is
 -- optional.  The @Z@ represents UTC.  The @Z@ may be replaced with a

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -123,6 +123,18 @@ utcTimeGood = do
   -- ts8 wraps around to the next day in UTC
   assertEqual "utctime" (parseWithRead "%FT%T%QZ" "2015-01-02T01:00:00Z") t8
   assertEqual "utctime" (parseWithRead "%FT%T%QZ" "2015-01-02T02:30:00Z") t9
+
+  -- Seconds in Time can be omitted
+  let ts10 = "2015-01-03T12:13Z" :: LT.Text
+  let ts11 = "2015-01-03 12:13Z" :: LT.Text
+  let ts12 = "2015-01-01T12:30-02" :: LT.Text
+  let (Just (t10 ::  UTCTime)) = parseWithAeson ts10
+  let (Just (t11 ::  UTCTime)) = parseWithAeson ts11
+  let (Just (t12 ::  UTCTime)) = parseWithAeson ts12
+  assertEqual "utctime" (parseWithRead "%FT%H:%MZ" ts10) t10
+  assertEqual "utctime" (parseWithRead "%F %H:%MZ" ts11) t11
+  assertEqual "utctime" (parseWithRead "%FT%T%QZ" "2015-01-01T14:30:00Z") t12
+
   where
     parseWithRead :: String -> LT.Text -> UTCTime
     parseWithRead f s =
@@ -143,6 +155,7 @@ utcTimeBad = do
   verifyFailParse "2015-01-01T12:30:00.00+00Z" -- no Zulu if offset given
   verifyFailParse "2015-01-01T12:30:00.00+00:00Z" -- no Zulu if offset given
   verifyFailParse "2015-01-03 12:13:00.Z" -- decimal at the end but no digits
+  verifyFailParse "2015-01-03 12:13.000Z" -- decimal at the end, but no seconds
   where
     verifyFailParse (s :: LT.Text) =
       let (dec :: Maybe UTCTime) = decode . LT.encodeUtf8 $ (LT.concat ["\"", s, "\""]) in


### PR DESCRIPTION
Some APIs around the Web give date information in `YYYY-MM-DDTHH:MM±hh:mm` format.  
Example: The [QPX Express API](https://developers.google.com/qpx-express/?hl=en) by Google.

As `HH:MM` is a valid time format in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601), I find this to be a valid format that should be accepted by aeson.

Changes:
- Make parsing the seconds optional in `timeOfDay`
- Adjust documentation indicating the allowed format
- Add corresponding tests