### PR TITLE
Fix a bug with generics and single-field records

### DIFF
--- a/Data/Aeson/Types/Generic.hs
+++ b/Data/Aeson/Types/Generic.hs
@@ -247,7 +247,7 @@ instance OVERLAPPING_ TaggedObjectEnc' U1 False where
     taggedObjectEnc' _ _ _ = Tagged mempty
 
 instance (RecordToEncoding f) => TaggedObjectEnc' f True where
-    taggedObjectEnc' opts _ = Tagged . (\z -> B.char7 ',' <> recordToEncoding opts z)
+    taggedObjectEnc' opts _ = Tagged . (B.char7 ',' <>) . fst . recordToEncoding opts
 
 instance (GToEncoding f) => TaggedObjectEnc' f False where
     taggedObjectEnc' opts contentsFieldName =
@@ -339,12 +339,11 @@ instance ( IsRecord        f isRecord
                           . consToEncoding' opts (isUnary (undefined :: f a))
 
 instance (RecordToEncoding f) => ConsToEncoding' f True where
-    consToEncoding' opts isUn x
-      | (True,True) <- (unwrapUnaryRecords opts,isUn) = Tagged $   recordToEncoding opts x
-      | otherwise = Tagged $
-          B.char7 '{' <>
-          recordToEncoding opts x <>
-          B.char7 '}'
+    consToEncoding' opts isUn x =
+      let (enc, mbVal) = recordToEncoding opts x
+      in case (unwrapUnaryRecords opts, isUn, mbVal) of
+           (True, True, Just val) -> Tagged val
+           _ -> Tagged $ B.char7 '{' <> enc <> B.char7 '}'
 
 instance GToEncoding f => ConsToEncoding' f False where
     consToEncoding' opts _ = Tagged . gbuilder opts
@@ -375,12 +374,16 @@ fieldToPair opts m1 = pure ( pack $ fieldLabelModifier opts $ selName m1
 --------------------------------------------------------------------------------
 
 class RecordToEncoding f where
-    recordToEncoding :: Options -> f a -> B.Builder
+    -- 1st element: whole thing
+    -- 2nd element: in case the record has only 1 field, just the value
+    --              of the field (without the key); 'Nothing' otherwise
+    recordToEncoding :: Options -> f a -> (B.Builder, Maybe B.Builder)
 
 instance (RecordToEncoding a, RecordToEncoding b) => RecordToEncoding (a :*: b) where
-    recordToEncoding opts (a :*: b) = recordToEncoding opts a <>
-                                      B.char7 ',' <>
-                                      recordToEncoding opts b
+    recordToEncoding opts (a :*: b) =
+      (fst (recordToEncoding opts a) <> B.char7 ',' <>
+       fst (recordToEncoding opts b),
+       Nothing)
 
 instance (Selector s, GToEncoding a) => RecordToEncoding (S1 s a) where
     recordToEncoding = fieldToEncoding
@@ -388,14 +391,14 @@ instance (Selector s, GToEncoding a) => RecordToEncoding (S1 s a) where
 instance OVERLAPPING_ (Selector s, ToJSON a) =>
   RecordToEncoding (S1 s (K1 i (Maybe a))) where
     recordToEncoding opts (M1 k1) | omitNothingFields opts
-                                  , K1 Nothing <- k1 = mempty
+                                  , K1 Nothing <- k1 = (mempty, Nothing)
     recordToEncoding opts m1 = fieldToEncoding opts m1
 
-fieldToEncoding :: (Selector s, GToEncoding a) => Options -> S1 s a p -> B.Builder
+fieldToEncoding :: (Selector s, GToEncoding a) => Options -> S1 s a p -> (B.Builder, Maybe B.Builder)
 fieldToEncoding opts m1 =
-    builder (fieldLabelModifier opts $ selName m1) <>
-    B.char7 ':' <>
-    gbuilder opts (unM1 m1)
+  let keyBuilder = builder (fieldLabelModifier opts $ selName m1)
+      valueBuilder = gbuilder opts (unM1 m1)
+  in  (keyBuilder <> B.char7 ':' <> valueBuilder, Just valueBuilder)
 
 --------------------------------------------------------------------------------
 

--- a/tests/DataFamilies/Encoders.hs
+++ b/tests/DataFamilies/Encoders.hs
@@ -136,3 +136,100 @@ thGADTToEncodingDefault = $(mkToEncoding defaultOptions 'GADT)
 
 thGADTParseJSONDefault :: Value -> Parser (GADT String)
 thGADTParseJSONDefault = $(mkParseJSON defaultOptions 'GADT)
+
+--------------------------------------------------------------------------------
+-- Generic encoders/decoders
+--------------------------------------------------------------------------------
+
+-- Nullary
+
+gNullaryToJSONString :: Nullary Int -> Value
+gNullaryToJSONString = genericToJSON defaultOptions
+
+gNullaryToEncodingString :: Nullary Int -> Encoding
+gNullaryToEncodingString = genericToEncoding defaultOptions
+
+gNullaryParseJSONString :: Value -> Parser (Nullary Int)
+gNullaryParseJSONString = genericParseJSON defaultOptions
+
+
+gNullaryToJSON2ElemArray :: Nullary Int -> Value
+gNullaryToJSON2ElemArray = genericToJSON opts2ElemArray
+
+gNullaryToEncoding2ElemArray :: Nullary Int -> Encoding
+gNullaryToEncoding2ElemArray = genericToEncoding opts2ElemArray
+
+gNullaryParseJSON2ElemArray :: Value -> Parser (Nullary Int)
+gNullaryParseJSON2ElemArray = genericParseJSON opts2ElemArray
+
+
+gNullaryToJSONTaggedObject :: Nullary Int -> Value
+gNullaryToJSONTaggedObject = genericToJSON optsTaggedObject
+
+gNullaryToEncodingTaggedObject :: Nullary Int -> Encoding
+gNullaryToEncodingTaggedObject = genericToEncoding optsTaggedObject
+
+gNullaryParseJSONTaggedObject :: Value -> Parser (Nullary Int)
+gNullaryParseJSONTaggedObject = genericParseJSON optsTaggedObject
+
+
+gNullaryToJSONObjectWithSingleField :: Nullary Int -> Value
+gNullaryToJSONObjectWithSingleField = genericToJSON optsObjectWithSingleField
+
+gNullaryToEncodingObjectWithSingleField :: Nullary Int -> Encoding
+gNullaryToEncodingObjectWithSingleField = genericToEncoding optsObjectWithSingleField
+
+gNullaryParseJSONObjectWithSingleField :: Value -> Parser (Nullary Int)
+gNullaryParseJSONObjectWithSingleField = genericParseJSON optsObjectWithSingleField
+
+-- SomeType
+
+gSomeTypeToJSON2ElemArray :: SomeType c () Int -> Value
+gSomeTypeToJSON2ElemArray = genericToJSON opts2ElemArray
+
+gSomeTypeToEncoding2ElemArray :: SomeType c () Int -> Encoding
+gSomeTypeToEncoding2ElemArray = genericToEncoding opts2ElemArray
+
+gSomeTypeParseJSON2ElemArray :: Value -> Parser (SomeType c () Int)
+gSomeTypeParseJSON2ElemArray = genericParseJSON opts2ElemArray
+
+
+gSomeTypeToJSONTaggedObject :: SomeType c () Int -> Value
+gSomeTypeToJSONTaggedObject = genericToJSON optsTaggedObject
+
+gSomeTypeToEncodingTaggedObject :: SomeType c () Int -> Encoding
+gSomeTypeToEncodingTaggedObject = genericToEncoding optsTaggedObject
+
+gSomeTypeParseJSONTaggedObject :: Value -> Parser (SomeType c () Int)
+gSomeTypeParseJSONTaggedObject = genericParseJSON optsTaggedObject
+
+
+gSomeTypeToJSONObjectWithSingleField :: SomeType c () Int -> Value
+gSomeTypeToJSONObjectWithSingleField = genericToJSON optsObjectWithSingleField
+
+gSomeTypeToEncodingObjectWithSingleField :: SomeType c () Int -> Encoding
+gSomeTypeToEncodingObjectWithSingleField = genericToEncoding optsObjectWithSingleField
+
+gSomeTypeParseJSONObjectWithSingleField :: Value -> Parser (SomeType c () Int)
+gSomeTypeParseJSONObjectWithSingleField = genericParseJSON optsObjectWithSingleField
+
+-- Approx
+
+gApproxToJSONUnwrap :: Approx String -> Value
+gApproxToJSONUnwrap = genericToJSON optsUnwrapUnaryRecords
+
+gApproxToEncodingUnwrap :: Approx String -> Encoding
+gApproxToEncodingUnwrap = genericToEncoding optsUnwrapUnaryRecords
+
+gApproxParseJSONUnwrap :: Value -> Parser (Approx String)
+gApproxParseJSONUnwrap = genericParseJSON optsUnwrapUnaryRecords
+
+
+gApproxToJSONDefault :: Approx String -> Value
+gApproxToJSONDefault = genericToJSON defaultOptions
+
+gApproxToEncodingDefault :: Approx String -> Encoding
+gApproxToEncodingDefault = genericToEncoding defaultOptions
+
+gApproxParseJSONDefault :: Value -> Parser (Approx String)
+gApproxParseJSONDefault = genericParseJSON defaultOptions

--- a/tests/DataFamilies/Encoders.hs
+++ b/tests/DataFamilies/Encoders.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE TemplateHaskell #-}
 
@@ -141,6 +142,8 @@ thGADTParseJSONDefault = $(mkParseJSON defaultOptions 'GADT)
 -- Generic encoders/decoders
 --------------------------------------------------------------------------------
 
+#if __GLASGOW_HASKELL__ >= 706
+
 -- Nullary
 
 gNullaryToJSONString :: Nullary Int -> Value
@@ -233,3 +236,5 @@ gApproxToEncodingDefault = genericToEncoding defaultOptions
 
 gApproxParseJSONDefault :: Value -> Parser (Approx String)
 gApproxParseJSONDefault = genericParseJSON defaultOptions
+
+#endif

--- a/tests/DataFamilies/Properties.hs
+++ b/tests/DataFamilies/Properties.hs
@@ -12,14 +12,13 @@ import Test.Framework.Providers.QuickCheck2 (testProperty)
 
 tests :: Test
 tests = testGroup "data families" [
-  testGroup "template-haskell" [
+    testGroup "template-haskell" [
       testGroup "toJSON" [
         testGroup "Nullary" [
             testProperty "string" (isString . thNullaryToJSONString)
           , testProperty "2ElemArray" (is2ElemArray . thNullaryToJSON2ElemArray)
           , testProperty "TaggedObject" (isNullaryTaggedObject . thNullaryToJSONTaggedObject)
           , testProperty "ObjectWithSingleField" (isObjectWithSingleField . thNullaryToJSONObjectWithSingleField)
-
           , testGroup "roundTrip" [
               testProperty "string" (toParseJSON thNullaryParseJSONString thNullaryToJSONString)
             , testProperty "2ElemArray" (toParseJSON thNullaryParseJSON2ElemArray thNullaryToJSON2ElemArray)
@@ -36,21 +35,21 @@ tests = testGroup "data families" [
           , testProperty "TaggedObject" (toParseJSON thSomeTypeParseJSONTaggedObject thSomeTypeToJSONTaggedObject)
           , testProperty "ObjectWithSingleField" (toParseJSON thSomeTypeParseJSONObjectWithSingleField thSomeTypeToJSONObjectWithSingleField)
           ]
+        ]
       , testGroup "Approx" [
-           testProperty "string"                (isString                . thApproxToJSONUnwrap)
-         , testProperty "ObjectWithSingleField" (isObjectWithSingleField . thApproxToJSONDefault)
-         , testGroup "roundTrip" [
-               testProperty "string"                (toParseJSON thApproxParseJSONUnwrap  thApproxToJSONUnwrap)
-             , testProperty "ObjectWithSingleField" (toParseJSON thApproxParseJSONDefault thApproxToJSONDefault)
-           ]
-         ]
+          testProperty "string"                (isString                . thApproxToJSONUnwrap)
+        , testProperty "ObjectWithSingleField" (isObjectWithSingleField . thApproxToJSONDefault)
+        , testGroup "roundTrip" [
+            testProperty "string"                (toParseJSON thApproxParseJSONUnwrap  thApproxToJSONUnwrap)
+          , testProperty "ObjectWithSingleField" (toParseJSON thApproxParseJSONDefault thApproxToJSONDefault)
+          ]
+        ]
       , testGroup "GADT" [
           testProperty "string"                (isString                . thGADTToJSONUnwrap)
         , testProperty "ObjectWithSingleField" (isObjectWithSingleField . thGADTToJSONDefault)
         , testGroup "roundTrip" [
-              testProperty "string"                (toParseJSON thGADTParseJSONUnwrap  thGADTToJSONUnwrap)
-            , testProperty "ObjectWithSingleField" (toParseJSON thGADTParseJSONDefault thGADTToJSONDefault)
-            ]
+            testProperty "string"                (toParseJSON thGADTParseJSONUnwrap  thGADTToJSONUnwrap)
+          , testProperty "ObjectWithSingleField" (toParseJSON thGADTParseJSONDefault thGADTToJSONDefault)
           ]
         ]
       ]
@@ -75,6 +74,63 @@ tests = testGroup "data families" [
       , testProperty "SomeTypeObjectWithSingleField" $
         thSomeTypeToJSONObjectWithSingleField `sameAs`
         thSomeTypeToEncodingObjectWithSingleField
+      ]
+    ]
+  
+  , testGroup "generics" [
+      testGroup "toJSON" [
+        testGroup "Nullary" [
+            testProperty "string" (isString . gNullaryToJSONString)
+          , testProperty "2ElemArray" (is2ElemArray . gNullaryToJSON2ElemArray)
+          , testProperty "TaggedObject" (isNullaryTaggedObject . gNullaryToJSONTaggedObject)
+          , testProperty "ObjectWithSingleField" (isObjectWithSingleField . gNullaryToJSONObjectWithSingleField)
+          , testGroup "roundTrip" [
+              testProperty "string" (toParseJSON gNullaryParseJSONString gNullaryToJSONString)
+            , testProperty "2ElemArray" (toParseJSON gNullaryParseJSON2ElemArray gNullaryToJSON2ElemArray)
+            , testProperty "TaggedObject" (toParseJSON gNullaryParseJSONTaggedObject gNullaryToJSONTaggedObject)
+            , testProperty "ObjectWithSingleField" (toParseJSON gNullaryParseJSONObjectWithSingleField gNullaryToJSONObjectWithSingleField)
+            ]
+        ]
+      , testGroup "SomeType" [
+          testProperty "2ElemArray" (is2ElemArray . gSomeTypeToJSON2ElemArray)
+        , testProperty "TaggedObject" (isTaggedObject . gSomeTypeToJSONTaggedObject)
+        , testProperty "ObjectWithSingleField" (isObjectWithSingleField . gSomeTypeToJSONObjectWithSingleField)
+        , testGroup "roundTrip" [
+            testProperty "2ElemArray" (toParseJSON gSomeTypeParseJSON2ElemArray gSomeTypeToJSON2ElemArray)
+          , testProperty "TaggedObject" (toParseJSON gSomeTypeParseJSONTaggedObject gSomeTypeToJSONTaggedObject)
+          , testProperty "ObjectWithSingleField" (toParseJSON gSomeTypeParseJSONObjectWithSingleField gSomeTypeToJSONObjectWithSingleField)
+          ]
+        ]
+      , testGroup "Approx" [
+          testProperty "string"                (isString                . gApproxToJSONUnwrap)
+        , testProperty "ObjectWithSingleField" (isObjectWithSingleField . gApproxToJSONDefault)
+        , testGroup "roundTrip" [
+            testProperty "string"                (toParseJSON gApproxParseJSONUnwrap  gApproxToJSONUnwrap)
+          , testProperty "ObjectWithSingleField" (toParseJSON gApproxParseJSONDefault gApproxToJSONDefault)
+          ]
+        ]
+      ]
+    , testGroup "toEncoding" [
+        testProperty "NullaryString" $
+        gNullaryToJSONString `sameAs` gNullaryToEncodingString
+      , testProperty "Nullary2ElemArray" $
+        gNullaryToJSON2ElemArray `sameAs` gNullaryToEncoding2ElemArray
+      , testProperty "NullaryTaggedObject" $
+        gNullaryToJSONTaggedObject `sameAs` gNullaryToEncodingTaggedObject
+      , testProperty "NullaryObjectWithSingleField" $
+        gNullaryToJSONObjectWithSingleField `sameAs`
+        gNullaryToEncodingObjectWithSingleField
+      , testProperty "ApproxUnwrap" $
+        gApproxToJSONUnwrap `sameAs` gApproxToEncodingUnwrap
+      , testProperty "ApproxDefault" $
+        gApproxToJSONDefault `sameAs` gApproxToEncodingDefault
+      , testProperty "SomeType2ElemArray" $
+        gSomeTypeToJSON2ElemArray `sameAs` gSomeTypeToEncoding2ElemArray
+      , testProperty "SomeTypeTaggedObject" $
+        gSomeTypeToJSONTaggedObject `sameAs` gSomeTypeToEncodingTaggedObject
+      , testProperty "SomeTypeObjectWithSingleField" $
+        gSomeTypeToJSONObjectWithSingleField `sameAs`
+        gSomeTypeToEncodingObjectWithSingleField
       ]
     ]
   ]

--- a/tests/DataFamilies/Properties.hs
+++ b/tests/DataFamilies/Properties.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module DataFamilies.Properties (tests) where
 
 import DataFamilies.Encoders
@@ -76,7 +78,10 @@ tests = testGroup "data families" [
         thSomeTypeToEncodingObjectWithSingleField
       ]
     ]
-  
+
+-- We only test generic instances for GHC 7.6 and higher because GHC 7.4 has
+-- a bug concerning generics and data families
+#if __GLASGOW_HASKELL__ >= 706
   , testGroup "generics" [
       testGroup "toJSON" [
         testGroup "Nullary" [
@@ -133,4 +138,5 @@ tests = testGroup "data families" [
         gSomeTypeToEncodingObjectWithSingleField
       ]
     ]
+#endif
   ]

--- a/tests/DataFamilies/Types.hs
+++ b/tests/DataFamilies/Types.hs
@@ -2,15 +2,18 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module DataFamilies.Types where
 
 import Types (ApproxEq(..))
 
+import GHC.Generics
+
 data family Nullary a
-data instance Nullary Int  = C1 | C2 | C3 deriving (Eq, Show)
-data instance Nullary Char = C4           deriving (Eq, Show)
+data instance Nullary Int  = C1 | C2 | C3 deriving (Eq, Show, Generic)
+data instance Nullary Char = C4           deriving (Eq, Show, Generic)
 
 data family SomeType a b c
 data instance SomeType c () a = Nullary
@@ -19,11 +22,11 @@ data instance SomeType c () a = Nullary
                               | Record { testOne   :: Double
                                        , testTwo   :: Maybe Bool
                                        , testThree :: Maybe a
-                                       } deriving (Eq, Show)
+                                       } deriving (Eq, Show, Generic)
 
 data family Approx a
 newtype instance Approx a = Approx { fromApprox :: a }
-    deriving (Show, ApproxEq, Num)
+    deriving (Show, ApproxEq, Num, Generic)
 
 instance (ApproxEq a) => Eq (Approx a) where
     Approx a == Approx b = a =~ b

--- a/tests/DataFamilies/Types.hs
+++ b/tests/DataFamilies/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -9,11 +10,13 @@ module DataFamilies.Types where
 
 import Types (ApproxEq(..))
 
+#if __GLASGOW_HASKELL__ >= 706
 import GHC.Generics
+#endif
 
 data family Nullary a
-data instance Nullary Int  = C1 | C2 | C3 deriving (Eq, Show, Generic)
-data instance Nullary Char = C4           deriving (Eq, Show, Generic)
+data instance Nullary Int  = C1 | C2 | C3 deriving (Eq, Show)
+data instance Nullary Char = C4           deriving (Eq, Show)
 
 data family SomeType a b c
 data instance SomeType c () a = Nullary
@@ -22,11 +25,11 @@ data instance SomeType c () a = Nullary
                               | Record { testOne   :: Double
                                        , testTwo   :: Maybe Bool
                                        , testThree :: Maybe a
-                                       } deriving (Eq, Show, Generic)
+                                       } deriving (Eq, Show)
 
 data family Approx a
 newtype instance Approx a = Approx { fromApprox :: a }
-    deriving (Show, ApproxEq, Num, Generic)
+    deriving (Show, ApproxEq, Num)
 
 instance (ApproxEq a) => Eq (Approx a) where
     Approx a == Approx b = a =~ b
@@ -37,3 +40,13 @@ data instance GADT a where
 
 deriving instance Eq   (GADT a)
 deriving instance Show (GADT a)
+
+-- We only derive instances for GHC 7.6 and higher because GHC 7.4 has a bug
+-- concerning generics and data families
+
+#if __GLASGOW_HASKELL__ >= 706
+deriving instance Generic (Nullary Int)
+deriving instance Generic (Nullary Char)
+deriving instance Generic (SomeType c () a)
+deriving instance Generic (Approx a)
+#endif


### PR DESCRIPTION
Here's the code that reproduces the bug:

    {-# LANGUAGE DeriveGeneric #-}

    import Data.Aeson
    import Data.Aeson.TH
    import GHC.Generics

    newtype Wrap a = Wrap {unwrap :: a}
      deriving Generic

    return []

    thToEncodingUnwrap :: Wrap String -> Encoding
    thToEncodingUnwrap =
      $(mkToEncoding defaultOptions{unwrapUnaryRecords=True} ''Wrap)

    gToEncodingUnwrap :: Wrap String -> Encoding
    gToEncodingUnwrap =
      genericToEncoding defaultOptions{unwrapUnaryRecords=True}

The results of thToEncodingUnwrap and gToEncodingUnwrap differ:

    > thToEncodingUnwrap (Wrap "")
    "\"\""
    λ> gToEncodingUnwrap (Wrap "")
    "\"unwrap\":\"\""

This was because the `toEncoding` code couldn't inspect the generated `Builder` and break it into key:value, but when the record has only 1 field the proper way to encode it (when `unwrapUnaryRecords` is turned on) is taking the value without the key.
