### PR TITLE
Track JSONPath in autoderived parsers. Fixes #357

### DIFF
--- a/Data/Aeson/TH.hs
+++ b/Data/Aeson/TH.hs
@@ -107,7 +107,7 @@ import Data.Aeson.Types ( Value(..), Parser
                         , defaultOptions
                         , defaultTaggedObject
                         )
-import Data.Aeson.Types.Internal (Encoding(..))
+import Data.Aeson.Types.Internal (Encoding(..), (<?>), JSONPathElement(Key))
 import Control.Monad       ( liftM2, return, mapM, fail )
 import Data.Bool           ( Bool(False, True), otherwise, (&&), not )
 import Data.Either         ( Either(Left, Right) )
@@ -1010,7 +1010,7 @@ instance OVERLAPPABLE_ (FromJSON a) => LookupField a where
     lookupField tName rec obj key =
         case H.lookup key obj of
           Nothing -> unknownFieldFail tName rec (T.unpack key)
-          Just v  -> parseJSON v
+          Just v  -> parseJSON v <?> Key key
 
 instance (FromJSON a) => LookupField (Maybe a) where
     lookupField _ _ = (.:?)

--- a/Data/Aeson/Types/Generic.hs
+++ b/Data/Aeson/Types/Generic.hs
@@ -679,12 +679,11 @@ instance (FromRecord a, FromRecord b) => FromRecord (a :*: b) where
                                    <*> parseRecord opts Nothing obj
 
 instance (Selector s, GFromJSON a) => FromRecord (S1 s a) where
-    parseRecord opts (Just lab) = maybe (notFound $ unpack lab)
-                      (gParseJSON opts) . H.lookup lab
-    parseRecord opts Nothing    = maybe (notFound label)
-                      (gParseJSON opts) . H.lookup (pack label)
+    parseRecord opts lab = (<?> Key label) . gParseJSON opts <=< (.: label)
         where
-          label = fieldLabelModifier opts $ selName (undefined :: t s a p)
+          label = fromMaybe defLabel lab
+          defLabel = pack . fieldLabelModifier opts $
+                       selName (undefined :: t s a p)
 
 instance OVERLAPPING_ (Selector s, FromJSON a) =>
   FromRecord (S1 s (K1 i (Maybe a))) where

--- a/Data/Aeson/Types/Generic.hs
+++ b/Data/Aeson/Types/Generic.hs
@@ -544,7 +544,7 @@ instance ( FromPair         (a :+: b)
 
 parseAllNullarySum :: SumFromString f => Options -> Value -> Parser (f a)
 parseAllNullarySum opts = withText "Text" $ \key ->
-                            maybe (notFound $ unpack key) return $
+                            maybe (notFound key) return $
                               parseSumFromString opts key
 
 class SumFromString f where
@@ -571,13 +571,13 @@ parseNonAllNullarySum opts =
       TaggedObject{..} ->
           withObject "Object" $ \obj -> do
             tag <- obj .: pack tagFieldName
-            fromMaybe (notFound $ unpack tag) $
+            fromMaybe (notFound tag) $
               parseFromTaggedObject opts contentsFieldName obj tag
 
       ObjectWithSingleField ->
           withObject "Object" $ \obj ->
             case H.toList obj of
-              [pair@(tag, _)] -> fromMaybe (notFound $ unpack tag) $
+              [pair@(tag, _)] -> fromMaybe (notFound tag) $
                                    parsePair opts pair
               _ -> fail "Object doesn't have a single field"
 
@@ -585,7 +585,7 @@ parseNonAllNullarySum opts =
           withArray "Array" $ \arr ->
             if V.length arr == 2
             then case V.unsafeIndex arr 0 of
-                   String tag -> fromMaybe (notFound $ unpack tag) $
+                   String tag -> fromMaybe (notFound tag) $
                                    parsePair opts (tag, V.unsafeIndex arr 1)
                    _ -> fail "First element is not a String"
             else fail "Array doesn't have 2 elements"
@@ -791,6 +791,6 @@ newtype Tagged2 (s :: * -> *) b = Tagged2 {unTagged2 :: b}
 
 --------------------------------------------------------------------------------
 
-notFound :: String -> Parser a
-notFound key = fail $ "The key \"" ++ key ++ "\" was not found"
+notFound :: Text -> Parser a
+notFound key = fail $ "The key \"" ++ unpack key ++ "\" was not found"
 {-# INLINE notFound #-}

--- a/Data/Aeson/Types/Instances.hs
+++ b/Data/Aeson/Types/Instances.hs
@@ -1655,10 +1655,7 @@ ifromJSON = iparse parseJSON
 (.:) :: (FromJSON a) => Object -> Text -> Parser a
 obj .: key = case H.lookup key obj of
                Nothing -> fail $ "key " ++ show key ++ " not present"
-               Just v  -> modifyFailure addKeyName
-                        $ parseJSON v <?> Key key
-  where
-    addKeyName = (("failed to parse field " <> unpack key <> ": ") <>)
+               Just v  -> parseJSON v <?> Key key
 {-# INLINE (.:) #-}
 
 -- | Retrieve the value associated with the given key of an 'Object'.
@@ -1671,10 +1668,7 @@ obj .: key = case H.lookup key obj of
 (.:?) :: (FromJSON a) => Object -> Text -> Parser (Maybe a)
 obj .:? key = case H.lookup key obj of
                Nothing -> pure Nothing
-               Just v  -> modifyFailure addKeyName
-                        $ parseJSON v <?> Key key
-  where
-    addKeyName = (("failed to parse field " <> unpack key <> ": ") <>)
+               Just v  -> parseJSON v <?> Key key
 {-# INLINE (.:?) #-}
 
 -- | Like '.:?', but the resulting parser will fail,
@@ -1682,10 +1676,7 @@ obj .:? key = case H.lookup key obj of
 (.:!) :: (FromJSON a) => Object -> Text -> Parser (Maybe a)
 obj .:! key = case H.lookup key obj of
                Nothing -> pure Nothing
-               Just v  -> modifyFailure addKeyName
-                        $ Just <$> parseJSON v <?> Key key
-  where
-    addKeyName = (("failed to parse field " <> unpack key <> ": ") <>)
+               Just v  -> Just <$> parseJSON v <?> Key key
 {-# INLINE (.:!) #-}
 
 -- | Helper for use in combination with '.:?' to provide default

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -86,7 +86,9 @@ camelFrom c s = let (p:ps) = split c s
 data Wibble = Wibble {
     wibbleString :: String
   , wibbleInt :: Int
-  } deriving (Generic, Show)
+  } deriving (Generic, Show, Eq)
+
+instance FromJSON Wibble
 
 instance ToJSON Wibble where
     toJSON     = genericToJSON defaultOptions
@@ -263,6 +265,10 @@ jsonPath = [
   , assertEqual "Seq a"
       (Left "Error in $[2]: expected Int, encountered Boolean")
       (eitherDecode "[0,1,true]" :: Either String (Seq Int))
+  , assertEqual "Wibble"
+      (Left "Error in $.wibbleInt: expected Int, encountered Boolean")
+      (eitherDecode "{\"wibbleString\":\"\",\"wibbleInt\":true}"
+         :: Either String Wibble)
   ]
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
The first commit is not a direct fix, but gets rid of some redundancy in error messages in nested records.

In the [definition of `(.:)`](https://github.com/bos/aeson/blob/803188803d402090ed515e5738710d542e29a244/Data/Aeson/Types/Instances.hs#L1658-L1659) (as well as its siblings `(.:?)`, etc.) the location information is provided twice. 

```haskell
    data X = {a :: (Int,Int,Int)}
    data Y = {x :: X}
    instance FromJSON X where
        parseJSON (Object obj) = X <$> obj .: "a"
    instance FromJSON Y where
        parseJSON (Object obj) = Y <$> obj .: "x"
```

This results in this kind of error when using `decodeEither`:

```haskell
    > eitherDecode "{\"x\":{\"a\": [1,2,true]}}" :: Either String Y
    Left "Error in $.x.a[2]: failed to parse field x: failed to parse field a: expected Int, encountered Boolean"
```

The location is given in two different forms; the second one is extremely verbose and also incomplete, missing the `[2]`.

This commit simply removes the use of `modifyFailure` in the combinators, so that only the compact path description is left.

    Left "Error in $.x.a[2]: expected Int, encountered Boolean"

One thing that might be problematic with this solution is that the function `parse :: (a -> Parser b) -> a -> Result b` no longer has any location information by default since it discards the `JSONPath` parameter.  OTOH some users might prefer to insert `modifyFailure` themselves to customize their error messages, which previously prevented the use of `(.:)`.