### PR TITLE
Alternate key strategy

### DIFF
--- a/Data/Aeson/Encode/Functions.hs
+++ b/Data/Aeson/Encode/Functions.hs
@@ -8,6 +8,7 @@ module Data.Aeson.Encode.Functions
     , encode
     , foldable
     , list
+    , list'
     , pairs
     ) where
 
@@ -47,6 +48,13 @@ list (x:xs) = Encoding $
               char7 '[' <> builder x <> commas xs <> char7 ']'
       where commas = foldr (\v vs -> char7 ',' <> builder v <> vs) mempty
 {-# INLINE list #-}
+
+list' :: (a -> Encoding) -> [a] -> Encoding
+list' _ []     = emptyArray_
+list' e (x:xs) = Encoding $
+              char7 '[' <> fromEncoding (e x) <> commas xs <> char7 ']'
+      where commas = foldr (\v vs -> char7 ',' <> fromEncoding (e v) <> vs) mempty
+{-# INLINE list' #-}
 
 brackets :: Char -> Char -> Series -> Encoding
 brackets begin end (Value v) = Encoding $

--- a/Data/Aeson/Types/Class.hs
+++ b/Data/Aeson/Types/Class.hs
@@ -258,13 +258,13 @@ class KeyValue kv where
     infixr 8 .=
 
 data ToJSONKeyFunction a
-  = ToJSONKeyText (a -> Text, a -> Encoding)
-  | ToJSONKeyValue (a -> Value, a -> Encoding)
+    = ToJSONKeyText (a -> Text, a -> Encoding)
+    | ToJSONKeyValue (a -> Value, a -> Encoding)
 
 data FromJSONKeyFunction a
-  = FromJSONKeyText (Text -> a)
-  | FromJSONKeyTextParser (Text -> Parser a)
-  | FromJSONKeyValue (Value -> Parser a)
+    = FromJSONKeyText (Text -> a)
+    | FromJSONKeyTextParser (Text -> Parser a)
+    | FromJSONKeyValue (Value -> Parser a)
 
 -- | Fail parsing due to a type mismatch, with a descriptive message.
 --

--- a/Data/Aeson/Types/Class.hs
+++ b/Data/Aeson/Types/Class.hs
@@ -26,8 +26,6 @@ module Data.Aeson.Types.Class
     -- * Classes and types for map keys
     , ToJSONKeyFunction(..)
     , FromJSONKeyFunction(..)
-    , ToJSONKey(..)
-    , FromJSONKey(..)
     -- * Object key-value pairs
     , KeyValue(..)
     -- * Functions needed for documentation
@@ -267,36 +265,6 @@ data FromJSONKeyFunction a
   = FromJSONKeyText (Text -> a)
   | FromJSONKeyTextParser (Text -> Parser a)
   | FromJSONKeyValue (Value -> Parser a)
-
-demandToJSONKeyValue :: ToJSONKeyFunction a -> (a -> Value, a -> Encoding)
-demandToJSONKeyValue x = 
-  case x of
-    ToJSONKeyText (f,g) -> (String . f, g)
-    ToJSONKeyValue a -> a
-
-class ToJSONKey a where
-  toJSONKey :: ToJSONKeyFunction a
-  default toJSONKey :: ToJSON a => ToJSONKeyFunction a
-  toJSONKey = ToJSONKeyValue (toJSON, toEncoding)
-  toJSONKeyList :: ToJSONKeyFunction [a]
-  toJSONKeyList = ToJSONKeyValue 
-      ( Array . V.fromList . map f
-      , list' g
-      )
-    where (f,g) = demandToJSONKeyValue toJSONKey
-
--- Stole this from Data.Aeson.Encode.Functions
-list' :: (a -> Encoding) -> [a] -> Encoding
-list' _ []     = emptyArray_
-list' e (x:xs) = Encoding $
-              B.char7 '[' <> fromEncoding (e x) <> commas xs <> B.char7 ']'
-      where commas = foldr (\v vs -> B.char7 ',' <> fromEncoding (e v) <> vs) mempty
-{-# INLINE list' #-}
-
-class FromJSONKey a where
-  fromJSONKey :: FromJSONKeyFunction a
-  fromJSONKeyList :: FromJSONKeyFunction [a]
-  fromJSONKeyList = error "fromJSONKeyList: write the default"
 
 -- | Fail parsing due to a type mismatch, with a descriptive message.
 --

--- a/Data/Aeson/Types/Class.hs
+++ b/Data/Aeson/Types/Class.hs
@@ -23,6 +23,11 @@ module Data.Aeson.Types.Class
     , genericToJSON
     , genericToEncoding
     , genericParseJSON
+    -- * Classes and types for map keys
+    , ToJSONKeyFunction(..)
+    , FromJSONKeyFunction(..)
+    , ToJSONKey(..)
+    , FromJSONKey(..)
     -- * Object key-value pairs
     , KeyValue(..)
     -- * Functions needed for documentation
@@ -249,6 +254,25 @@ class FromJSON a where
 class KeyValue kv where
     (.=) :: ToJSON v => Text -> v -> kv
     infixr 8 .=
+
+data ToJSONKeyFunction a
+  = ToJSONKeyText (a -> Text, a -> Encoding)
+  | ToJSONKeyValue (a -> Value, a -> Encoding)
+
+data FromJSONKeyFunction a
+  = FromJSONKeyText (Text -> a)
+  | FromJSONKeyTextParser (Text -> Parser a)
+  | FromJSONKeyValue (Value -> Parser a)
+
+class ToJSONKey a where
+  toJSONKey :: ToJSONKeyFunction a
+  toJSONKeyList :: ToJSONKeyFunction [a]
+  toJSONKeyList = error "toJSONKeyList: write the default"
+
+class FromJSONKey a where
+  fromJSONKey :: FromJSONKeyFunction a
+  fromJSONKeyList :: FromJSONKeyFunction [a]
+  fromJSONKeyList = error "fromJSONKeyList: write the default"
 
 -- | Fail parsing due to a type mismatch, with a descriptive message.
 --

--- a/Data/Aeson/Types/Instances.hs
+++ b/Data/Aeson/Types/Instances.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP, BangPatterns, DeriveDataTypeable, FlexibleContexts,
     FlexibleInstances, GeneralizedNewtypeDeriving,
-    OverloadedStrings, UndecidableInstances,
+    OverloadedStrings, UndecidableInstances, ScopedTypeVariables,
     ViewPatterns #-}
 {-# LANGUAGE DefaultSignatures #-}
 
@@ -67,7 +67,7 @@ module Data.Aeson.Types.Instances
     ) where
 
 import Control.Applicative (Const(..))
-import Data.Aeson.Encode.Functions (brackets, builder, encode, foldable, list)
+import Data.Aeson.Encode.Functions (brackets, builder, encode, foldable, list, list')
 import Data.Aeson.Functions (hashMapKey, mapHashKeyVal, mapKey, mapKeyVal)
 import Data.Aeson.Types.Class
 import Data.Aeson.Types.Internal
@@ -111,7 +111,10 @@ import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
+import qualified Data.Text.Read as TR
 import qualified Data.Text.Lazy as LT
+import qualified Data.Text.Lazy.Builder as LTB
+import qualified Data.Text.Lazy.Builder.Int as LTBI
 import qualified Data.Tree as Tree
 import qualified Data.Vector as V
 import qualified Data.Vector.Generic as VG
@@ -135,6 +138,24 @@ import System.Locale (defaultTimeLocale)
 
 parseIndexedJSON :: FromJSON a => Int -> Value -> Parser a
 parseIndexedJSON idx value = parseJSON value <?> Index idx
+
+parseIndexedJSONPair :: FromJSON b => (Value -> Parser a) -> Int -> Value -> Parser (a, b)
+parseIndexedJSONPair keyParser idx value = p value <?> Index idx
+  where
+    p = withArray "(k,v)" $ \ab ->
+        let n = V.length ab
+        in if n == 2
+             then (,) <$> parseJSONElemAtIndex' keyParser 0 ab
+                      <*> parseJSONElemAtIndex 1 ab
+             else fail $ "cannot unpack array of length " ++
+                         show n ++ " into a pair"
+
+toJSONPair :: ToJSON b => (a -> Value) -> (a, b) -> Value
+toJSONPair keySerialiser (a, b) = Array $ V.create $ do
+     mv <- VM.unsafeNew 2
+     VM.unsafeWrite mv 0 (keySerialiser a)
+     VM.unsafeWrite mv 1 (toJSON b)
+     return mv
 
 instance (ToJSON a) => ToJSON (Identity a) where
     toJSON (Identity a) = toJSON a
@@ -653,94 +674,90 @@ instance FromJSON a => FromJSON (IntMap.IntMap a) where
     parseJSON = fmap IntMap.fromList . parseJSON
     {-# INLINE parseJSON #-}
 
-instance (ToJSON v) => ToJSON (M.Map Text v) where
-    toJSON = Object . M.foldrWithKey (\k -> H.insert k . toJSON) H.empty
-    {-# INLINE toJSON #-}
-
-    toEncoding = encodeMap M.minViewWithKey M.foldrWithKey
-    {-# INLINE toEncoding #-}
-
-encodeMap :: (ToJSON k, ToJSON v) =>
-             (m -> Maybe ((k,v), m))
+encodeMap :: (ToJSON v)
+          => (k -> Encoding)
+          -> (m -> Maybe ((k,v), m))
           -> ((k -> v -> B.Builder -> B.Builder) -> B.Builder -> m -> B.Builder)
           -> m -> Encoding
-encodeMap minViewWithKey foldrWithKey xs =
+encodeMap encodeKey minViewWithKey foldrWithKey xs =
     case minViewWithKey xs of
       Nothing         -> E.emptyObject_
       Just ((k,v),ys) -> Encoding $
-                         B.char7 '{' <> encodeKV k v <>
+                         B.char7 '{' <> encodeKV encodeKey k v <>
                          foldrWithKey go (B.char7 '}') ys
-  where go k v b = B.char7 ',' <> encodeKV k v <> b
+  where go k v b = B.char7 ',' <> encodeKV encodeKey k v <> b
 {-# INLINE encodeMap #-}
 
-encodeWithKey :: (ToJSON k, ToJSON v) =>
-                 ((k -> v -> Series -> Series) -> Series -> m -> Series)
+encodeWithKey :: (ToJSON v)
+              => (k -> Encoding)
+              -> ((k -> v -> Series -> Series) -> Series -> m -> Series)
               -> m -> Encoding
-encodeWithKey foldrWithKey = brackets '{' '}' . foldrWithKey go mempty
-  where go k v c = Value (Encoding $ encodeKV k v) <> c
+encodeWithKey encodeKey foldrWithKey = brackets '{' '}' . foldrWithKey go mempty
+  where go k v c = Value (Encoding $ encodeKV encodeKey k v) <> c
 {-# INLINE encodeWithKey #-}
 
-encodeKV :: (ToJSON k, ToJSON v) => k -> v -> B.Builder
-encodeKV k v = builder k <> B.char7 ':' <> builder v
+encodeKV :: (ToJSON v) => (k -> Encoding) -> k -> v -> B.Builder
+encodeKV encodeKey k v = fromEncoding (encodeKey k) <> B.char7 ':' <> builder v
 {-# INLINE encodeKV #-}
 
 instance (FromJSON v) => FromJSON (M.Map Text v) where
     parseJSON = withObject "Map Text a" $
                   fmap (H.foldrWithKey M.insert M.empty) . H.traverseWithKey (\k v -> parseJSON v <?> Key k)
 
-instance (ToJSON v) => ToJSON (M.Map LT.Text v) where
-    toJSON = Object . mapHashKeyVal LT.toStrict toJSON
-    {-# INLINE toJSON #-}
-
-    toEncoding = encodeMap M.minViewWithKey M.foldrWithKey
-    {-# INLINE toEncoding #-}
-
 instance (FromJSON v) => FromJSON (M.Map LT.Text v) where
     parseJSON = fmap (hashMapKey LT.fromStrict) . parseJSON
     {-# INLINE parseJSON #-}
-
-instance (ToJSON v) => ToJSON (M.Map String v) where
-    toJSON = Object . mapHashKeyVal pack toJSON
-    {-# INLINE toJSON #-}
-
-    toEncoding = encodeMap M.minViewWithKey M.foldrWithKey
-    {-# INLINE toEncoding #-}
 
 instance (FromJSON v) => FromJSON (M.Map String v) where
     parseJSON = fmap (hashMapKey unpack) . parseJSON
     {-# INLINE parseJSON #-}
 
-instance (ToJSON v) => ToJSON (H.HashMap Text v) where
-    toJSON = Object . H.map toJSON
+instance (ToJSON v, ToJSONKey k) => ToJSON (M.Map k v) where
+    toJSON = case toJSONKey of
+        ToJSONKeyText (f,_) -> Object . mapHashKeyVal f toJSON
+        ToJSONKeyValue (f,_) -> Array . V.fromList . map (toJSONPair f) . M.toList
     {-# INLINE toJSON #-}
 
-    toEncoding = encodeWithKey H.foldrWithKey
+    toEncoding = case toJSONKey of
+        ToJSONKeyText (_,f) -> encodeMap f M.minViewWithKey M.foldrWithKey
+        ToJSONKeyValue (_,f) -> list' (pairEncoding f) . M.toList
+      where pairEncoding :: (k -> Encoding) -> (k, v) -> Encoding
+            pairEncoding f (a, b) = tuple $ fromEncoding (f a) >*< builder b
     {-# INLINE toEncoding #-}
 
-instance (FromJSON v) => FromJSON (H.HashMap Text v) where
-    parseJSON = withObject "HashMap Text a" $ H.traverseWithKey (\k v -> parseJSON v <?> Key k)
+instance (FromJSON v, FromJSONKey k, Ord k) => FromJSON (M.Map k v) where
+    parseJSON = case fromJSONKey of
+        FromJSONKeyText f -> withObject "Map k v" $
+            fmap (H.foldrWithKey (M.insert . f) M.empty) . H.traverseWithKey (\k v -> parseJSON v <?> Key k)
+        FromJSONKeyTextParser f -> withObject "Map k v" $
+            H.foldrWithKey (\k v m -> M.insert <$> f k <*> (parseJSON v <?> Key k) <*> m) (pure M.empty)
+        FromJSONKeyValue f -> withArray "Map k v" $ \arr ->
+            M.fromList <$> (Tr.sequence .
+                zipWith (parseIndexedJSONPair f) [0..] . V.toList $ arr)
     {-# INLINE parseJSON #-}
 
-instance (ToJSON v) => ToJSON (H.HashMap LT.Text v) where
-    toJSON = Object . mapKeyVal LT.toStrict toJSON
+instance (ToJSON v, ToJSONKey k) => ToJSON (H.HashMap k v) where
+    toJSON = case toJSONKey of
+        ToJSONKeyText (f,_) -> Object . mapKeyVal f toJSON
+        ToJSONKeyValue (f,_) -> Array . V.fromList . map (toJSONPair f) . H.toList
     {-# INLINE toJSON #-}
 
-    toEncoding = encodeWithKey H.foldrWithKey
+    toEncoding = case toJSONKey of
+        ToJSONKeyText (_,f) -> encodeWithKey f H.foldrWithKey
+        ToJSONKeyValue (_,f) -> list' (pairEncoding f) . H.toList
+      where pairEncoding :: (k -> Encoding) -> (k, v) -> Encoding
+            pairEncoding f (a, b) = tuple $ fromEncoding (f a) >*< builder b
     {-# INLINE toEncoding #-}
 
-instance (FromJSON v) => FromJSON (H.HashMap LT.Text v) where
-    parseJSON = fmap (mapKey LT.fromStrict) . parseJSON
-    {-# INLINE parseJSON #-}
-
-instance (ToJSON v) => ToJSON (H.HashMap String v) where
-    toJSON = Object . mapKeyVal pack toJSON
-    {-# INLINE toJSON #-}
-
-    toEncoding = encodeWithKey H.foldrWithKey
-    {-# INLINE toEncoding #-}
-
-instance (FromJSON v) => FromJSON (H.HashMap String v) where
-    parseJSON = fmap (mapKey unpack) . parseJSON
+instance (FromJSON v, FromJSONKey k, Eq k, Hashable k) => FromJSON (H.HashMap k v) where
+    parseJSON = case fromJSONKey of
+        FromJSONKeyText f -> withObject "HashMap k v" $
+            fmap (mapKey f) . H.traverseWithKey (\k v -> parseJSON v <?> Key k)
+        FromJSONKeyTextParser f -> withObject "HashMap k v" $
+            H.foldrWithKey (\k v m -> H.insert <$> f k <*> (parseJSON v <?> Key k) <*> m) (pure H.empty)
+        FromJSONKeyValue f -> withArray "Map k v" $ \arr ->
+            H.fromList <$> (Tr.sequence .
+                zipWith (parseIndexedJSONPair f) [0..] . V.toList $ arr)
     {-# INLINE parseJSON #-}
 
 instance (ToJSON v) => ToJSON (Tree.Tree v) where
@@ -844,7 +861,10 @@ instance FromJSON NominalDiffTime where
     {-# INLINE parseJSON #-}
 
 parseJSONElemAtIndex :: FromJSON a => Int -> Vector Value -> Parser a
-parseJSONElemAtIndex idx ary = parseJSON (V.unsafeIndex ary idx) <?> Index idx
+parseJSONElemAtIndex = parseJSONElemAtIndex' parseJSON
+
+parseJSONElemAtIndex' :: (Value -> Parser a) -> Int -> Vector Value -> Parser a
+parseJSONElemAtIndex' p idx ary = p (V.unsafeIndex ary idx) <?> Index idx
 
 tuple :: B.Builder -> Encoding
 tuple b = Encoding (B.char7 '[' <> b <> B.char7 ']')
@@ -1583,6 +1603,45 @@ instance ToJSON a => ToJSON (Const a b) where
 instance FromJSON a => FromJSON (Const a b) where
     {-# INLINE parseJSON #-}
     parseJSON = fmap Const . parseJSON
+
+--------------------------------------------
+-- Instances for converting to/from map keys
+--------------------------------------------
+instance ToJSONKey Text where
+  toJSONKey = ToJSONKeyText (id,toEncoding)
+
+instance FromJSONKey Text where
+  fromJSONKey = FromJSONKeyText id
+
+instance ToJSONKey Int where
+  toJSONKey = ToJSONKeyText 
+    (LT.toStrict . LTB.toLazyText . LTBI.decimal, toEncoding)
+
+instance FromJSONKey Int where
+  -- not sure if there if there is already a helper in
+  -- aeson for doing this.
+  fromJSONKey = FromJSONKeyTextParser $ \t -> case TR.decimal t of
+    Left err -> fail err
+    Right (v,t2) -> if T.null t2 
+      then return v 
+      else fail "Was not an integer, had extra stuff."
+
+instance ToJSONKey a => ToJSONKey (Identity a) where
+  toJSONKey = contramapToJSONKeyFunction Identity toJSONKey
+
+instance FromJSONKey a => FromJSONKey (Identity a) where
+  fromJSONKey = mapFromJSONKeyFunction Identity fromJSONKey
+
+contramapToJSONKeyFunction :: (b -> a) -> ToJSONKeyFunction a -> ToJSONKeyFunction b
+contramapToJSONKeyFunction h x = case x of
+  ToJSONKeyText (f,g) -> ToJSONKeyText (f . h, g . h)
+  ToJSONKeyValue (f,g) -> ToJSONKeyValue (f . h, g . h)
+
+mapFromJSONKeyFunction :: (a -> b) -> FromJSONKeyFunction a -> FromJSONKeyFunction b
+mapFromJSONKeyFunction h x = case x of
+  FromJSONKeyText f -> FromJSONKeyText (h . f)
+  FromJSONKeyTextParser f -> FromJSONKeyTextParser (fmap h . f)
+  FromJSONKeyValue f -> FromJSONKeyValue (fmap h . f)
 
 -- | @withObject expected f value@ applies @f@ to the 'Object' when @value@ is an @Object@
 --   and fails using @'typeMismatch' expected@ otherwise.


### PR DESCRIPTION
This is an alternative approach that accomplishes the same thing as https://github.com/bos/aeson/pull/341. A lot of the helper functions in this branch were taken from that one. Here is an example on the JSON encodings that are produced:

    > let encodePrint = BC8.putStrLn . L.toStrict . encode
    > encodePrint $ Map.singleton ("hey" :: Text) (4 :: Int)
    {"hey":4}
    > encodePrint $ Map.singleton ("hey" :: String) (4 :: Int)
    {"hey":4}
    > encodePrint $ Map.singleton (2 :: Int) ("dog" :: Text)
    {"2":"dog"}
    > encodePrint $ Map.singleton True ("dog" :: Text)
    {"true":"dog"}
    > encodePrint $ Map.singleton (2 :: Int, 3 :: Int) ("dog" :: Text)
    [[[2,3],"dog"]]
    > encodePrint $ Map.singleton (2 :: Int, "bob" :: String) ("dog" :: Text)
    [[[2,"bob"],"dog"]]
    > encodePrint $ Map.singleton (Identity (4 :: Int)) ("dog" :: Text)
    {"4":"dog"}
    > encodePrint $ Map.singleton (Identity ("bobert" :: String)) ("dog" :: Text)
    {"bobert":"dog"}
    > encodePrint $ Map.singleton (Prelude.map Identity ("bobert" :: String)) ("dog" :: Text)
    [[["b","o","b","e","r","t"],"dog"]]

This implementation is not totally complete, and I have not benchmarked it. I do think that the implementation ends up being simpler than the one in the PR that inspired this approach.