### PR TITLE
Remove upper bound on nats

### DIFF
--- a/aeson.cabal
+++ b/aeson.cabal
@@ -112,7 +112,7 @@ library
 
   if !impl(ghc >= 7.10)
     -- `Numeric.Natural` is available in base only since GHC 7.10 / base 4.8
-    build-depends: nats >=1 && <1.1
+    build-depends: nats >=1
 
   if flag(old-locale)
     build-depends: time < 1.5, old-locale
@@ -180,7 +180,7 @@ test-suite tests
     build-depends: time >= 1.5
 
   if !impl(ghc >= 7.10)
-    build-depends: nats >=1 && <1.1
+    build-depends: nats >=1
 
 source-repository head
   type:     git


### PR DESCRIPTION
This is for compatibility with nats-1.1.

Since nats has become a compatibility package, it seems highly
unlikely that it will introduce a breaking change.