### PR TITLE
Alternate key strategy oleg

### DIFF
--- a/Data/Aeson.hs
+++ b/Data/Aeson.hs
@@ -57,6 +57,11 @@ module Data.Aeson
     , fromJSON
     , ToJSON(..)
     , KeyValue(..)
+    -- ** Keys for maps
+    , ToJSONKey(..)
+    , ToJSONKeyFunction(..)
+    , FromJSONKey(..)
+    , FromJSONKeyFunction(..)
     -- ** Generic JSON classes and options
     , GFromJSON(..)
     , GToJSON(..)

--- a/Data/Aeson/Encode/Functions.hs
+++ b/Data/Aeson/Encode/Functions.hs
@@ -8,6 +8,7 @@ module Data.Aeson.Encode.Functions
     , encode
     , foldable
     , list
+    , list'
     , pairs
     ) where
 
@@ -47,6 +48,13 @@ list (x:xs) = Encoding $
               char7 '[' <> builder x <> commas xs <> char7 ']'
       where commas = foldr (\v vs -> char7 ',' <> builder v <> vs) mempty
 {-# INLINE list #-}
+
+list' :: (a -> Encoding) -> [a] -> Encoding
+list' _ []     = emptyArray_
+list' e (x:xs) = Encoding $
+              char7 '[' <> fromEncoding (e x) <> commas xs <> char7 ']'
+      where commas = foldr (\v vs -> char7 ',' <> fromEncoding (e v) <> vs) mempty
+{-# INLINE list' #-}
 
 brackets :: Char -> Char -> Series -> Encoding
 brackets begin end (Value v) = Encoding $

--- a/Data/Aeson/Types.hs
+++ b/Data/Aeson/Types.hs
@@ -37,6 +37,12 @@ module Data.Aeson.Types
     , KeyValue(..)
     , modifyFailure
 
+    -- ** Keys for maps
+    , ToJSONKey(..)
+    , ToJSONKeyFunction(..)
+    , FromJSONKey(..)
+    , FromJSONKeyFunction(..)
+
     -- ** Generic JSON classes
     , GFromJSON(..)
     , GToJSON(..)

--- a/Data/Aeson/Types.hs
+++ b/Data/Aeson/Types.hs
@@ -42,6 +42,8 @@ module Data.Aeson.Types
     , ToJSONKeyFunction(..)
     , FromJSONKey(..)
     , FromJSONKeyFunction(..)
+    , fromJSONKeyCoerce
+    , coerceFromJSONKeyFunction
 
     -- ** Generic JSON classes
     , GFromJSON(..)

--- a/Data/Aeson/Types/Class.hs
+++ b/Data/Aeson/Types/Class.hs
@@ -262,7 +262,8 @@ data ToJSONKeyFunction a
     | ToJSONKeyValue (a -> Value, a -> Encoding)
 
 data FromJSONKeyFunction a
-    = FromJSONKeyText (Text -> a)
+    = FromJSONKeyCoerce
+    | FromJSONKeyText (Text -> a)
     | FromJSONKeyTextParser (Text -> Parser a)
     | FromJSONKeyValue (Value -> Parser a)
   deriving (Functor)

--- a/Data/Aeson/Types/Class.hs
+++ b/Data/Aeson/Types/Class.hs
@@ -258,13 +258,13 @@ class KeyValue kv where
     infixr 8 .=
 
 data ToJSONKeyFunction a
-  = ToJSONKeyText (a -> Text, a -> Encoding)
-  | ToJSONKeyValue (a -> Value, a -> Encoding)
+    = ToJSONKeyText (a -> Text, a -> Encoding)
+    | ToJSONKeyValue (a -> Value, a -> Encoding)
 
 data FromJSONKeyFunction a
-  = FromJSONKeyText (Text -> a)
-  | FromJSONKeyTextParser (Text -> Parser a)
-  | FromJSONKeyValue (Value -> Parser a)
+    = FromJSONKeyText (Text -> a)
+    | FromJSONKeyTextParser (Text -> Parser a)
+    | FromJSONKeyValue (Value -> Parser a)
 
 -- | Fail parsing due to a type mismatch, with a descriptive message.
 --

--- a/Data/Aeson/Types/Class.hs
+++ b/Data/Aeson/Types/Class.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, DefaultSignatures, FlexibleContexts #-}
+{-# LANGUAGE CPP, DefaultSignatures, FlexibleContexts, DeriveFunctor #-}
 
 -- |
 -- Module:      Data.Aeson.Types.Class
@@ -265,6 +265,8 @@ data FromJSONKeyFunction a
     = FromJSONKeyText (Text -> a)
     | FromJSONKeyTextParser (Text -> Parser a)
     | FromJSONKeyValue (Value -> Parser a)
+  deriving (Functor)
+
 
 -- | Fail parsing due to a type mismatch, with a descriptive message.
 --

--- a/Data/Aeson/Types/Class.hs
+++ b/Data/Aeson/Types/Class.hs
@@ -321,6 +321,17 @@ coerceFromJSONKeyFunction (FromJSONKeyText f)            = FromJSONKeyText (coer
 coerceFromJSONKeyFunction (FromJSONKeyTextParser f)      = FromJSONKeyTextParser (fmap coerce' . f)
 coerceFromJSONKeyFunction (FromJSONKeyValue f)           = FromJSONKeyValue (fmap coerce' . f)
 
+{-# RULES
+  "FromJSONKeyCoerce: fmap id"     forall (x :: FromJSONKeyFunction a).
+                                   fmap id x = x
+  #-}
+#if HAS_COERCIBLE
+{-# RULES
+  "FromJSONKeyCoerce: fmap coerce" forall x .
+                                   fmap coerce x = coerceFromJSONKeyFunction x
+  #-}
+#endif
+
 -- | Fail parsing due to a type mismatch, with a descriptive message.
 --
 -- Example usage:

--- a/Data/Aeson/Types/Class.hs
+++ b/Data/Aeson/Types/Class.hs
@@ -26,8 +26,6 @@ module Data.Aeson.Types.Class
     -- * Classes and types for map keys
     , ToJSONKeyFunction(..)
     , FromJSONKeyFunction(..)
-    , ToJSONKey(..)
-    , FromJSONKey(..)
     -- * Object key-value pairs
     , KeyValue(..)
     -- * Functions needed for documentation
@@ -267,36 +265,6 @@ data FromJSONKeyFunction a
   = FromJSONKeyText (Text -> a)
   | FromJSONKeyTextParser (Text -> Parser a)
   | FromJSONKeyValue (Value -> Parser a)
-
-demandToJSONKeyValue :: ToJSONKeyFunction a -> (a -> Value, a -> Encoding)
-demandToJSONKeyValue x = 
-  case x of
-    ToJSONKeyText (f,g) -> (String . f, g)
-    ToJSONKeyValue a -> a
-
-class ToJSONKey a where
-  toJSONKey :: ToJSONKeyFunction a
-  default toJSONKey :: ToJSON a => ToJSONKeyFunction a
-  toJSONKey = ToJSONKeyValue (toJSON, toEncoding)
-  toJSONKeyList :: ToJSONKeyFunction [a]
-  toJSONKeyList = ToJSONKeyValue 
-      ( Array . V.fromList . map f
-      , list' g
-      )
-    where (f,g) = demandToJSONKeyValue toJSONKey
-
--- Stole this from Data.Aeson.Encode.Functions
-list' :: (a -> Encoding) -> [a] -> Encoding
-list' _ []     = emptyArray_
-list' e (x:xs) = Encoding $
-              B.char7 '[' <> fromEncoding (e x) <> commas xs <> B.char7 ']'
-      where commas = foldr (\v vs -> B.char7 ',' <> fromEncoding (e v) <> vs) mempty
-{-# INLINE list' #-}
-
-class FromJSONKey a where
-  fromJSONKey :: FromJSONKeyFunction a
-  fromJSONKeyList :: FromJSONKeyFunction [a]
-  fromJSONKeyList = error "fromJSONKeyList: write the default"
 
 -- | Fail parsing due to a type mismatch, with a descriptive message.
 --

--- a/Data/Aeson/Types/Class.hs
+++ b/Data/Aeson/Types/Class.hs
@@ -44,7 +44,8 @@ import qualified Data.ByteString.Builder as B
 import qualified Data.Aeson.Encode.Builder as E
 import qualified Data.Vector as V
 
-#define HAS_COERCIBLE MIN_VERSION_base(4,7,0)
+-- Coercible derivations aren't as powerful on GHC 7.8, though supported.
+#define HAS_COERCIBLE (__GLASGOW_HASKELL__ >= 709)
 
 #if HAS_COERCIBLE
 import Data.Coerce (Coercible, coerce)

--- a/Data/Aeson/Types/Class.hs
+++ b/Data/Aeson/Types/Class.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE CPP, DefaultSignatures, FlexibleContexts, DeriveFunctor #-}
+{-# LANGUAGE CPP, GADTs, DefaultSignatures, FlexibleContexts, DeriveFunctor,
+    ScopedTypeVariables #-}
 
 -- |
 -- Module:      Data.Aeson.Types.Class
@@ -26,6 +27,8 @@ module Data.Aeson.Types.Class
     -- * Classes and types for map keys
     , ToJSONKeyFunction(..)
     , FromJSONKeyFunction(..)
+    , fromJSONKeyCoerce
+    , coerceFromJSONKeyFunction
     -- * Object key-value pairs
     , KeyValue(..)
     -- * Functions needed for documentation
@@ -40,6 +43,18 @@ import Data.Aeson.Encode.Builder (emptyArray_)
 import qualified Data.ByteString.Builder as B
 import qualified Data.Aeson.Encode.Builder as E
 import qualified Data.Vector as V
+
+#define HAS_COERCIBLE MIN_VERSION_base(4,7,0)
+
+#if HAS_COERCIBLE
+import Data.Coerce (Coercible, coerce)
+coerce' :: Coercible a b => a -> b
+coerce' = coerce
+#else
+import Unsafe.Coerce (unsafeCoerce)
+coerce' :: a -> b
+coerce' = unsafeCoerce
+#endif
 
 -- | Class of generic representation types ('Rep') that can be converted to
 -- JSON.
@@ -261,13 +276,50 @@ data ToJSONKeyFunction a
     = ToJSONKeyText (a -> Text, a -> Encoding)
     | ToJSONKeyValue (a -> Value, a -> Encoding)
 
+-- | With GHC 7.8 + we carry around 'Coercible Text a' dictionary,
+-- to have even some amount of safety net.
+-- Unfortunately we cannot enforce that 'Hashable' instance agree on the type level
+--
+-- ATM this type is intentionally not exported. FromJSONKeyFunction can be inspected,
+-- but cannot be constructed.
+data CoerceText a where
+#if HAS_COERCIBLE
+    CoerceText :: Coercible Text a => CoerceText a
+#else
+    CoerceText :: CoerceText a
+#endif
+
 data FromJSONKeyFunction a
-    = FromJSONKeyCoerce
+    = FromJSONKeyCoerce (CoerceText a)
     | FromJSONKeyText (Text -> a)
     | FromJSONKeyTextParser (Text -> Parser a)
     | FromJSONKeyValue (Value -> Parser a)
-  deriving (Functor)
 
+instance Functor FromJSONKeyFunction where
+    fmap h (FromJSONKeyCoerce CoerceText) = FromJSONKeyText (h . coerce')
+    fmap h (FromJSONKeyText f)            = FromJSONKeyText (h . f)
+    fmap h (FromJSONKeyTextParser f)      = FromJSONKeyTextParser (fmap h . f)
+    fmap h (FromJSONKeyValue f)           = FromJSONKeyValue (fmap h . f)
+
+-- | Construct 'FromJSONKeyFunction' for types coercible from 'Text'. This
+-- conversion is still unsafe, as 'Hashable' and 'Eq' instances of @a@ should be
+-- compatible with 'Text' i.e. hash values be equal for wrapped values as well.
+fromJSONKeyCoerce ::
+#if HAS_COERCIBLE
+    Coercible Text a =>
+#endif
+    FromJSONKeyFunction a
+fromJSONKeyCoerce = FromJSONKeyCoerce CoerceText
+
+coerceFromJSONKeyFunction ::
+#if HAS_COERCIBLE
+    Coercible a b =>
+#endif
+    FromJSONKeyFunction a -> FromJSONKeyFunction b
+coerceFromJSONKeyFunction (FromJSONKeyCoerce CoerceText) = FromJSONKeyCoerce CoerceText
+coerceFromJSONKeyFunction (FromJSONKeyText f)            = FromJSONKeyText (coerce' . f)
+coerceFromJSONKeyFunction (FromJSONKeyTextParser f)      = FromJSONKeyTextParser (fmap coerce' . f)
+coerceFromJSONKeyFunction (FromJSONKeyValue f)           = FromJSONKeyValue (fmap coerce' . f)
 
 -- | Fail parsing due to a type mismatch, with a descriptive message.
 --

--- a/Data/Aeson/Types/Class.hs
+++ b/Data/Aeson/Types/Class.hs
@@ -23,6 +23,11 @@ module Data.Aeson.Types.Class
     , genericToJSON
     , genericToEncoding
     , genericParseJSON
+    -- * Classes and types for map keys
+    , ToJSONKeyFunction(..)
+    , FromJSONKeyFunction(..)
+    , ToJSONKey(..)
+    , FromJSONKey(..)
     -- * Object key-value pairs
     , KeyValue(..)
     -- * Functions needed for documentation
@@ -249,6 +254,25 @@ class FromJSON a where
 class KeyValue kv where
     (.=) :: ToJSON v => Text -> v -> kv
     infixr 8 .=
+
+data ToJSONKeyFunction a
+  = ToJSONKeyText (a -> Text, a -> Encoding)
+  | ToJSONKeyValue (a -> Value, a -> Encoding)
+
+data FromJSONKeyFunction a
+  = FromJSONKeyText (Text -> a)
+  | FromJSONKeyTextParser (Text -> Parser a)
+  | FromJSONKeyValue (Value -> Parser a)
+
+class ToJSONKey a where
+  toJSONKey :: ToJSONKeyFunction a
+  toJSONKeyList :: ToJSONKeyFunction [a]
+  toJSONKeyList = error "toJSONKeyList: write the default"
+
+class FromJSONKey a where
+  fromJSONKey :: FromJSONKeyFunction a
+  fromJSONKeyList :: FromJSONKeyFunction [a]
+  fromJSONKeyList = error "fromJSONKeyList: write the default"
 
 -- | Fail parsing due to a type mismatch, with a descriptive message.
 --

--- a/Data/Aeson/Types/Instances.hs
+++ b/Data/Aeson/Types/Instances.hs
@@ -35,6 +35,11 @@ module Data.Aeson.Types.Instances
       FromJSON(..)
     , ToJSON(..)
     , KeyValue(..)
+    -- ** Keys for maps
+    , ToJSONKey(..)
+    , ToJSONKeyFunction(..)
+    , FromJSONKey(..)
+    , FromJSONKeyFunction(..)
     -- ** Generic JSON classes
     , GFromJSON(..)
     , GToJSON(..)
@@ -64,15 +69,11 @@ module Data.Aeson.Types.Instances
     , tuple
     , (>*<)
     , typeMismatch
-
-    -- * Keys for maps
-    , ToJSONKey(..)
-    , FromJSONKey(..)
     ) where
 
 import Control.Applicative (Const(..))
 import Data.Aeson.Encode.Functions (brackets, builder, encode, foldable, list, list')
-import Data.Aeson.Functions (hashMapKey, mapHashKeyVal, mapKey, mapKeyVal)
+import Data.Aeson.Functions (mapHashKeyVal, mapKey, mapKeyVal)
 import Data.Aeson.Types.Class
 import Data.Aeson.Types.Internal
 import Data.Attoparsec.Number (Number(..))

--- a/Data/Aeson/Types/Instances.hs
+++ b/Data/Aeson/Types/Instances.hs
@@ -704,18 +704,6 @@ encodeKV :: (ToJSON v) => (k -> Encoding) -> k -> v -> B.Builder
 encodeKV encodeKey k v = fromEncoding (encodeKey k) <> B.char7 ':' <> builder v
 {-# INLINE encodeKV #-}
 
-instance (FromJSON v) => FromJSON (M.Map Text v) where
-    parseJSON = withObject "Map Text a" $
-                  fmap (H.foldrWithKey M.insert M.empty) . H.traverseWithKey (\k v -> parseJSON v <?> Key k)
-
-instance (FromJSON v) => FromJSON (M.Map LT.Text v) where
-    parseJSON = fmap (hashMapKey LT.fromStrict) . parseJSON
-    {-# INLINE parseJSON #-}
-
-instance (FromJSON v) => FromJSON (M.Map String v) where
-    parseJSON = fmap (hashMapKey unpack) . parseJSON
-    {-# INLINE parseJSON #-}
-
 instance (ToJSON v, ToJSONKey k) => ToJSON (M.Map k v) where
     toJSON = case toJSONKey of
         ToJSONKeyText (f,_) -> Object . mapHashKeyVal f toJSON

--- a/Data/Aeson/Types/Instances.hs
+++ b/Data/Aeson/Types/Instances.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP, BangPatterns, DeriveDataTypeable, FlexibleContexts,
     FlexibleInstances, GeneralizedNewtypeDeriving,
-    OverloadedStrings, UndecidableInstances,
+    OverloadedStrings, UndecidableInstances, ScopedTypeVariables,
     ViewPatterns #-}
 {-# LANGUAGE DefaultSignatures #-}
 
@@ -67,7 +67,7 @@ module Data.Aeson.Types.Instances
     ) where
 
 import Control.Applicative (Const(..))
-import Data.Aeson.Encode.Functions (brackets, builder, encode, foldable, list)
+import Data.Aeson.Encode.Functions (brackets, builder, encode, foldable, list, list')
 import Data.Aeson.Functions (hashMapKey, mapHashKeyVal, mapKey, mapKeyVal)
 import Data.Aeson.Types.Class
 import Data.Aeson.Types.Internal
@@ -111,7 +111,10 @@ import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
+import qualified Data.Text.Read as TR
 import qualified Data.Text.Lazy as LT
+import qualified Data.Text.Lazy.Builder as LTB
+import qualified Data.Text.Lazy.Builder.Int as LTBI
 import qualified Data.Tree as Tree
 import qualified Data.Vector as V
 import qualified Data.Vector.Generic as VG
@@ -135,6 +138,24 @@ import System.Locale (defaultTimeLocale)
 
 parseIndexedJSON :: FromJSON a => Int -> Value -> Parser a
 parseIndexedJSON idx value = parseJSON value <?> Index idx
+
+parseIndexedJSONPair :: FromJSON b => (Value -> Parser a) -> Int -> Value -> Parser (a, b)
+parseIndexedJSONPair keyParser idx value = p value <?> Index idx
+  where
+    p = withArray "(k,v)" $ \ab ->
+        let n = V.length ab
+        in if n == 2
+             then (,) <$> parseJSONElemAtIndex' keyParser 0 ab
+                      <*> parseJSONElemAtIndex 1 ab
+             else fail $ "cannot unpack array of length " ++
+                         show n ++ " into a pair"
+
+toJSONPair :: ToJSON b => (a -> Value) -> (a, b) -> Value
+toJSONPair keySerialiser (a, b) = Array $ V.create $ do
+     mv <- VM.unsafeNew 2
+     VM.unsafeWrite mv 0 (keySerialiser a)
+     VM.unsafeWrite mv 1 (toJSON b)
+     return mv
 
 instance (ToJSON a) => ToJSON (Identity a) where
     toJSON (Identity a) = toJSON a
@@ -653,94 +674,90 @@ instance FromJSON a => FromJSON (IntMap.IntMap a) where
     parseJSON = fmap IntMap.fromList . parseJSON
     {-# INLINE parseJSON #-}
 
-instance (ToJSON v) => ToJSON (M.Map Text v) where
-    toJSON = Object . M.foldrWithKey (\k -> H.insert k . toJSON) H.empty
-    {-# INLINE toJSON #-}
-
-    toEncoding = encodeMap M.minViewWithKey M.foldrWithKey
-    {-# INLINE toEncoding #-}
-
-encodeMap :: (ToJSON k, ToJSON v) =>
-             (m -> Maybe ((k,v), m))
+encodeMap :: (ToJSON v)
+          => (k -> Encoding)
+          -> (m -> Maybe ((k,v), m))
           -> ((k -> v -> B.Builder -> B.Builder) -> B.Builder -> m -> B.Builder)
           -> m -> Encoding
-encodeMap minViewWithKey foldrWithKey xs =
+encodeMap encodeKey minViewWithKey foldrWithKey xs =
     case minViewWithKey xs of
       Nothing         -> E.emptyObject_
       Just ((k,v),ys) -> Encoding $
-                         B.char7 '{' <> encodeKV k v <>
+                         B.char7 '{' <> encodeKV encodeKey k v <>
                          foldrWithKey go (B.char7 '}') ys
-  where go k v b = B.char7 ',' <> encodeKV k v <> b
+  where go k v b = B.char7 ',' <> encodeKV encodeKey k v <> b
 {-# INLINE encodeMap #-}
 
-encodeWithKey :: (ToJSON k, ToJSON v) =>
-                 ((k -> v -> Series -> Series) -> Series -> m -> Series)
+encodeWithKey :: (ToJSON v)
+              => (k -> Encoding)
+              -> ((k -> v -> Series -> Series) -> Series -> m -> Series)
               -> m -> Encoding
-encodeWithKey foldrWithKey = brackets '{' '}' . foldrWithKey go mempty
-  where go k v c = Value (Encoding $ encodeKV k v) <> c
+encodeWithKey encodeKey foldrWithKey = brackets '{' '}' . foldrWithKey go mempty
+  where go k v c = Value (Encoding $ encodeKV encodeKey k v) <> c
 {-# INLINE encodeWithKey #-}
 
-encodeKV :: (ToJSON k, ToJSON v) => k -> v -> B.Builder
-encodeKV k v = builder k <> B.char7 ':' <> builder v
+encodeKV :: (ToJSON v) => (k -> Encoding) -> k -> v -> B.Builder
+encodeKV encodeKey k v = fromEncoding (encodeKey k) <> B.char7 ':' <> builder v
 {-# INLINE encodeKV #-}
 
 instance (FromJSON v) => FromJSON (M.Map Text v) where
     parseJSON = withObject "Map Text a" $
                   fmap (H.foldrWithKey M.insert M.empty) . H.traverseWithKey (\k v -> parseJSON v <?> Key k)
 
-instance (ToJSON v) => ToJSON (M.Map LT.Text v) where
-    toJSON = Object . mapHashKeyVal LT.toStrict toJSON
-    {-# INLINE toJSON #-}
-
-    toEncoding = encodeMap M.minViewWithKey M.foldrWithKey
-    {-# INLINE toEncoding #-}
-
 instance (FromJSON v) => FromJSON (M.Map LT.Text v) where
     parseJSON = fmap (hashMapKey LT.fromStrict) . parseJSON
     {-# INLINE parseJSON #-}
-
-instance (ToJSON v) => ToJSON (M.Map String v) where
-    toJSON = Object . mapHashKeyVal pack toJSON
-    {-# INLINE toJSON #-}
-
-    toEncoding = encodeMap M.minViewWithKey M.foldrWithKey
-    {-# INLINE toEncoding #-}
 
 instance (FromJSON v) => FromJSON (M.Map String v) where
     parseJSON = fmap (hashMapKey unpack) . parseJSON
     {-# INLINE parseJSON #-}
 
-instance (ToJSON v) => ToJSON (H.HashMap Text v) where
-    toJSON = Object . H.map toJSON
+instance (ToJSON v, ToJSONKey k) => ToJSON (M.Map k v) where
+    toJSON = case toJSONKey of
+        ToJSONKeyText (f,_) -> Object . mapHashKeyVal f toJSON
+        ToJSONKeyValue (f,_) -> Array . V.fromList . map (toJSONPair f) . M.toList
     {-# INLINE toJSON #-}
 
-    toEncoding = encodeWithKey H.foldrWithKey
+    toEncoding = case toJSONKey of
+        ToJSONKeyText (_,f) -> encodeMap f M.minViewWithKey M.foldrWithKey
+        ToJSONKeyValue (_,f) -> list' (pairEncoding f) . M.toList
+      where pairEncoding :: (k -> Encoding) -> (k, v) -> Encoding
+            pairEncoding f (a, b) = tuple $ fromEncoding (f a) >*< builder b
     {-# INLINE toEncoding #-}
 
-instance (FromJSON v) => FromJSON (H.HashMap Text v) where
-    parseJSON = withObject "HashMap Text a" $ H.traverseWithKey (\k v -> parseJSON v <?> Key k)
+instance (FromJSON v, FromJSONKey k, Ord k) => FromJSON (M.Map k v) where
+    parseJSON = case fromJSONKey of
+        FromJSONKeyText f -> withObject "Map k v" $
+            fmap (H.foldrWithKey (M.insert . f) M.empty) . H.traverseWithKey (\k v -> parseJSON v <?> Key k)
+        FromJSONKeyTextParser f -> withObject "Map k v" $
+            H.foldrWithKey (\k v m -> M.insert <$> f k <*> (parseJSON v <?> Key k) <*> m) (pure M.empty)
+        FromJSONKeyValue f -> withArray "Map k v" $ \arr ->
+            M.fromList <$> (Tr.sequence .
+                zipWith (parseIndexedJSONPair f) [0..] . V.toList $ arr)
     {-# INLINE parseJSON #-}
 
-instance (ToJSON v) => ToJSON (H.HashMap LT.Text v) where
-    toJSON = Object . mapKeyVal LT.toStrict toJSON
+instance (ToJSON v, ToJSONKey k) => ToJSON (H.HashMap k v) where
+    toJSON = case toJSONKey of
+        ToJSONKeyText (f,_) -> Object . mapKeyVal f toJSON
+        ToJSONKeyValue (f,_) -> Array . V.fromList . map (toJSONPair f) . H.toList
     {-# INLINE toJSON #-}
 
-    toEncoding = encodeWithKey H.foldrWithKey
+    toEncoding = case toJSONKey of
+        ToJSONKeyText (_,f) -> encodeWithKey f H.foldrWithKey
+        ToJSONKeyValue (_,f) -> list' (pairEncoding f) . H.toList
+      where pairEncoding :: (k -> Encoding) -> (k, v) -> Encoding
+            pairEncoding f (a, b) = tuple $ fromEncoding (f a) >*< builder b
     {-# INLINE toEncoding #-}
 
-instance (FromJSON v) => FromJSON (H.HashMap LT.Text v) where
-    parseJSON = fmap (mapKey LT.fromStrict) . parseJSON
-    {-# INLINE parseJSON #-}
-
-instance (ToJSON v) => ToJSON (H.HashMap String v) where
-    toJSON = Object . mapKeyVal pack toJSON
-    {-# INLINE toJSON #-}
-
-    toEncoding = encodeWithKey H.foldrWithKey
-    {-# INLINE toEncoding #-}
-
-instance (FromJSON v) => FromJSON (H.HashMap String v) where
-    parseJSON = fmap (mapKey unpack) . parseJSON
+instance (FromJSON v, FromJSONKey k, Eq k, Hashable k) => FromJSON (H.HashMap k v) where
+    parseJSON = case fromJSONKey of
+        FromJSONKeyText f -> withObject "HashMap k v" $
+            fmap (mapKey f) . H.traverseWithKey (\k v -> parseJSON v <?> Key k)
+        FromJSONKeyTextParser f -> withObject "HashMap k v" $
+            H.foldrWithKey (\k v m -> H.insert <$> f k <*> (parseJSON v <?> Key k) <*> m) (pure H.empty)
+        FromJSONKeyValue f -> withArray "Map k v" $ \arr ->
+            H.fromList <$> (Tr.sequence .
+                zipWith (parseIndexedJSONPair f) [0..] . V.toList $ arr)
     {-# INLINE parseJSON #-}
 
 instance (ToJSON v) => ToJSON (Tree.Tree v) where
@@ -844,7 +861,10 @@ instance FromJSON NominalDiffTime where
     {-# INLINE parseJSON #-}
 
 parseJSONElemAtIndex :: FromJSON a => Int -> Vector Value -> Parser a
-parseJSONElemAtIndex idx ary = parseJSON (V.unsafeIndex ary idx) <?> Index idx
+parseJSONElemAtIndex = parseJSONElemAtIndex' parseJSON
+
+parseJSONElemAtIndex' :: (Value -> Parser a) -> Int -> Vector Value -> Parser a
+parseJSONElemAtIndex' p idx ary = p (V.unsafeIndex ary idx) <?> Index idx
 
 tuple :: B.Builder -> Encoding
 tuple b = Encoding (B.char7 '[' <> b <> B.char7 ']')
@@ -1583,6 +1603,45 @@ instance ToJSON a => ToJSON (Const a b) where
 instance FromJSON a => FromJSON (Const a b) where
     {-# INLINE parseJSON #-}
     parseJSON = fmap Const . parseJSON
+
+--------------------------------------------
+-- Instances for converting to/from map keys
+--------------------------------------------
+instance ToJSONKey Text where
+  toJSONKey = ToJSONKeyText (id,toEncoding)
+
+instance FromJSONKey Text where
+  fromJSONKey = FromJSONKeyText id
+
+instance ToJSONKey Int where
+  toJSONKey = ToJSONKeyText 
+    (LT.toStrict . LTB.toLazyText . LTBI.decimal, toEncoding)
+
+instance FromJSONKey Int where
+  -- not sure if there if there is already a helper in
+  -- aeson for doing this.
+  fromJSONKey = FromJSONKeyTextParser $ \t -> case TR.decimal t of
+    Left err -> fail err
+    Right (v,t2) -> if T.null t2 
+      then return v 
+      else fail "Was not an integer, had extra stuff."
+
+instance ToJSONKey a => ToJSONKey (Identity a) where
+  toJSONKey = contramapToJSONKeyFunction Identity toJSONKey
+
+instance FromJSONKey a => FromJSONKey (Identity a) where
+  fromJSONKey = mapFromJSONKeyFunction Identity fromJSONKey
+
+contramapToJSONKeyFunction :: (b -> a) -> ToJSONKeyFunction a -> ToJSONKeyFunction b
+contramapToJSONKeyFunction h x = case x of
+  ToJSONKeyText (f,g) -> ToJSONKeyText (f . h, g . h)
+  ToJSONKeyValue (f,g) -> ToJSONKeyValue (f . h, g . h)
+
+mapFromJSONKeyFunction :: (a -> b) -> FromJSONKeyFunction a -> FromJSONKeyFunction b
+mapFromJSONKeyFunction h x = case x of
+  FromJSONKeyText f -> FromJSONKeyText (h . f)
+  FromJSONKeyTextParser f -> FromJSONKeyTextParser (fmap h . f)
+  FromJSONKeyValue f -> FromJSONKeyValue (fmap h . f)
 
 -- | @withObject expected f value@ applies @f@ to the 'Object' when @value@ is an @Object@
 --   and fails using @'typeMismatch' expected@ otherwise.

--- a/benchmarks/AesonMap.hs
+++ b/benchmarks/AesonMap.hs
@@ -44,7 +44,6 @@ instance FromJSONKey T1 where
 -- Coerce
 -------------------------------------------------------------------------------
 
--- | TODO: same as T1 for now
 newtype T2 = T2 T.Text
   deriving (Eq, Ord)
 
@@ -55,7 +54,7 @@ instance Hashable T2 where
 instance FromJSON T2 where
     parseJSON = withText "T2" $ pure . T2
 instance FromJSONKey T2 where
-    fromJSONKey = FromJSONKeyText T2
+    fromJSONKey = FromJSONKeyCoerce
 
 -------------------------------------------------------------------------------
 -- TextParser

--- a/benchmarks/AesonMap.hs
+++ b/benchmarks/AesonMap.hs
@@ -152,7 +152,7 @@ benchDecodeMap name val =
 main :: IO ()
 main = do
     defaultMain
-        [ bgroup "encode"
+        [ bgroup "decode"
             [ bgroup "HashMap"
                 [ benchDecodeHM "10"    encodedValue10
                 , benchDecodeHM "100"   encodedValue100

--- a/benchmarks/AesonMap.hs
+++ b/benchmarks/AesonMap.hs
@@ -1,0 +1,115 @@
+{-# LANGUAGE BangPatterns, OverloadedStrings, FlexibleInstances, MultiParamTypeClasses, DataKinds #-}
+
+import Control.DeepSeq
+import Criterion.Main
+import Data.Aeson
+import Data.Aeson.Types (Parser)
+import Data.Hashable
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Text as T
+import qualified Data.Map as M
+import qualified Data.HashMap.Strict as HM
+
+value :: Int -> HM.HashMap T.Text T.Text
+value n = HM.fromList $ map f [1..n]
+  where
+    f m = let t = T.pack (show m) in (t, t)
+
+newtype T1 = T1 T.Text
+  deriving (Eq, Ord)
+
+instance NFData T1 where
+  rnf (T1 t) = rnf t
+instance Hashable T1 where
+  hashWithSalt salt (T1 t) = hashWithSalt salt t
+instance FromJSONKey T1 'JSONKeyIdentity where
+    fromJSONKey _ = T1
+
+newtype T2 = T2 T.Text
+  deriving (Eq, Ord)
+
+instance NFData T2 where
+  rnf (T2 t) = rnf t
+instance Hashable T2 where
+  hashWithSalt salt (T2 t) = hashWithSalt salt t
+instance FromJSONKey T2 'JSONKeyCoerce where
+    fromJSONKey _ = ()
+
+newtype T3 = T3 T.Text
+  deriving (Eq, Ord)
+
+instance NFData T3 where
+  rnf (T3 t) = rnf t
+instance Hashable T3 where
+  hashWithSalt salt (T3 t) = hashWithSalt salt t
+instance FromJSONKey T3 'JSONKeyTextParser where
+    fromJSONKey _ = return . T3
+
+encodedValue10 :: LBS.ByteString
+encodedValue10 = encode $ value 10
+
+encodedValue100 :: LBS.ByteString
+encodedValue100 = encode $ value 100
+
+encodedValue1000 :: LBS.ByteString
+encodedValue1000 = encode $ value 1000
+
+encodedValue10000 :: LBS.ByteString
+encodedValue10000 = encode $ value 10000
+
+main :: IO ()
+main = do
+  defaultMain
+    [ bgroup "HashMap"
+      [ bgroup "10"
+        [  bench "Text" $ nf (decode :: LBS.ByteString -> Maybe (HM.HashMap T.Text T.Text)) encodedValue10
+        ,  bench "Identity" $ nf (decode :: LBS.ByteString -> Maybe (HM.HashMap T1 T.Text)) encodedValue10
+        ,  bench "Coerce" $ nf (decode :: LBS.ByteString -> Maybe (HM.HashMap T2 T.Text)) encodedValue10
+        ,  bench "Parser" $ nf (decode :: LBS.ByteString -> Maybe (HM.HashMap T3 T.Text)) encodedValue10
+        ]
+      , bgroup "100"
+        [  bench "Text" $ nf (decode :: LBS.ByteString -> Maybe (HM.HashMap T.Text T.Text)) encodedValue100
+        ,  bench "Identity" $ nf (decode :: LBS.ByteString -> Maybe (HM.HashMap T1 T.Text)) encodedValue100
+        ,  bench "Coerce" $ nf (decode :: LBS.ByteString -> Maybe (HM.HashMap T2 T.Text)) encodedValue100
+        ,  bench "Parser" $ nf (decode :: LBS.ByteString -> Maybe (HM.HashMap T3 T.Text)) encodedValue100
+        ]
+      , bgroup "1000"
+        [  bench "Text" $ nf (decode :: LBS.ByteString -> Maybe (HM.HashMap T.Text T.Text)) encodedValue1000
+        ,  bench "Identity" $ nf (decode :: LBS.ByteString -> Maybe (HM.HashMap T1 T.Text)) encodedValue1000
+        ,  bench "Coerce" $ nf (decode :: LBS.ByteString -> Maybe (HM.HashMap T2 T.Text)) encodedValue1000
+        ,  bench "Parser" $ nf (decode :: LBS.ByteString -> Maybe (HM.HashMap T3 T.Text)) encodedValue1000
+        ]
+      , bgroup "10000"
+        [  bench "Text" $ nf (decode :: LBS.ByteString -> Maybe (HM.HashMap T.Text T.Text)) encodedValue10000
+        ,  bench "Identity" $ nf (decode :: LBS.ByteString -> Maybe (HM.HashMap T1 T.Text)) encodedValue10000
+        ,  bench "Coerce" $ nf (decode :: LBS.ByteString -> Maybe (HM.HashMap T2 T.Text)) encodedValue10000
+        ,  bench "Parser" $ nf (decode :: LBS.ByteString -> Maybe (HM.HashMap T3 T.Text)) encodedValue10000
+        ]
+      ]
+    , bgroup "Map"
+      [ bgroup "10"
+        [  bench "Text" $ nf (decode :: LBS.ByteString -> Maybe (M.Map T.Text T.Text)) encodedValue10
+        ,  bench "Identity" $ nf (decode :: LBS.ByteString -> Maybe (M.Map T1 T.Text)) encodedValue10
+        ,  bench "Coerce" $ nf (decode :: LBS.ByteString -> Maybe (M.Map T2 T.Text)) encodedValue10
+        ,  bench "Parser" $ nf (decode :: LBS.ByteString -> Maybe (M.Map T3 T.Text)) encodedValue10
+        ]
+      , bgroup "100"
+        [  bench "Text" $ nf (decode :: LBS.ByteString -> Maybe (M.Map T.Text T.Text)) encodedValue100
+        ,  bench "Identity" $ nf (decode :: LBS.ByteString -> Maybe (M.Map T1 T.Text)) encodedValue100
+        ,  bench "Coerce" $ nf (decode :: LBS.ByteString -> Maybe (M.Map T2 T.Text)) encodedValue100
+        ,  bench "Parser" $ nf (decode :: LBS.ByteString -> Maybe (M.Map T3 T.Text)) encodedValue100
+        ]
+      , bgroup "1000"
+        [  bench "Text" $ nf (decode :: LBS.ByteString -> Maybe (M.Map T.Text T.Text)) encodedValue1000
+        ,  bench "Identity" $ nf (decode :: LBS.ByteString -> Maybe (M.Map T1 T.Text)) encodedValue1000
+        ,  bench "Coerce" $ nf (decode :: LBS.ByteString -> Maybe (M.Map T2 T.Text)) encodedValue1000
+        ,  bench "Parser" $ nf (decode :: LBS.ByteString -> Maybe (M.Map T3 T.Text)) encodedValue1000
+        ]
+      , bgroup "10000"
+        [  bench "Text" $ nf (decode :: LBS.ByteString -> Maybe (M.Map T.Text T.Text)) encodedValue10000
+        ,  bench "Identity" $ nf (decode :: LBS.ByteString -> Maybe (M.Map T1 T.Text)) encodedValue10000
+        ,  bench "Coerce" $ nf (decode :: LBS.ByteString -> Maybe (M.Map T2 T.Text)) encodedValue10000
+        ,  bench "Parser" $ nf (decode :: LBS.ByteString -> Maybe (M.Map T3 T.Text)) encodedValue10000
+        ]
+      ]
+    ]

--- a/benchmarks/AesonMap.hs
+++ b/benchmarks/AesonMap.hs
@@ -3,7 +3,7 @@
 import Control.DeepSeq
 import Criterion.Main
 import Data.Aeson
--- import Data.Aeson.Types (Parser)
+import Data.Aeson.Types (fromJSONKeyCoerce)
 import Data.Hashable
 import Data.Proxy (Proxy (..))
 import Data.Tagged (Tagged (..))
@@ -54,7 +54,7 @@ instance Hashable T2 where
 instance FromJSON T2 where
     parseJSON = withText "T2" $ pure . T2
 instance FromJSONKey T2 where
-    fromJSONKey = FromJSONKeyCoerce
+    fromJSONKey = fromJSONKeyCoerce
 
 -------------------------------------------------------------------------------
 -- TextParser

--- a/benchmarks/AesonMap.hs
+++ b/benchmarks/AesonMap.hs
@@ -1,10 +1,11 @@
-{-# LANGUAGE BangPatterns, OverloadedStrings, FlexibleInstances, MultiParamTypeClasses, DataKinds #-}
+{-# LANGUAGE OverloadedStrings, RankNTypes #-}
 
 import Control.DeepSeq
 import Criterion.Main
 import Data.Aeson
-import Data.Aeson.Types (Parser)
+-- import Data.Aeson.Types (Parser)
 import Data.Hashable
+import Data.Proxy (Proxy (..))
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Text as T
 import qualified Data.Map as M
@@ -15,6 +16,10 @@ value n = HM.fromList $ map f [1..n]
   where
     f m = let t = T.pack (show m) in (t, t)
 
+-------------------------------------------------------------------------------
+-- Text 
+-------------------------------------------------------------------------------
+
 newtype T1 = T1 T.Text
   deriving (Eq, Ord)
 
@@ -22,9 +27,16 @@ instance NFData T1 where
   rnf (T1 t) = rnf t
 instance Hashable T1 where
   hashWithSalt salt (T1 t) = hashWithSalt salt t
-instance FromJSONKey T1 'JSONKeyIdentity where
-    fromJSONKey _ = T1
+instance FromJSON T1 where
+    parseJSON = withText "T1" $ pure . T1
+instance FromJSONKey T1 where
+    fromJSONKey = FromJSONKeyText T1
 
+-------------------------------------------------------------------------------
+-- Coerce
+-------------------------------------------------------------------------------
+
+-- | TODO: same as T1 for now
 newtype T2 = T2 T.Text
   deriving (Eq, Ord)
 
@@ -32,8 +44,14 @@ instance NFData T2 where
   rnf (T2 t) = rnf t
 instance Hashable T2 where
   hashWithSalt salt (T2 t) = hashWithSalt salt t
-instance FromJSONKey T2 'JSONKeyCoerce where
-    fromJSONKey _ = ()
+instance FromJSON T2 where
+    parseJSON = withText "T2" $ pure . T2
+instance FromJSONKey T2 where
+    fromJSONKey = FromJSONKeyText T2
+
+-------------------------------------------------------------------------------
+-- TextParser
+-------------------------------------------------------------------------------
 
 newtype T3 = T3 T.Text
   deriving (Eq, Ord)
@@ -42,8 +60,14 @@ instance NFData T3 where
   rnf (T3 t) = rnf t
 instance Hashable T3 where
   hashWithSalt salt (T3 t) = hashWithSalt salt t
-instance FromJSONKey T3 'JSONKeyTextParser where
-    fromJSONKey _ = return . T3
+instance FromJSON T3 where
+    parseJSON = withText "T3" $ pure . T3
+instance FromJSONKey T3 where
+    fromJSONKey = FromJSONKeyTextParser (pure . T3)
+
+-------------------------------------------------------------------------------
+-- Values
+-------------------------------------------------------------------------------
 
 encodedValue10 :: LBS.ByteString
 encodedValue10 = encode $ value 10
@@ -57,59 +81,75 @@ encodedValue1000 = encode $ value 1000
 encodedValue10000 :: LBS.ByteString
 encodedValue10000 = encode $ value 10000
 
+-------------------------------------------------------------------------------
+-- Helpers
+-------------------------------------------------------------------------------
+
+decodeHM
+    :: (FromJSONKey k, Eq k, Hashable k)
+    => Proxy k -> LBS.ByteString -> Maybe (HM.HashMap k T.Text)
+decodeHM _ = decode
+
+decodeMap
+    :: (FromJSONKey k, Ord k)
+    => Proxy k -> LBS.ByteString -> Maybe (M.Map k T.Text)
+decodeMap _ = decode
+
+proxyText :: Proxy T.Text
+proxyText = Proxy
+
+proxyT1 :: Proxy T1
+proxyT1 = Proxy
+
+proxyT2 :: Proxy T2
+proxyT2 = Proxy
+
+proxyT3 :: Proxy T3
+proxyT3 = Proxy
+
+-------------------------------------------------------------------------------
+-- Main
+-------------------------------------------------------------------------------
+
+benchDecodeHM
+    :: String
+    -> LBS.ByteString
+    -> Benchmark
+benchDecodeHM name val = 
+    bgroup name
+        [  bench "Text"     $ nf (decodeHM proxyText) val
+        ,  bench "Identity" $ nf (decodeHM proxyT1)   val
+        ,  bench "Coerce"   $ nf (decodeHM proxyT2)   val
+        ,  bench "Parser"   $ nf (decodeHM proxyT3)   val
+        ]
+
+benchDecodeMap
+    :: String
+    -> LBS.ByteString
+    -> Benchmark
+benchDecodeMap name val = 
+    bgroup name
+        [  bench "Text"     $ nf (decodeMap proxyText) val
+        ,  bench "Identity" $ nf (decodeMap proxyT1)   val
+        ,  bench "Coerce"   $ nf (decodeMap proxyT2)   val
+        ,  bench "Parser"   $ nf (decodeMap proxyT3)   val
+        ]
+
 main :: IO ()
 main = do
   defaultMain
-    [ bgroup "HashMap"
-      [ bgroup "10"
-        [  bench "Text" $ nf (decode :: LBS.ByteString -> Maybe (HM.HashMap T.Text T.Text)) encodedValue10
-        ,  bench "Identity" $ nf (decode :: LBS.ByteString -> Maybe (HM.HashMap T1 T.Text)) encodedValue10
-        ,  bench "Coerce" $ nf (decode :: LBS.ByteString -> Maybe (HM.HashMap T2 T.Text)) encodedValue10
-        ,  bench "Parser" $ nf (decode :: LBS.ByteString -> Maybe (HM.HashMap T3 T.Text)) encodedValue10
+    [ bgroup "encode"
+      [ bgroup "HashMap"
+        [ benchDecodeHM "10"    encodedValue10
+        , benchDecodeHM "100"   encodedValue100
+        , benchDecodeHM "1000"  encodedValue1000
+        , benchDecodeHM "10000" encodedValue10000
         ]
-      , bgroup "100"
-        [  bench "Text" $ nf (decode :: LBS.ByteString -> Maybe (HM.HashMap T.Text T.Text)) encodedValue100
-        ,  bench "Identity" $ nf (decode :: LBS.ByteString -> Maybe (HM.HashMap T1 T.Text)) encodedValue100
-        ,  bench "Coerce" $ nf (decode :: LBS.ByteString -> Maybe (HM.HashMap T2 T.Text)) encodedValue100
-        ,  bench "Parser" $ nf (decode :: LBS.ByteString -> Maybe (HM.HashMap T3 T.Text)) encodedValue100
-        ]
-      , bgroup "1000"
-        [  bench "Text" $ nf (decode :: LBS.ByteString -> Maybe (HM.HashMap T.Text T.Text)) encodedValue1000
-        ,  bench "Identity" $ nf (decode :: LBS.ByteString -> Maybe (HM.HashMap T1 T.Text)) encodedValue1000
-        ,  bench "Coerce" $ nf (decode :: LBS.ByteString -> Maybe (HM.HashMap T2 T.Text)) encodedValue1000
-        ,  bench "Parser" $ nf (decode :: LBS.ByteString -> Maybe (HM.HashMap T3 T.Text)) encodedValue1000
-        ]
-      , bgroup "10000"
-        [  bench "Text" $ nf (decode :: LBS.ByteString -> Maybe (HM.HashMap T.Text T.Text)) encodedValue10000
-        ,  bench "Identity" $ nf (decode :: LBS.ByteString -> Maybe (HM.HashMap T1 T.Text)) encodedValue10000
-        ,  bench "Coerce" $ nf (decode :: LBS.ByteString -> Maybe (HM.HashMap T2 T.Text)) encodedValue10000
-        ,  bench "Parser" $ nf (decode :: LBS.ByteString -> Maybe (HM.HashMap T3 T.Text)) encodedValue10000
-        ]
-      ]
-    , bgroup "Map"
-      [ bgroup "10"
-        [  bench "Text" $ nf (decode :: LBS.ByteString -> Maybe (M.Map T.Text T.Text)) encodedValue10
-        ,  bench "Identity" $ nf (decode :: LBS.ByteString -> Maybe (M.Map T1 T.Text)) encodedValue10
-        ,  bench "Coerce" $ nf (decode :: LBS.ByteString -> Maybe (M.Map T2 T.Text)) encodedValue10
-        ,  bench "Parser" $ nf (decode :: LBS.ByteString -> Maybe (M.Map T3 T.Text)) encodedValue10
-        ]
-      , bgroup "100"
-        [  bench "Text" $ nf (decode :: LBS.ByteString -> Maybe (M.Map T.Text T.Text)) encodedValue100
-        ,  bench "Identity" $ nf (decode :: LBS.ByteString -> Maybe (M.Map T1 T.Text)) encodedValue100
-        ,  bench "Coerce" $ nf (decode :: LBS.ByteString -> Maybe (M.Map T2 T.Text)) encodedValue100
-        ,  bench "Parser" $ nf (decode :: LBS.ByteString -> Maybe (M.Map T3 T.Text)) encodedValue100
-        ]
-      , bgroup "1000"
-        [  bench "Text" $ nf (decode :: LBS.ByteString -> Maybe (M.Map T.Text T.Text)) encodedValue1000
-        ,  bench "Identity" $ nf (decode :: LBS.ByteString -> Maybe (M.Map T1 T.Text)) encodedValue1000
-        ,  bench "Coerce" $ nf (decode :: LBS.ByteString -> Maybe (M.Map T2 T.Text)) encodedValue1000
-        ,  bench "Parser" $ nf (decode :: LBS.ByteString -> Maybe (M.Map T3 T.Text)) encodedValue1000
-        ]
-      , bgroup "10000"
-        [  bench "Text" $ nf (decode :: LBS.ByteString -> Maybe (M.Map T.Text T.Text)) encodedValue10000
-        ,  bench "Identity" $ nf (decode :: LBS.ByteString -> Maybe (M.Map T1 T.Text)) encodedValue10000
-        ,  bench "Coerce" $ nf (decode :: LBS.ByteString -> Maybe (M.Map T2 T.Text)) encodedValue10000
-        ,  bench "Parser" $ nf (decode :: LBS.ByteString -> Maybe (M.Map T3 T.Text)) encodedValue10000
+      , bgroup "Map"
+        [ benchDecodeMap "10"    encodedValue10
+        , benchDecodeMap "100"   encodedValue100
+        , benchDecodeMap "1000"  encodedValue1000
+        , benchDecodeMap "10000" encodedValue10000
         ]
       ]
     ]

--- a/benchmarks/aeson-benchmarks.cabal
+++ b/benchmarks/aeson-benchmarks.cabal
@@ -52,6 +52,9 @@ library
     unordered-containers >= 0.2.3.0,
     vector >= 0.7.1
 
+  if impl(ghc >=7.8)
+    cpp-options: -DHAS_COERCIBLE
+
   if !impl(ghc >= 8.0)
     -- `Data.Semigroup` is available in base only since GHC 8.0 / base 4.9
     build-depends: semigroups >= 0.16.1 && < 0.19
@@ -162,3 +165,19 @@ executable aeson-benchmark-dates
     aeson-benchmarks,
     text,
     time
+
+executable aeson-benchmark-map
+  main-is: AesonMap.hs
+  ghc-options: -Wall -O2 -rtsopts
+  build-depends:
+    aeson-benchmarks,
+    base,
+    criterion >= 1.0,
+    bytestring,
+    containers,
+    deepseq,
+    hashable,
+    text,
+    transformers,
+    transformers-compat,
+    unordered-containers

--- a/benchmarks/aeson-benchmarks.cabal
+++ b/benchmarks/aeson-benchmarks.cabal
@@ -177,6 +177,7 @@ executable aeson-benchmark-map
     containers,
     deepseq,
     hashable,
+    tagged,
     text,
     transformers,
     transformers-compat,


### PR DESCRIPTION
Follow-up to https://github.com/bos/aeson/pull/393

- [Original](http://oleg.fi/aeson-bench/datakinds.html)
- [without coerce](http://oleg.fi/aeson-bench/without-coerce.html)
- [with coerce](http://oleg.fi/aeson-bench/with-coerce.html)

Looks like that alternative approach is as fast, and is simpler. Good job @andrewthad !
Coerce approach gives a little speedup, don't know if it's worth the safety (common case in our codebase though, where the keys are `newtypes` of `Text`).

Didn't add dependency on `contravariant.