### PR TITLE
Enabled PolyKinds in Data.Aeson.Types.Instances

### DIFF
--- a/Data/Aeson/Types/Instances.hs
+++ b/Data/Aeson/Types/Instances.hs
@@ -4,6 +4,11 @@
     ViewPatterns #-}
 {-# LANGUAGE DefaultSignatures #-}
 
+-- Needed for Tagged, Const and Proxy instances
+#if __GLASGOW_HASKELL__ >= 706
+{-# LANGUAGE PolyKinds #-}
+#endif
+
 #define NEEDS_INCOHERENT
 #include "overlapping-compat.h"
 


### PR DESCRIPTION
This is needed to make the instances for `Proxy`, `Tagged` and `Const` fully general.