### PR TITLE
add instances/tests for TimeOfDay, make test for LocalTime actually arbitrary

### DIFF
--- a/Data/Aeson/Types/Instances.hs
+++ b/Data/Aeson/Types/Instances.hs
@@ -72,7 +72,7 @@ import Data.Monoid (Dual(..), First(..), Last(..))
 import Data.Ratio (Ratio, (%), numerator, denominator)
 import Data.Scientific (Scientific)
 import Data.Text (Text, pack, unpack)
-import Data.Time (Day, LocalTime, NominalDiffTime, UTCTime, ZonedTime)
+import Data.Time (Day, LocalTime, NominalDiffTime, UTCTime, ZonedTime, TimeOfDay)
 import Data.Time.Format (FormatTime, formatTime, parseTime)
 import Data.Traversable as Tr (sequence, traverse)
 import Data.Vector (Vector)
@@ -717,6 +717,13 @@ instance ToJSON Day where
 
 instance FromJSON Day where
     parseJSON = withText "Day" (Time.run Time.day)
+
+instance ToJSON TimeOfDay where
+    toJSON       = stringEncoding
+    toEncoding z = Encoding (E.quote $ E.timeOfDay z)
+
+instance FromJSON TimeOfDay where
+    parseJSON = withText "TimeOfDay" (Time.run Time.timeOfDay)
 
 instance ToJSON LocalTime where
     toJSON       = stringEncoding

--- a/tests/Instances.hs
+++ b/tests/Instances.hs
@@ -6,15 +6,16 @@ module Instances where
 import Types
 import Data.Function (on)
 import Control.Monad
-import Test.QuickCheck (Arbitrary(..), Gen, choose, oneof, elements)
+import Test.QuickCheck (Arbitrary(..), Gen, choose, oneof, elements, Positive(..))
 import Data.Time.Clock (DiffTime, UTCTime(..), picosecondsToDiffTime)
 import Data.Fixed (Pico)
 import Data.Time (ZonedTime(..), LocalTime(..), TimeZone(..),
                   hoursToTimeZone, Day(..), TimeOfDay(..),
-                  NominalDiffTime)
+                  NominalDiffTime, makeTimeOfDayValid)
 import qualified Data.Text as T
 import qualified Data.Map as Map
 import Data.Text (Text)
+import Data.Maybe
 import Data.Aeson.Types
 import Control.Applicative
 import Functions
@@ -27,8 +28,15 @@ instance Arbitrary Text where
 instance (Ord k, Arbitrary k, Arbitrary v) => Arbitrary (Map.Map k v) where
     arbitrary = Map.fromList <$> arbitrary
 
+instance Arbitrary TimeOfDay where
+    arbitrary = do
+      Positive h <- arbitrary
+      Positive m <- arbitrary
+      Positive s <- arbitrary
+      return $ fromMaybe (TimeOfDay 0 0 0 ) (makeTimeOfDayValid h m s)
+
 instance Arbitrary LocalTime where
-    arbitrary = return $ LocalTime (ModifiedJulianDay 1) (TimeOfDay 1 2 3)
+    arbitrary = LocalTime <$> arbitrary <*> arbitrary
 
 instance Arbitrary TimeZone where
     arbitrary = do

--- a/tests/Instances.hs
+++ b/tests/Instances.hs
@@ -30,10 +30,10 @@ instance (Ord k, Arbitrary k, Arbitrary v) => Arbitrary (Map.Map k v) where
 
 instance Arbitrary TimeOfDay where
     arbitrary = do
-      Positive h <- arbitrary
-      Positive m <- arbitrary
-      Positive s <- arbitrary
-      return $ fromMaybe (TimeOfDay 0 0 0 ) (makeTimeOfDayValid h m s)
+      h <- choose (0, 23)
+      m <- choose (0, 59)
+      s <- fromRational . toRational <$> choose (0, 59 :: Double)
+      return $ TimeOfDay h m s
 
 instance Arbitrary LocalTime where
     arbitrary = LocalTime <$> arbitrary <*> arbitrary

--- a/tests/Instances.hs
+++ b/tests/Instances.hs
@@ -11,7 +11,7 @@ import Data.Time.Clock (DiffTime, UTCTime(..), picosecondsToDiffTime)
 import Data.Fixed (Pico)
 import Data.Time (ZonedTime(..), LocalTime(..), TimeZone(..),
                   hoursToTimeZone, Day(..), TimeOfDay(..),
-                  NominalDiffTime, makeTimeOfDayValid)
+                  NominalDiffTime)
 import qualified Data.Text as T
 import qualified Data.Map as Map
 import Data.Text (Text)

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -9,7 +9,7 @@ import Data.Aeson.Parser (value)
 import Data.Aeson.Types
 import Data.ByteString.Builder (toLazyByteString)
 import Data.Int (Int8)
-import Data.Time (Day, LocalTime, NominalDiffTime, UTCTime, ZonedTime)
+import Data.Time (Day, LocalTime, NominalDiffTime, UTCTime, ZonedTime, TimeOfDay)
 import Encoders
 import Instances ()
 import Test.Framework (Test, testGroup)
@@ -129,6 +129,7 @@ tests = testGroup "properties" [
     , testProperty "Day" $ roundTripEq (undefined :: Day)
     , testProperty "DotNetTime" $ roundTripEq (undefined :: DotNetTime)
     , testProperty "LocalTime" $ roundTripEq (undefined :: LocalTime)
+    , testProperty "TimeOfDay" $ roundTripEq (undefined :: TimeOfDay)
     , testProperty "UTCTime" $ roundTripEq (undefined :: UTCTime)
     , testProperty "ZonedTime" $ roundTripEq (undefined :: ZonedTime)
     , testProperty "NominalDiffTime" $ roundTripEq (undefined :: NominalDiffTime)


### PR DESCRIPTION
This changes adds FromJSON/ToJSON instances for TimeOfDay (the parser/builder is already present since TimeOfDay appears as components of other time datatypes with instances).

Also, the arbitrary instance for local time was not arbitrary at all, this fixes that. 