### PR TITLE
Speed up default FromJSON/ToJSON instances

### DIFF
--- a/Data/Aeson.hs
+++ b/Data/Aeson.hs
@@ -60,6 +60,7 @@ module Data.Aeson
     -- ** Generic JSON classes and options
     , GFromJSON(..)
     , GToJSON(..)
+    , GToEncoding(..)
     , genericToJSON
     , genericToEncoding
     , genericParseJSON

--- a/Data/Aeson/Types.hs
+++ b/Data/Aeson/Types.hs
@@ -39,6 +39,7 @@ module Data.Aeson.Types
     -- ** Generic JSON classes
     , GFromJSON(..)
     , GToJSON(..)
+    , GToEncoding(..)
     , genericToJSON
     , genericToEncoding
     , genericParseJSON

--- a/Data/Aeson/Types/Class.hs
+++ b/Data/Aeson/Types/Class.hs
@@ -19,6 +19,7 @@ module Data.Aeson.Types.Class
     -- * Generic JSON classes
     , GFromJSON(..)
     , GToJSON(..)
+    , GToEncoding(..)
     , genericToJSON
     , genericToEncoding
     , genericParseJSON
@@ -40,6 +41,9 @@ class GToJSON f where
     -- default generic implementation of 'toJSON'.
     gToJSON :: Options -> f a -> Value
 
+-- | Class of generic representation types ('Rep') that can be converted to
+-- a JSON 'Encoding'.
+class GToEncoding f where
     -- | This method (applied to 'defaultOptions') can be used as the
     -- default generic implementation of 'toEncoding'.
     gToEncoding :: Options -> f a -> Encoding
@@ -59,7 +63,7 @@ genericToJSON opts = gToJSON opts . from
 -- | A configurable generic JSON encoder. This function applied to
 -- 'defaultOptions' is used as the default for 'toEncoding' when the type
 -- is an instance of 'Generic'.
-genericToEncoding :: (Generic a, GToJSON (Rep a)) => Options -> a -> Encoding
+genericToEncoding :: (Generic a, GToEncoding (Rep a)) => Options -> a -> Encoding
 genericToEncoding opts = gToEncoding opts . from
 
 -- | A configurable generic JSON decoder. This function applied to

--- a/Data/Aeson/Types/Instances.hs
+++ b/Data/Aeson/Types/Instances.hs
@@ -32,6 +32,7 @@ module Data.Aeson.Types.Instances
     -- ** Generic JSON classes
     , GFromJSON(..)
     , GToJSON(..)
+    , GToEncoding(..)
     , genericToJSON
     , genericToEncoding
     , genericParseJSON


### PR DESCRIPTION
Fixes #296 and #309 (I believe).

The `DefaultInstances`-based mechanism for deriving `FromJSON` and `ToJSON` instances via GHC generics currently consumes way more memory than it should. I believe this is the result of two things:

1. [GHC Trac #9630](https://ghc.haskell.org/trac/ghc/ticket/9630). It was discovered that having generic classes that have more than one method [such as](https://github.com/bos/aeson/blob/4667ef1029a373cf4510f7deca147c357c6d8947/Data/Aeson/Types/Class.hs#L38):

   ```haskell
   class GToJSON f where
     gToJSON :: Options -> f a -> Value
     gToEncoding :: Options -> f a -> Encoding
   ```

   hurt the optimizer badly. To compensate for this bug, I split `GToEncoding` off from `GToJSON` (as well as the many internal typeclasses that `GToJSON` uses).
2. `Data.Aeson.Types.Generic` puts `INLINE` pragmas on all generic class instance methods. This results in an explosion of inlined code, to the point that [`pandoc-types` takes ~7 GB of memory](https://github.com/fpco/stackage/issues/845#issuecomment-171342178) to compile. In my experience, inlining generic methods has turned out to be a bad idea, so I've removed the `INLINE` pragmas.

To test out the improvments, I did a very fast-and-loose profiling of the time and memory it takes to compile `pandoc-types` (a package known to be [affected badly](https://github.com/bos/aeson/issues/296#issuecomment-169826563) by the `aeson-0.10` compilation regressions). I did these tests on a 64-bit Linux laptop with 4 GB of RAM. Here are the results:

* `pandoc-types` (vanilla `aeson-0.10`):

```
$ /usr/bin/time -v cabal install pandoc-types
Resolving dependencies...
Downloading pandoc-types-1.16.0.1...
Configuring pandoc-types-1.16.0.1...
Building pandoc-types-1.16.0.1...
Installed pandoc-types-1.16.0.1
        Command being timed: "cabal install pandoc-types"
        User time (seconds): 251.96
        System time (seconds): 5.90
        Percent of CPU this job got: 41%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 10:20.85
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 3048536
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 54055
        Minor (reclaiming a frame) page faults: 1332223
        Voluntary context switches: 61491
        Involuntary context switches: 15193
        Swaps: 0
        File system inputs: 3456696
        File system outputs: 123552
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

* `pandoc-types` (`aeson-0.10` with the changes in this pull request):

```
$ /usr/bin/time -v cabal install pandoc-types
Resolving dependencies...
Configuring pandoc-types-1.16.0.1...
Building pandoc-types-1.16.0.1...
Installed pandoc-types-1.16.0.1
        Command being timed: "cabal install pandoc-types"
        User time (seconds): 39.66
        System time (seconds): 0.89
        Percent of CPU this job got: 98%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:41.25
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 501804
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 55
        Minor (reclaiming a frame) page faults: 324617
        Voluntary context switches: 2115
        Involuntary context switches: 1401
        Swaps: 0
        File system inputs: 14520
        File system outputs: 87472
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

The total wall time went from 10 minutes to under a minute, and it went from using 3 GB of RAM (and thrashing my laptop mercilessly) to about 500 MB of RAM.