### PR TITLE
use mconcat and intersperse to avoid extra commas. Fixes #387

### DIFF
--- a/tests/Encoders.hs
+++ b/tests/Encoders.hs
@@ -160,6 +160,13 @@ gSomeTypeParseJSONObjectWithSingleField :: Value -> Parser (SomeType Int)
 gSomeTypeParseJSONObjectWithSingleField = genericParseJSON optsObjectWithSingleField
 
 
+gSomeTypeToJSONOmitNothingFields :: SomeType Int -> Value
+gSomeTypeToJSONOmitNothingFields = genericToJSON optsOmitNothingFields
+
+gSomeTypeToEncodingOmitNothingFields :: SomeType Int -> Encoding
+gSomeTypeToEncodingOmitNothingFields = genericToEncoding optsOmitNothingFields
+
+
 --------------------------------------------------------------------------------
 -- Approx encoders/decoders
 --------------------------------------------------------------------------------

--- a/tests/Options.hs
+++ b/tests/Options.hs
@@ -29,3 +29,8 @@ optsObjectWithSingleField = optsDefault
                             { allNullaryToStringTag = False
                             , sumEncoding           = ObjectWithSingleField
                             }
+
+optsOmitNothingFields :: Options
+optsOmitNothingFields = optsDefault
+                        { omitNothingFields = True
+                        }

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -215,6 +215,8 @@ tests = testGroup "properties" [
       , testProperty "SomeTypeObjectWithSingleField" $
         gSomeTypeToJSONObjectWithSingleField `sameAs`
         gSomeTypeToEncodingObjectWithSingleField
+      , testProperty "SomeTypeOmitNothingFields" $
+        gSomeTypeToJSONOmitNothingFields `sameAs` gSomeTypeToEncodingOmitNothingFields
       ]
     ]
   , testGroup "template-haskell" [


### PR DESCRIPTION
This is a fix for #387. When an item is nothing, the result of encoding it is empty, but the concatenation code does not take this into account. This uses intersperse and mconcat for the desired behaviour. I am not sure about the performance characteristics of the way to filter out the empty values, and would love some input. Possible improvement is using `toLazyByteStringWith` from `Data.ByteString.Builder.Extra`, though I am unsure of the internals of `ByteString`. It seems as though there should be an easy way to check if a `Builder` has only the `empty` bytestring, though I did not find it.

Edit: I hadn't seen #394 when I created this, since it's not linked on #387 for some reason. That fixes #387 specifically, but not my issue, i.e. that there are extra commas added for empty field.