### PR TITLE
Fix typo in 125b641785e1ce3f9facfaf7199de2917d4

### DIFF
--- a/Data/Aeson/TH.hs
+++ b/Data/Aeson/TH.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP, FlexibleInstances, NamedFieldPuns,
     NoImplicitPrelude, UndecidableInstances #-}
-#if __GLASGOW_HASKELL >= 800
+#if __GLASGOW_HASKELL__ >= 800
 -- a) THQ works on cross-compilers and unregisterised GHCs
 -- b) may make compilation faster as no dynamic loading is ever needed (not sure about this)
 -- c) removes one hindrance to have code inferred as SafeHaskell safe

--- a/Data/Aeson/Types/Internal.hs
+++ b/Data/Aeson/Types/Internal.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP, DeriveDataTypeable, GeneralizedNewtypeDeriving, Rank2Types,
     RecordWildCards #-}
-#if __GLASGOW_HASKELL >= 800
+#if __GLASGOW_HASKELL__ >= 800
 -- a) THQ works on cross-compilers and unregisterised GHCs
 -- b) may make compilation faster as no dynamic loading is ever needed (not sure about this)
 -- c) removes one hindrance to have code inferred as SafeHaskell safe


### PR DESCRIPTION
The `__GLASGOW_HASKELL__` identifier was written incorrectly
therefore causing 125b641785e1ce3f9facfaf7199de2917d4 to
have no effect, and hence making `aeson` fail on TH-less GHCs