### PR TITLE
Added unsafeToEncoding

### DIFF
--- a/Data/Aeson/Types.hs
+++ b/Data/Aeson/Types.hs
@@ -14,6 +14,7 @@ module Data.Aeson.Types
     -- * Core JSON types
       Value(..)
     , Encoding
+    , unsafeToEncoding
     , fromEncoding
     , Series
     , Array

--- a/Data/Aeson/Types/Internal.hs
+++ b/Data/Aeson/Types/Internal.hs
@@ -25,6 +25,7 @@ module Data.Aeson.Types.Internal
     -- * Core JSON types
       Value(..)
     , Encoding(..)
+    , unsafeToEncoding
     , Series(..)
     , Array
     , emptyArray, isEmptyArray
@@ -342,6 +343,13 @@ newtype Encoding = Encoding {
       fromEncoding :: Builder
       -- ^ Acquire the underlying bytestring builder.
     } deriving (Semigroup,Monoid)
+
+-- | Make Encoding from Builder.
+--
+--   Use with care! You have to make sure that the passed Builder 
+--   is a valid JSON Encoding! 
+unsafeToEncoding :: Builder -> Encoding
+unsafeToEncoding = Encoding
 
 instance Show Encoding where
     show (Encoding e) = show (toLazyByteString e)


### PR DESCRIPTION
I needed something like that, because I have an encoded JSON from a library (servant-server) and want to include it in another JSON object. I want to skip an additional decoding/encoding. 

If there is another way to accomplish this - I am happy too! If not: Here is a PR ;-)