### PR TITLE
Sample implementation for #323

### DIFF
--- a/Data/Aeson.hs
+++ b/Data/Aeson.hs
@@ -79,6 +79,7 @@ module Data.Aeson
     , foldable
     , (.:)
     , (.:?)
+    , (.:??)
     , (.:!)
     , (.!=)
     , object

--- a/Data/Aeson/Encode.hs
+++ b/Data/Aeson/Encode.hs
@@ -49,6 +49,7 @@ encodeToTextBuilder :: Value -> Builder
 encodeToTextBuilder =
     go
   where
+    go Omitted    = {-# SCC "go/Omitted" #-} ""
     go Null       = {-# SCC "go/Null" #-} "null"
     go (Bool b)   = {-# SCC "go/Bool" #-} if b then "true" else "false"
     go (Number s) = {-# SCC "go/Number" #-} fromScientific s
@@ -61,7 +62,7 @@ encodeToTextBuilder =
                       V.foldr f (singleton ']') (V.unsafeTail v)
       where f a z = singleton ',' <> go a <> z
     go (Object m) = {-# SCC "go/Object" #-}
-        case H.toList m of
+        case (filter ((/=) Omitted . snd) ) (H.toList m) of
           (x:xs) -> singleton '{' <> one x <> foldr f (singleton '}') xs
           _      -> "{}"
       where f a z     = singleton ',' <> one a <> z

--- a/Data/Aeson/Encode/Builder.hs
+++ b/Data/Aeson/Encode/Builder.hs
@@ -57,6 +57,7 @@ import qualified Data.Vector as V
 -- Use this function if you are encoding over the wire, or need to
 -- prepend or append further bytes to the encoded JSON value.
 encodeToBuilder :: Value -> Builder
+encodeToBuilder Omitted    = mempty
 encodeToBuilder Null       = null_
 encodeToBuilder (Bool b)   = bool b
 encodeToBuilder (Number n) = number n
@@ -85,7 +86,7 @@ array v
 
 -- Encode a JSON object.
 object :: HMS.HashMap T.Text Value -> Builder
-object m = case HMS.toList m of
+object m = case (filter ((/=) Omitted . snd) ) (HMS.toList m) of
     (x:xs) -> B.char8 '{' <> one x <> foldr withComma (B.char8 '}') xs
     _      -> emptyObject__
   where

--- a/Data/Aeson/Types.hs
+++ b/Data/Aeson/Types.hs
@@ -56,6 +56,7 @@ module Data.Aeson.Types
     , foldable
     , (.:)
     , (.:?)
+    , (.:??)
     , (.:!)
     , (.!=)
     , object

--- a/Data/Aeson/Types/Instances.hs
+++ b/Data/Aeson/Types/Instances.hs
@@ -53,6 +53,7 @@ module Data.Aeson.Types.Instances
     , ifromJSON
     , (.:)
     , (.:?)
+    , (.:??)
     , (.:!)
     , (.!=)
     , tuple
@@ -73,6 +74,7 @@ import Data.Int (Int8, Int16, Int32, Int64)
 import Data.Maybe (fromMaybe)
 import Data.Monoid ((<>))
 import Data.Monoid (Dual(..), First(..), Last(..))
+import Data.Possible
 import Data.Ratio (Ratio, (%), numerator, denominator)
 import Data.Scientific (Scientific)
 import Data.Text (Text, pack, unpack)
@@ -151,6 +153,23 @@ instance (ToJSON a) => ToJSON (Maybe a) where
 instance (FromJSON a) => FromJSON (Maybe a) where
     parseJSON Null   = pure Nothing
     parseJSON a      = Just <$> parseJSON a
+    {-# INLINE parseJSON #-}
+
+instance (ToJSON a) => ToJSON (Possible a) where
+    toJSON (HaveData a) = toJSON a
+    toJSON MissingData  = Omitted
+    toJSON HaveNull     = Null
+    {-# INLINE toJSON #-}
+
+    toEncoding (HaveData a) = toEncoding a
+    toEncoding MissingData  = mempty
+    toEncoding HaveNull     = Encoding E.null_
+    {-# INLINE toEncoding #-}
+
+instance (FromJSON a) => FromJSON (Possible a) where
+    parseJSON Null    = pure HaveNull
+    parseJSON Omitted = pure MissingData
+    parseJSON a       = HaveData <$> parseJSON a
     {-# INLINE parseJSON #-}
 
 instance (ToJSON a, ToJSON b) => ToJSON (Either a b) where
@@ -1598,7 +1617,8 @@ ifromJSON = iparse parseJSON
 -- optional, use '.:?' instead.
 (.:) :: (FromJSON a) => Object -> Text -> Parser a
 obj .: key = case H.lookup key obj of
-               Nothing -> fail $ "key " ++ show key ++ " not present"
+               Nothing      -> fail $ "key " ++ show key ++ " not present"
+               Just Omitted -> fail $ "key " ++ show key ++ " not present"
                Just v  -> modifyFailure addKeyName
                         $ parseJSON v <?> Key key
   where
@@ -1614,9 +1634,11 @@ obj .: key = case H.lookup key obj of
 -- value are mandatory, use '.:' instead.
 (.:?) :: (FromJSON a) => Object -> Text -> Parser (Maybe a)
 obj .:? key = case H.lookup key obj of
-               Nothing -> pure Nothing
-               Just v  -> modifyFailure addKeyName
-                        $ parseJSON v <?> Key key
+               Nothing      -> pure Nothing
+               Just Null    -> pure Nothing
+               Just Omitted -> pure Nothing
+               Just v       -> modifyFailure addKeyName
+                         $ Just <$> parseJSON v <?> Key key
   where
     addKeyName = (("failed to parse field " <> unpack key <> ": ") <>)
 {-# INLINE (.:?) #-}
@@ -1631,6 +1653,20 @@ obj .:! key = case H.lookup key obj of
   where
     addKeyName = (("failed to parse field " <> unpack key <> ": ") <>)
 {-# INLINE (.:!) #-}
+
+-- | Retrieve the value associated with the given key of an 'Object'.
+-- This is a bit more sensitive version than '(.:?)' as will tell exactly
+-- if the key was not present or it had a 'null' value.
+(.:??) :: (FromJSON a) => Object -> Text -> Parser (Possible a)
+obj .:?? key = case H.lookup key obj of
+               Nothing      -> pure MissingData
+               Just Omitted -> pure MissingData
+               Just Null    -> pure HaveNull
+               Just v       -> modifyFailure addKeyName
+                        $ HaveData <$> parseJSON v <?> Key key
+  where
+    addKeyName = (("failed to parse field " <> unpack key <> ": ") <>)
+{-# INLINE (.:??) #-}
 
 -- | Helper for use in combination with '.:?' to provide default
 -- values for optional JSON object fields.

--- a/Data/Aeson/Types/Internal.hs
+++ b/Data/Aeson/Types/Internal.hs
@@ -330,6 +330,7 @@ data Value = Object !Object
            | Number !Scientific
            | Bool !Bool
            | Null
+           | Omitted
              deriving (Eq, Read, Show, Typeable, Data)
 
 -- | An encoding of a JSON value.
@@ -385,6 +386,7 @@ instance NFData Value where
     rnf (Number n) = rnf n
     rnf (Bool b)   = rnf b
     rnf Null       = ()
+    rnf Omitted    = ()
 
 instance IsString Value where
     fromString = String . pack
@@ -399,6 +401,7 @@ hashValue s (String str) = s `hashWithSalt` (2::Int) `hashWithSalt` str
 hashValue s (Number n)   = s `hashWithSalt` (3::Int) `hashWithSalt` n
 hashValue s (Bool b)     = s `hashWithSalt` (4::Int) `hashWithSalt` b
 hashValue s Null         = s `hashWithSalt` (5::Int)
+hashValue s Omitted      = s `hashWithSalt` (6::Int)
 
 instance Hashable Value where
     hashWithSalt = hashValue

--- a/aeson.cabal
+++ b/aeson.cabal
@@ -104,7 +104,8 @@ library
     text >= 1.1.1.0,
     transformers,
     unordered-containers >= 0.2.5.0,
-    vector >= 0.7.1
+    vector >= 0.7.1,
+    possible
 
   if !impl(ghc >= 8.0)
     -- `Data.Semigroup` is available in base only since GHC 8.0

--- a/examples/PossibleGen.hs
+++ b/examples/PossibleGen.hs
@@ -1,0 +1,64 @@
+
+-- module Possible where
+-- This example is basically the same as in Simplest.hs, only it uses
+-- GHC's builtin generics instead of explicit instances of ToJSON and
+-- FromJSON.
+
+-- This example only works with GHC 7.2 or newer, as it uses the
+-- datatype-generic programming machinery introduced in 7.2.
+
+-- We enable the DeriveGeneric language extension so that GHC can
+-- automatically derive the Generic class for us.
+
+{-# LANGUAGE DeriveGeneric #-}
+
+{-# LANGUAGE OverloadedStrings #-}
+
+
+import Data.Aeson
+import Data.Aeson.TH (deriveJSON, defaultOptions)
+import GHC.Generics (Generic)
+import Data.Possible
+--  (FromJSON, ToJSON, decode, encode)
+import qualified Data.ByteString.Lazy.Char8 as BL
+-- import Data.Map
+-- To decode or encode a value using the generic machinery, we must
+-- make the type an instance of the Generic class.
+
+data Coord = Coord { x :: Double, y :: Double
+                   , z :: Possible Double}
+             deriving (Show, Generic)
+
+-- While we still have to declare our type as instances of FromJSON
+-- and ToJSON, we do *not* need to provide bodies for the instances.
+-- Default versions will be supplied for us.
+
+-- $(deriveJSON defaultOptions ''Coord)
+
+instance FromJSON Coord
+instance ToJSON Coord
+
+blen :: ToJSON a => a -> IO ()
+blen a = do
+  BL.putStrLn . encode $ a
+  print $ toJSON a
+
+pde = print . (\a -> decode a :: Maybe Coord)
+main :: IO ()
+main = do
+  pde "{\"x\":3.0,\"y\":-1.0,\"z\":1}"
+  blen $ Coord 3 (-1) (HaveData 1)
+
+  pde "{\"x\":3.0,\"y\":-1.0,\"z\":null}"
+  blen $ Coord 3 (-2) HaveNull
+
+  pde "{\"x\":3.0,\"y\":-1.0}"
+  blen $ Coord 3 (-1) MissingData
+
+  blen $ object $  ["1" .= Omitted, "2" .= Null ]
+
+  blen $ object ["a" .= Null , "b" .= Omitted, "c" .= Number 1 ]
+
+
+
+

--- a/examples/PossibleTH.hs
+++ b/examples/PossibleTH.hs
@@ -1,0 +1,62 @@
+
+-- module Possible where
+-- This example is basically the same as in Simplest.hs, only it uses
+-- GHC's builtin generics instead of explicit instances of ToJSON and
+-- FromJSON.
+
+-- This example only works with GHC 7.2 or newer, as it uses the
+-- datatype-generic programming machinery introduced in 7.2.
+
+-- We enable the DeriveGeneric language extension so that GHC can
+-- automatically derive the Generic class for us.
+
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+
+import Data.Possible
+import Data.Aeson
+--  (FromJSON, ToJSON, decode, encode)
+import Data.Aeson.TH (deriveJSON, defaultOptions)
+import qualified Data.ByteString.Lazy.Char8 as BL
+-- import Data.Map
+-- To decode or encode a value using the generic machinery, we must
+-- make the type an instance of the Generic class.
+
+data Coord = Coord { x :: Double, y :: Double
+                   , z :: Possible Double}
+             deriving Show
+
+-- While we still have to declare our type as instances of FromJSON
+-- and ToJSON, we do *not* need to provide bodies for the instances.
+-- Default versions will be supplied for us.
+
+$(deriveJSON defaultOptions ''Coord)
+
+-- instance FromJSON Coord
+-- instance ToJSON Coord
+
+blen :: ToJSON a => a -> IO ()
+blen a = do
+  BL.putStrLn . encode $ a
+  print $ toJSON a
+
+pde = print . (\a -> decode a :: Maybe Coord)
+main :: IO ()
+main = do
+  pde "{\"x\":3.0,\"y\":-1.0,\"z\":1}"
+  blen $ Coord 3 (-1) (HaveData 1)
+
+  pde "{\"x\":3.0,\"y\":-1.0,\"z\":null}"
+  blen $ Coord 3 (-2) HaveNull
+
+  pde "{\"x\":3.0,\"y\":-1.0}"
+  blen $ Coord 3 (-1) MissingData
+
+  blen $ object $  ["1" .= Omitted, "2" .= Null ]
+
+  blen $ object ["a" .= Null , "b" .= Omitted, "c" .= Number 1 ]
+
+
+
+

--- a/examples/aeson-examples.cabal
+++ b/examples/aeson-examples.cabal
@@ -12,6 +12,28 @@ executable aeson-example-generic
     bytestring,
     ghc-prim
 
+executable aeson-example-possible-th
+  main-is: PossibleTH.hs
+  ghc-options: -Wall
+  build-depends:
+    aeson >= 0.10,
+    base,
+    bytestring,
+    possible,
+    ghc-prim,
+    unordered-containers
+
+executable aeson-example-possible-generic
+  main-is: PossibleGen.hs
+  ghc-options: -Wall
+  build-depends:
+    aeson >= 0.10,
+    base,
+    bytestring,
+    possible,
+    ghc-prim,
+    unordered-containers
+
 executable aeson-example-simplest
   main-is: Simplest.hs
   ghc-options: -Wall


### PR DESCRIPTION
Hi,

I am not sure if there is a shorter way to address this extension; I had to add an extra `basic` type next to `Maybe` so I can capture the `Omitted` bits.

I tried to keep the new `Omitted` values as much internally as possible; so it should not even show in generated  `toJSON`.

The library should be functionally exactly the same modulo when using `Possible` rather then `Maybe` in constructors. List of `[Possible]` will serialize in a funny way but someone might actually want it this way (One can always use lists of `[Maybe]` there...