### PR TITLE
More general map encoding/decoding

### DIFF
--- a/Data/Aeson.hs
+++ b/Data/Aeson.hs
@@ -55,8 +55,10 @@ module Data.Aeson
     , FromJSON(..)
     , Result(..)
     , fromJSON
+    , FromJSONKey(..)
     , ToJSON(..)
     , KeyValue(..)
+    , ToJSONKey(..)
     -- ** Generic JSON classes and options
     , GFromJSON(..)
     , GToJSON(..)

--- a/Data/Aeson/Encode/Functions.hs
+++ b/Data/Aeson/Encode/Functions.hs
@@ -4,6 +4,7 @@ module Data.Aeson.Encode.Functions
     (
       brackets
     , builder
+    , keyBuilder
     , char7
     , encode
     , foldable
@@ -28,6 +29,9 @@ import Data.Monoid (mempty)
 builder :: ToJSON a => a -> Builder
 builder = fromEncoding . toEncoding
 {-# INLINE builder #-}
+
+keyBuilder :: ToJSONKey a => a -> Builder
+keyBuilder = fromEncoding . toKeyEncoding
 
 -- | Efficiently serialize a JSON value as a lazy 'L.ByteString'.
 --

--- a/Data/Aeson/Types.hs
+++ b/Data/Aeson/Types.hs
@@ -29,11 +29,13 @@ module Data.Aeson.Types
     , Result(..)
     , FromJSON(..)
     , fromJSON
+    , FromJSONKey(..)
     , parse
     , parseEither
     , parseMaybe
     , ToJSON(..)
     , KeyValue(..)
+    , ToJSONKey(..)
     , modifyFailure
 
     -- ** Generic JSON classes

--- a/Data/Aeson/Types/Class.hs
+++ b/Data/Aeson/Types/Class.hs
@@ -16,6 +16,9 @@ module Data.Aeson.Types.Class
     -- * Core JSON classes
       FromJSON(..)
     , ToJSON(..)
+    -- * Map classes
+    , FromJSONKey(..)
+    , ToJSONKey(..)
     -- * Generic JSON classes
     , GFromJSON(..)
     , GToJSON(..)
@@ -244,6 +247,18 @@ class FromJSON a where
 
     default parseJSON :: (Generic a, GFromJSON (Rep a)) => Value -> Parser a
     parseJSON = genericParseJSON defaultOptions
+
+-- | Helper typeclass to implement 'FromJSON' for map-like structures.
+class FromJSONKey a where
+    fromJSONKey :: Text -> a
+
+-- | Helper typeclass to implement 'ToJSON' for map-like structures.
+class ToJSONKey a where
+    toJSONKey :: a -> Text
+
+    toKeyEncoding :: a -> Encoding
+    toKeyEncoding = Encoding . E.text . toJSONKey
+    {-# INLINE toKeyEncoding #-}
 
 -- | A key-value pair for encoding a JSON object.
 class KeyValue kv where


### PR DESCRIPTION
Implementation of https://github.com/bos/aeson/issues/289

It would make some sense to have:

```hs
class FromJSONKey a where
  parseJSONKey :: Text -> Parser a
```

but there will be performance hit for straight forward cases.

By throwing in GADTs, TypeFamilies, and FunctionalDependencies one can make implementors 
to choose between `Identity` and `Parser` though.

```hs
class FromJSONKey a m | a -> m where
  parseJSONKey :: Text -> m a

instance FromJSONKey Text Identity where
  parseJSONKey = Identity

instance FromJSONKey Int Parser where
  parseJSONKey = ...

data SJSONKeyMonad a where
  SJSONKeyMonadIdentity :: SJSONKeyMonad Identity
  SJSONKeyMonadParser   :: SJSONKeyMonad Parser

class IJSONKeyMonad m where
  jsonKeyMonadSing :: proxy m -> SJSONKeyMonad m

instance (FromJSON v, FromJSONKey k m, IJSONKeyMonad m, Ord k) => FromJSON (M.Map k v) where
    parseJSON = case jsonKeyMonadSing (Proxy :: Proxy m) of
        SJSONKeyMonadIdentity -> withObject "Map k v" $
            fmap (H.foldrWithKey (M.insert . runIdentity . fromJSONKey) M.empty) . H.traverseWithKey (\k v -> parseJSON v <?> Key k)
        SJSONKeyMonadParser -> withObject "Map k v" $
            H.foldrWithKey (\k v m -> M.insert <$> fromJSONKey k <*> (parseJSON v <?> Key k) <*> m) (pure M.empty)
```

