### PR TITLE
Define Semigroup instances to silence -Wcompat

### DIFF
--- a/aeson.cabal
+++ b/aeson.cabal
@@ -104,6 +104,10 @@ library
     unordered-containers >= 0.2.5.0,
     vector >= 0.7.1
 
+  if !impl(ghc >= 8.0)
+    -- `Data.Semigroup` is available in base only since GHC 8.0
+    build-depends: semigroups >= 0.16.1
+
   if flag(old-locale)
     build-depends: time < 1.5, old-locale
   else


### PR DESCRIPTION
Since GHC 8.0/base-4.9, Data.Semigroup is available in `base-4.9`, so we
can now finally express that something is (also) a Semigroup.

In order to avoid CPP, this PR adds a conditional dependency on the
`semigroups` package for GHCs prior to 8.0