### PR TITLE
Add missing null handling:

### DIFF
--- a/Data/Aeson/Types/Instances.hs
+++ b/Data/Aeson/Types/Instances.hs
@@ -1613,9 +1613,10 @@ obj .: key = case H.lookup key obj of
 -- value are mandatory, use '.:' instead.
 (.:?) :: (FromJSON a) => Object -> Text -> Parser (Maybe a)
 obj .:? key = case H.lookup key obj of
-               Nothing -> pure Nothing
-               Just v  -> modifyFailure addKeyName
-                        $ parseJSON v <?> Key key
+               Nothing   -> pure Nothing
+               Just Null -> pure Nothing
+               Just v    -> modifyFailure addKeyName
+                         $ Just <$> parseJSON v <?> Key key
   where
     addKeyName = (("failed to parse field " <> unpack key <> ": ") <>)
 {-# INLINE (.:?) #-}


### PR DESCRIPTION
Simple solution; adding just one extra pattern match; almost by definition `Null` maps to Nothing in `Maybe a` situation and only the rest is exposed for further parsing.
resolves: https://github.com/bos/aeson/issues/325