### PR TITLE
Update the docs for 'defaultOptions' (fixes #373)

### DIFF
--- a/Data/Aeson/Types/Internal.hs
+++ b/Data/Aeson/Types/Internal.hs
@@ -607,6 +607,7 @@ data SumEncoding =
 -- , 'allNullaryToStringTag'   = True
 -- , 'omitNothingFields'       = False
 -- , 'sumEncoding'             = 'defaultTaggedObject'
+-- , 'unwrapUnaryRecords'      = False
 -- }
 -- @
 defaultOptions :: Options


### PR DESCRIPTION
The 'unwrapUnaryRecords' field was missing in the documentation for 'defaultOptions'.