### PR TITLE
Canonicalise Monad instances and define MonadFail instances

### DIFF
--- a/aeson.cabal
+++ b/aeson.cabal
@@ -92,6 +92,7 @@ library
     containers,
     deepseq,
     dlist >= 0.2,
+    fail == 4.9.*,
     ghc-prim >= 0.2,
     hashable >= 1.1.2.0,
     mtl,


### PR DESCRIPTION
This makes the code a bit more forward-compatible

The dependency on the `fail` compat-package is unconditional because
it's a minimal package that has at most a dependency on `base`.