### PR TITLE
Add encode/foldable benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 dist
 .cabal-sandbox/
 cabal.sandbox.config
+.stack-work/
 
 *.o
 *.hi

--- a/Data/Aeson/Encode/Functions.hs
+++ b/Data/Aeson/Encode/Functions.hs
@@ -21,8 +21,9 @@ import Data.Monoid ((<>))
 import qualified Data.ByteString.Builder as B
 import qualified Data.ByteString.Lazy as L
 
+import Data.Foldable (toList)
 #if !MIN_VERSION_base(4,8,0)
-import Data.Foldable (Foldable, foldMap)
+import Data.Foldable (Foldable)
 import Data.Monoid (mempty)
 #endif
 
@@ -39,7 +40,7 @@ encode = B.toLazyByteString . builder
 
 -- | Encode a 'Foldable' as a JSON array.
 foldable :: (Foldable t, ToJSON a) => t a -> Encoding
-foldable = brackets '[' ']' . foldMap (Value . toEncoding)
+foldable = list . toList
 {-# INLINE foldable #-}
 
 list :: (ToJSON a) => [a] -> Encoding

--- a/benchmarks/AesonFoldable.hs
+++ b/benchmarks/AesonFoldable.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE OverloadedStrings #-}
+import Criterion.Main
+import Data.Aeson
+import Data.Foldable (toList)
+
+import qualified Data.Sequence as S
+import qualified Data.Vector as V
+
+-------------------------------------------------------------------------------
+-- List
+-------------------------------------------------------------------------------
+
+newtype L f = L { getL :: f Int }
+
+instance Foldable f => ToJSON (L f) where
+    toJSON = error "do not use this"
+    toEncoding = toEncoding . toList . getL
+
+-------------------------------------------------------------------------------
+-- Foldable
+-------------------------------------------------------------------------------
+
+newtype F f = F { getF :: f Int }
+
+instance Foldable f => ToJSON (F f) where
+    toJSON = error "do not use this"
+    toEncoding = foldable . getF
+
+-------------------------------------------------------------------------------
+-- Values
+-------------------------------------------------------------------------------
+
+valueList :: [Int]
+valueList = [1..1000]
+
+valueSeq :: S.Seq Int
+valueSeq = S.fromList valueList
+
+valueVector :: V.Vector Int
+valueVector = V.fromList valueList
+
+-------------------------------------------------------------------------------
+-- Main
+-------------------------------------------------------------------------------
+
+benchEncode
+    :: ToJSON a
+    => String
+    -> a
+    -> Benchmark
+benchEncode name val
+    = bench name $ nf encode val
+
+main :: IO ()
+main =  defaultMain
+    [ bgroup "encode"
+        [ bgroup "List"
+            [ benchEncode "-"     valueList
+            , benchEncode "L" $ L valueList
+            , benchEncode "F" $ F valueList
+            ]
+        , bgroup "Seq"
+            [ benchEncode "-"     valueSeq
+            , benchEncode "L" $ L valueSeq
+            , benchEncode "F" $ F valueSeq
+            ]
+        , bgroup "Vector"
+            [ benchEncode "-"     valueVector
+            , benchEncode "L" $ L valueVector
+            , benchEncode "F" $ F valueVector
+            ]
+        ]
+    ]

--- a/benchmarks/aeson-benchmarks.cabal
+++ b/benchmarks/aeson-benchmarks.cabal
@@ -179,6 +179,20 @@ executable aeson-benchmark-map
     hashable,
     tagged,
     text,
-    transformers,
-    transformers-compat,
     unordered-containers
+
+executable aeson-benchmark-foldable
+  main-is: AesonFoldable.hs
+  ghc-options: -Wall -O2 -rtsopts
+  build-depends:
+    aeson-benchmarks,
+    base,
+    criterion >= 1.0,
+    bytestring,
+    containers,
+    deepseq,
+    hashable,
+    tagged,
+    text,
+    unordered-containers,
+    vector


### PR DESCRIPTION
Benchmark for https://github.com/bos/aeson/issues/402

<img width="969" alt="screen shot 2016-06-01 at 22 43 18" src="https://cloud.githubusercontent.com/assets/51087/15723311/861bcbec-284a-11e6-90dd-0ed8376f0da6.png">

Indeed, using `foldable` is suboptimal.