### PR TITLE
Fix ambigous foldl' for base-2.7

### DIFF
--- a/Data/Aeson/Types/Internal.hs
+++ b/Data/Aeson/Types/Internal.hs
@@ -91,7 +91,7 @@ import Data.Traversable (Traversable(..))
 #endif
 
 #if !MIN_VERSION_unordered_containers(0,2,6)
-import Data.List (foldl', sort)
+import Data.List (sort)
 #endif
 
 -- | Elements of a JSON path used to describe the location of an


### PR DESCRIPTION
When compiling with unordered-containers < 0.2.6 and base < 4.8, some CPP gets triggered that imports `sort` and `foldl'` from Data.List, seemingly from [this commit](https://github.com/bos/aeson/commit/c2def3b753269fe3d6603e5361584c486b10ed0d) 13 days ago. I'm suspecting that CI doesn't hit this case because I don't think it can work. I get the error:

```
Data/Aeson/Types/Internal.hs:401:28:
    Ambiguous occurrence ‘foldl'’
    It could refer to either ‘Data.Foldable.foldl'’,
                             imported from ‘Data.Foldable’ at Data/Aeson/Types/Internal.hs:88:23-34
                          or ‘Data.List.foldl'’,
                             imported from ‘Data.List’ at Data/Aeson/Types/Internal.hs:94:19-24
```

I can understand why we have the explicit imports of Foldable due to
FTP, but Data.Foldable has had `foldl'` for many years and so would
always conflict with the one from Data.List. You can test this by
building this repo with:

```
cabal install --only-dependencies --enable-tests --enable-benchmarks --constraint='base==4.7.0.2' --constraint='unordered-containers==0.2.5.1'
```

Tagging in the author of the commit, @watashi to see if there was a
reason for the explicit foldl' there.