### PR TITLE
Abstract `Encoding`

### DIFF
--- a/Data/Aeson/Encode.hs
+++ b/Data/Aeson/Encode.hs
@@ -28,16 +28,26 @@ module Data.Aeson.Encode
     ) where
 
 import Data.Aeson.Encode.Builder (encodeToBuilder)
-import Data.Aeson.Encode.Functions (encode)
-import Data.Aeson.Types (Value(..))
+import Data.Aeson.Types (Value(..), ToJSON (..))
+import Data.Aeson.Encoding (fromEncoding)
 import Data.Monoid ((<>))
 import Data.Scientific (FPFormat(..), Scientific, base10Exponent)
 import Data.Text.Lazy.Builder
 import Data.Text.Lazy.Builder.Scientific (formatScientificBuilder)
+
 import Numeric (showHex)
+import qualified Data.ByteString.Builder as B
 import qualified Data.HashMap.Strict as H
 import qualified Data.Text as T
 import qualified Data.Vector as V
+import qualified Data.ByteString.Lazy as L
+
+-- | Efficiently serialize a JSON value as a lazy 'L.ByteString'.
+--
+-- This is implemented in terms of the 'ToJSON' class's 'toEncoding' method.
+encode :: ToJSON a => a -> L.ByteString
+encode = B.toLazyByteString . fromEncoding . toEncoding
+{-# INLINE encode #-}
 
 -- | Encode a JSON 'Value' to a "Data.Text" 'Builder', which can be
 -- embedded efficiently in a text-based protocol.

--- a/Data/Aeson/Encode/Functions.hs
+++ b/Data/Aeson/Encode/Functions.hs
@@ -3,12 +3,11 @@
 module Data.Aeson.Encode.Functions
     (
       builder
-    , char7 -- TODO: used by TH module
     ) where
 
 import Data.Aeson.Encoding
 import Data.Aeson.Types.Class
-import Data.ByteString.Builder (Builder, char7)
+import Data.ByteString.Builder (Builder)
 import Data.Monoid ((<>))
 
 builder :: ToJSON a => a -> Builder

--- a/Data/Aeson/Encode/Functions.hs
+++ b/Data/Aeson/Encode/Functions.hs
@@ -2,22 +2,14 @@
 
 module Data.Aeson.Encode.Functions
     (
-      brackets
-    , builder
-    , builder'
-    , char7
+      builder
+    , char7 -- TODO: used by TH module
     , encode
-    , list
-    , encodeMap
-    , encodeWithKey
     ) where
 
-import Data.Aeson.Encode.Builder
+import Data.Aeson.Encoding
 import Data.Aeson.Types.Class
-import Data.Aeson.Types.Internal
 import Data.ByteString.Builder (Builder, char7)
-import Data.ByteString.Builder.Prim (primBounded)
-import Data.Foldable (toList)
 import Data.Monoid ((<>))
 import qualified Data.ByteString.Builder as B
 import qualified Data.ByteString.Lazy as L
@@ -27,16 +19,9 @@ import Data.Foldable (Foldable, foldMap)
 import Data.Monoid (mempty)
 #endif
 
-list :: (a -> Encoding) -> [a] -> Encoding
-list = listEncoding
-
 builder :: ToJSON a => a -> Builder
 builder = fromEncoding . toEncoding
 {-# INLINE builder #-}
-
-builder' :: (a -> Encoding) -> a -> Builder
-builder' f = fromEncoding . f
-{-# INLINE builder' #-}
 
 -- | Efficiently serialize a JSON value as a lazy 'L.ByteString'.
 --
@@ -44,36 +29,3 @@ builder' f = fromEncoding . f
 encode :: ToJSON a => a -> L.ByteString
 encode = B.toLazyByteString . builder
 {-# INLINE encode #-}
-
-brackets :: Char -> Char -> Series -> Encoding
-brackets begin end (Value v) = Encoding $
-                               char7 begin <> fromEncoding v <> char7 end
-brackets begin end Empty     = Encoding (primBounded (ascii2 (begin,end)) ())
-
-
-
-encodeMap :: (k -> Encoding)
-          -> (v -> Encoding)
-          -> (m -> Maybe ((k,v), m))
-          -> ((k -> v -> B.Builder -> B.Builder) -> B.Builder -> m -> B.Builder)
-          -> m -> Encoding
-encodeMap encodeKey encodeVal minViewWithKey foldrWithKey xs =
-    case minViewWithKey xs of
-      Nothing         -> Encoding $ primBounded (ascii2 ('{', '}')) ()
-      Just ((k,v),ys) -> Encoding $
-                         B.char7 '{' <> encodeKV encodeKey encodeVal k v <>
-                         foldrWithKey go (B.char7 '}') ys
-  where go k v b = B.char7 ',' <> encodeKV encodeKey encodeVal k v <> b
-{-# INLINE encodeMap #-}
-
-encodeWithKey :: (k -> Encoding)
-              -> (v -> Encoding)
-              -> ((k -> v -> Series -> Series) -> Series -> m -> Series)
-              -> m -> Encoding
-encodeWithKey encodeKey encodeVal foldrWithKey = brackets '{' '}' . foldrWithKey go mempty
-  where go k v c = Value (Encoding $ encodeKV encodeKey encodeVal k v) <> c
-{-# INLINE encodeWithKey #-}
-
-encodeKV :: (k -> Encoding) -> (v -> Encoding) -> k -> v -> B.Builder
-encodeKV encodeKey encodeVal k v = fromEncoding (encodeKey k) <> B.char7 ':' <> builder' encodeVal v
-{-# INLINE encodeKV #-}

--- a/Data/Aeson/Encode/Functions.hs
+++ b/Data/Aeson/Encode/Functions.hs
@@ -4,28 +4,13 @@ module Data.Aeson.Encode.Functions
     (
       builder
     , char7 -- TODO: used by TH module
-    , encode
     ) where
 
 import Data.Aeson.Encoding
 import Data.Aeson.Types.Class
 import Data.ByteString.Builder (Builder, char7)
 import Data.Monoid ((<>))
-import qualified Data.ByteString.Builder as B
-import qualified Data.ByteString.Lazy as L
-
-#if !MIN_VERSION_base(4,8,0)
-import Data.Foldable (Foldable, foldMap)
-import Data.Monoid (mempty)
-#endif
 
 builder :: ToJSON a => a -> Builder
 builder = fromEncoding . toEncoding
 {-# INLINE builder #-}
-
--- | Efficiently serialize a JSON value as a lazy 'L.ByteString'.
---
--- This is implemented in terms of the 'ToJSON' class's 'toEncoding' method.
-encode :: ToJSON a => a -> L.ByteString
-encode = B.toLazyByteString . builder
-{-# INLINE encode #-}

--- a/Data/Aeson/Encoding.hs
+++ b/Data/Aeson/Encoding.hs
@@ -1,165 +1,19 @@
-{-# LANGUAGE CPP, GeneralizedNewtypeDeriving, DeriveDataTypeable, RankNTypes #-}
 module Data.Aeson.Encoding
     (
     -- * Encoding
-      Encoding (..) -- TODO: export fromEncoding for now
+      Encoding
     , fromEncoding
     , unsafeToEncoding
-    , Series (..) -- TODO: don't export constructor
+    , Series
     , pairs
     -- * Predicates
     , nullEncoding
     -- * Encoding constructors
     , emptyArray_
     , emptyObject_
-    , wrapArray
-    , wrapObject
     , text
     , list
     , dict
-    , tuple
-    , (>*<)
-    -- ** chars
-    , comma, colon, openBracket, closeBracket, openCurly, closeCurly
     ) where
 
-#if !MIN_VERSION_base(4,8,0)
-import Data.Monoid (Monoid(..))
-#endif
-
-import Data.Text (Text)
-import Data.ByteString.Builder (Builder, char7, toLazyByteString)
-import Data.Semigroup (Semigroup((<>)))
-import Data.ByteString.Builder.Prim (primBounded)
-import Data.Typeable (Typeable)
-
-import qualified Data.ByteString.Lazy as BSL
-import qualified Data.Aeson.Encode.Builder as B
-
--- | An encoding of a JSON value.
-newtype Encoding = Encoding {
-      fromEncoding :: Builder
-      -- ^ Acquire the underlying bytestring builder.
-    } deriving (Semigroup,Monoid,Typeable)
-
--- | Make Encoding from Builder.
---
--- Use with care! You have to make sure that the passed Builder
--- is a valid JSON Encoding!
-unsafeToEncoding :: Builder -> Encoding
-unsafeToEncoding = Encoding
-
--------------------------------------------------------------------------------
--- Encoding instances
--------------------------------------------------------------------------------
-
-instance Show Encoding where
-    show (Encoding e) = show (toLazyByteString e)
-
-instance Eq Encoding where
-    Encoding a == Encoding b = toLazyByteString a == toLazyByteString b
-
-instance Ord Encoding where
-    compare (Encoding a) (Encoding b) =
-      compare (toLazyByteString a) (toLazyByteString b)
-
--- | A series of values that, when encoded, should be separated by
--- commas. Since 0.11.0.0, the '.=' operator is overloaded to create
--- either @(Text, Value)@ or 'Series'. You can use Series when
--- encoding directly to a bytestring builder as in the following
--- example:
---
--- > toEncoding (Person name age) = pairs ("name" .= name <> "age" .= age)
-data Series = Empty
-            | Value Encoding
-            deriving (Typeable)
-
-instance Semigroup Series where
-    Empty   <> a = a
-    Value a <> b =
-        Value $
-        a <> case b of
-               Empty   -> mempty
-               Value c -> Encoding (char7 ',') <> c
-
-instance Monoid Series where
-    mempty  = Empty
-    mappend = (<>)
-
-nullEncoding :: Encoding -> Bool
-nullEncoding = BSL.null . toLazyByteString . fromEncoding
-
-emptyArray_ :: Encoding
-emptyArray_ = Encoding B.emptyArray_
-
-emptyObject_ :: Encoding
-emptyObject_ = Encoding B.emptyObject_
-
-wrapArray :: Encoding -> Encoding
-wrapArray e = openBracket <> e <> closeBracket
-
-wrapObject :: Encoding -> Encoding
-wrapObject e = openCurly <> e <> closeCurly
-
--- | Encode a series of key/value pairs, separated by commas.
-pairs :: Series -> Encoding
-pairs = brackets '{' '}'
-{-# INLINE pairs #-}
-
-brackets :: Char -> Char -> Series -> Encoding
-brackets begin end (Value v) = Encoding $
-                               char7 begin <> fromEncoding v <> char7 end
-brackets begin end Empty     = Encoding (primBounded (B.ascii2 (begin,end)) ())
-
-list :: (a -> Encoding) -> [a] -> Encoding
-list _  []     = emptyArray_
-list to' (x:xs) = Encoding $
-    char7 '[' <> fromEncoding (to' x) <> commas xs <> char7 ']'
-  where
-    commas = foldr (\v vs -> char7 ',' <> fromEncoding (to' v) <> vs) mempty
-{-# INLINE list #-}
-
--- | Encode as JSON object
-dict
-    :: (k -> Encoding)                                -- ^ key encoding
-    -> (v -> Encoding)                                -- ^ value encoding
-    -> (forall a. (k -> v -> a -> a) -> a -> m -> a)  -- ^ @foldrWithKey@ - indexed fold
-    -> m                                              -- ^ container
-    -> Encoding
-dict encodeKey encodeVal foldrWithKey = brackets '{' '}' . foldrWithKey go mempty
-  where
-    go k v c = Value (encodeKV k v) <> c
-    encodeKV k v = encodeKey k <> Encoding (char7 ':') <> encodeVal v
-{-# INLINE dict #-}
-
-infixr 6 >*<
--- | See 'tuple'.
-(>*<) :: Encoding -> Encoding -> Encoding
-Encoding a >*< Encoding b = Encoding $ a <> char7 ',' <> b
-{-# INLINE (>*<) #-}
-
--- | Encode as a tuple.
---
--- @
--- toEncoding (X a b c) = tuple $
---     toEncoding a >*<
---     toEncoding b >*<
---     toEncoding c
-tuple :: Encoding -> Encoding
-tuple b = Encoding (char7 '[' <> fromEncoding b <> char7 ']')
-{-# INLINE tuple #-}
-
-text :: Text -> Encoding
-text = Encoding . B.text
-
--------------------------------------------------------------------------------
--- chars
--------------------------------------------------------------------------------
-
-comma, colon, openBracket, closeBracket, openCurly, closeCurly :: Encoding
-comma        = Encoding $ char7 ','
-colon        = Encoding $ char7 ':'
-openBracket  = Encoding $ char7 '['
-closeBracket = Encoding $ char7 ']'
-openCurly    = Encoding $ char7 '{'
-closeCurly   = Encoding $ char7 '}'
+import Data.Aeson.Encoding.Internal

--- a/Data/Aeson/Encoding.hs
+++ b/Data/Aeson/Encoding.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving, DeriveDataTypeable, RankNTypes #-}
+{-# LANGUAGE CPP, GeneralizedNewtypeDeriving, DeriveDataTypeable, RankNTypes #-}
 module Data.Aeson.Encoding
     (
     -- * Encoding
@@ -22,6 +22,10 @@ module Data.Aeson.Encoding
     -- ** chars
     , comma, colon, openBracket, closeBracket, openCurly, closeCurly
     ) where
+
+#if !MIN_VERSION_base(4,8,0)
+import Data.Monoid (Monoid(..))
+#endif
 
 import Data.Text (Text)
 import Data.ByteString.Builder (Builder, char7, toLazyByteString)

--- a/Data/Aeson/Encoding.hs
+++ b/Data/Aeson/Encoding.hs
@@ -10,12 +10,18 @@ module Data.Aeson.Encoding
     -- * Encoding constructors
     , emptyArray_
     , emptyObject_
+    , wrapArray
+    , wrapObject
+    , text
     , list
-    , dict 
+    , dict
     , tuple
     , (>*<)
+    -- ** chars
+    , comma, colon, openBracket, closeBracket, openCurly, closeCurly
     ) where
 
+import Data.Text (Text)
 import Data.ByteString.Builder (Builder, char7, toLazyByteString)
 import Data.Semigroup (Semigroup((<>)))
 import Data.ByteString.Builder.Prim (primBounded)
@@ -79,6 +85,12 @@ emptyArray_ = Encoding B.emptyArray_
 emptyObject_ :: Encoding
 emptyObject_ = Encoding B.emptyObject_
 
+wrapArray :: Encoding -> Encoding
+wrapArray e = openBracket <> e <> closeBracket
+
+wrapObject :: Encoding -> Encoding
+wrapObject e = openCurly <> e <> closeCurly
+
 -- | Encode a series of key/value pairs, separated by commas.
 pairs :: Series -> Encoding
 pairs = brackets '{' '}'
@@ -126,3 +138,18 @@ Encoding a >*< Encoding b = Encoding $ a <> char7 ',' <> b
 tuple :: Encoding -> Encoding
 tuple b = Encoding (char7 '[' <> fromEncoding b <> char7 ']')
 {-# INLINE tuple #-}
+
+text :: Text -> Encoding
+text = Encoding . B.text
+
+-------------------------------------------------------------------------------
+-- chars
+-------------------------------------------------------------------------------
+
+comma, colon, openBracket, closeBracket, openCurly, closeCurly :: Encoding
+comma        = Encoding $ char7 ','
+colon        = Encoding $ char7 ':'
+openBracket  = Encoding $ char7 '['
+closeBracket = Encoding $ char7 ']'
+openCurly    = Encoding $ char7 '{'
+closeCurly   = Encoding $ char7 '}'

--- a/Data/Aeson/Encoding.hs
+++ b/Data/Aeson/Encoding.hs
@@ -7,6 +7,8 @@ module Data.Aeson.Encoding
     , unsafeToEncoding
     , Series (..) -- TODO: don't export constructor
     , pairs
+    -- * Predicates
+    , nullEncoding
     -- * Encoding constructors
     , emptyArray_
     , emptyObject_
@@ -27,6 +29,7 @@ import Data.Semigroup (Semigroup((<>)))
 import Data.ByteString.Builder.Prim (primBounded)
 import Data.Typeable (Typeable)
 
+import qualified Data.ByteString.Lazy as BSL
 import qualified Data.Aeson.Encode.Builder as B
 
 -- | An encoding of a JSON value.
@@ -78,6 +81,9 @@ instance Semigroup Series where
 instance Monoid Series where
     mempty  = Empty
     mappend = (<>)
+
+nullEncoding :: Encoding -> Bool
+nullEncoding = BSL.null . toLazyByteString . fromEncoding
 
 emptyArray_ :: Encoding
 emptyArray_ = Encoding B.emptyArray_

--- a/Data/Aeson/Encoding.hs
+++ b/Data/Aeson/Encoding.hs
@@ -1,0 +1,128 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving, DeriveDataTypeable, RankNTypes #-}
+module Data.Aeson.Encoding
+    (
+    -- * Encoding
+      Encoding (..) -- TODO: export fromEncoding for now
+    , fromEncoding
+    , unsafeToEncoding
+    , Series (..) -- TODO: don't export constructor
+    , pairs
+    -- * Encoding constructors
+    , emptyArray_
+    , emptyObject_
+    , list
+    , dict 
+    , tuple
+    , (>*<)
+    ) where
+
+import Data.ByteString.Builder (Builder, char7, toLazyByteString)
+import Data.Semigroup (Semigroup((<>)))
+import Data.ByteString.Builder.Prim (primBounded)
+import Data.Typeable (Typeable)
+
+import qualified Data.Aeson.Encode.Builder as B
+
+-- | An encoding of a JSON value.
+newtype Encoding = Encoding {
+      fromEncoding :: Builder
+      -- ^ Acquire the underlying bytestring builder.
+    } deriving (Semigroup,Monoid,Typeable)
+
+-- | Make Encoding from Builder.
+--
+-- Use with care! You have to make sure that the passed Builder
+-- is a valid JSON Encoding!
+unsafeToEncoding :: Builder -> Encoding
+unsafeToEncoding = Encoding
+
+-------------------------------------------------------------------------------
+-- Encoding instances
+-------------------------------------------------------------------------------
+
+instance Show Encoding where
+    show (Encoding e) = show (toLazyByteString e)
+
+instance Eq Encoding where
+    Encoding a == Encoding b = toLazyByteString a == toLazyByteString b
+
+instance Ord Encoding where
+    compare (Encoding a) (Encoding b) =
+      compare (toLazyByteString a) (toLazyByteString b)
+
+-- | A series of values that, when encoded, should be separated by
+-- commas. Since 0.11.0.0, the '.=' operator is overloaded to create
+-- either @(Text, Value)@ or 'Series'. You can use Series when
+-- encoding directly to a bytestring builder as in the following
+-- example:
+--
+-- > toEncoding (Person name age) = pairs ("name" .= name <> "age" .= age)
+data Series = Empty
+            | Value Encoding
+            deriving (Typeable)
+
+instance Semigroup Series where
+    Empty   <> a = a
+    Value a <> b =
+        Value $
+        a <> case b of
+               Empty   -> mempty
+               Value c -> Encoding (char7 ',') <> c
+
+instance Monoid Series where
+    mempty  = Empty
+    mappend = (<>)
+
+emptyArray_ :: Encoding
+emptyArray_ = Encoding B.emptyArray_
+
+emptyObject_ :: Encoding
+emptyObject_ = Encoding B.emptyObject_
+
+-- | Encode a series of key/value pairs, separated by commas.
+pairs :: Series -> Encoding
+pairs = brackets '{' '}'
+{-# INLINE pairs #-}
+
+brackets :: Char -> Char -> Series -> Encoding
+brackets begin end (Value v) = Encoding $
+                               char7 begin <> fromEncoding v <> char7 end
+brackets begin end Empty     = Encoding (primBounded (B.ascii2 (begin,end)) ())
+
+list :: (a -> Encoding) -> [a] -> Encoding
+list _  []     = emptyArray_
+list to' (x:xs) = Encoding $
+    char7 '[' <> fromEncoding (to' x) <> commas xs <> char7 ']'
+  where
+    commas = foldr (\v vs -> char7 ',' <> fromEncoding (to' v) <> vs) mempty
+{-# INLINE list #-}
+
+-- | Encode as JSON object
+dict
+    :: (k -> Encoding)                                -- ^ key encoding
+    -> (v -> Encoding)                                -- ^ value encoding
+    -> (forall a. (k -> v -> a -> a) -> a -> m -> a)  -- ^ @foldrWithKey@ - indexed fold
+    -> m                                              -- ^ container
+    -> Encoding
+dict encodeKey encodeVal foldrWithKey = brackets '{' '}' . foldrWithKey go mempty
+  where
+    go k v c = Value (encodeKV k v) <> c
+    encodeKV k v = encodeKey k <> Encoding (char7 ':') <> encodeVal v
+{-# INLINE dict #-}
+
+infixr 6 >*<
+-- | See 'tuple'.
+(>*<) :: Encoding -> Encoding -> Encoding
+Encoding a >*< Encoding b = Encoding $ a <> char7 ',' <> b
+{-# INLINE (>*<) #-}
+
+-- | Encode as a tuple.
+--
+-- @
+-- toEncoding (X a b c) = tuple $
+--     toEncoding a >*<
+--     toEncoding b >*<
+--     toEncoding c
+tuple :: Encoding -> Encoding
+tuple b = Encoding (char7 '[' <> fromEncoding b <> char7 ']')
+{-# INLINE tuple #-}

--- a/Data/Aeson/Encoding/Internal.hs
+++ b/Data/Aeson/Encoding/Internal.hs
@@ -1,0 +1,166 @@
+{-# LANGUAGE CPP, GeneralizedNewtypeDeriving, DeriveDataTypeable, RankNTypes #-}
+module Data.Aeson.Encoding.Internal
+    (
+    -- * Encoding
+      Encoding (..) -- TODO: export fromEncoding for now
+    , fromEncoding
+    , unsafeToEncoding
+    , Series (..) -- TODO: don't export constructor
+    , pairs
+    -- * Predicates
+    , nullEncoding
+    -- * Encoding constructors
+    , emptyArray_
+    , emptyObject_
+    , wrapArray
+    , wrapObject
+    , text
+    , list
+    , dict
+    , tuple
+    , (>*<)
+    -- ** chars
+    , comma, colon, openBracket, closeBracket, openCurly, closeCurly
+    ) where
+
+#if !MIN_VERSION_base(4,8,0)
+import Data.Monoid (Monoid(..))
+#endif
+
+import Data.Text (Text)
+import Data.ByteString.Builder (Builder, char7, toLazyByteString)
+import Data.Semigroup (Semigroup((<>)))
+import Data.ByteString.Builder.Prim (primBounded)
+import Data.Typeable (Typeable)
+
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.Aeson.Encode.Builder as B
+
+-- | An encoding of a JSON value.
+newtype Encoding = Encoding {
+      fromEncoding :: Builder
+      -- ^ Acquire the underlying bytestring builder.
+    } deriving (Semigroup,Monoid,Typeable)
+
+-- | Make Encoding from Builder.
+--
+-- Use with care! You have to make sure that the passed Builder
+-- is a valid JSON Encoding!
+unsafeToEncoding :: Builder -> Encoding
+unsafeToEncoding = Encoding
+
+-------------------------------------------------------------------------------
+-- Encoding instances
+-------------------------------------------------------------------------------
+
+instance Show Encoding where
+    show (Encoding e) = show (toLazyByteString e)
+
+instance Eq Encoding where
+    Encoding a == Encoding b = toLazyByteString a == toLazyByteString b
+
+instance Ord Encoding where
+    compare (Encoding a) (Encoding b) =
+      compare (toLazyByteString a) (toLazyByteString b)
+
+-- | A series of values that, when encoded, should be separated by
+-- commas. Since 0.11.0.0, the '.=' operator is overloaded to create
+-- either @(Text, Value)@ or 'Series'. You can use Series when
+-- encoding directly to a bytestring builder as in the following
+-- example:
+--
+-- > toEncoding (Person name age) = pairs ("name" .= name <> "age" .= age)
+data Series = Empty
+            | Value Encoding
+            deriving (Typeable)
+
+instance Semigroup Series where
+    Empty   <> a = a
+    Value a <> b =
+        Value $
+        a <> case b of
+               Empty   -> mempty
+               Value c -> Encoding (char7 ',') <> c
+
+instance Monoid Series where
+    mempty  = Empty
+    mappend = (<>)
+
+nullEncoding :: Encoding -> Bool
+nullEncoding = BSL.null . toLazyByteString . fromEncoding
+
+emptyArray_ :: Encoding
+emptyArray_ = Encoding B.emptyArray_
+
+emptyObject_ :: Encoding
+emptyObject_ = Encoding B.emptyObject_
+
+wrapArray :: Encoding -> Encoding
+wrapArray e = openBracket <> e <> closeBracket
+
+wrapObject :: Encoding -> Encoding
+wrapObject e = openCurly <> e <> closeCurly
+
+-- | Encode a series of key/value pairs, separated by commas.
+pairs :: Series -> Encoding
+pairs = brackets '{' '}'
+{-# INLINE pairs #-}
+
+brackets :: Char -> Char -> Series -> Encoding
+brackets begin end (Value v) = Encoding $
+                               char7 begin <> fromEncoding v <> char7 end
+brackets begin end Empty     = Encoding (primBounded (B.ascii2 (begin,end)) ())
+
+list :: (a -> Encoding) -> [a] -> Encoding
+list _  []     = emptyArray_
+list to' (x:xs) = Encoding $
+    char7 '[' <> fromEncoding (to' x) <> commas xs <> char7 ']'
+  where
+    commas = foldr (\v vs -> char7 ',' <> fromEncoding (to' v) <> vs) mempty
+{-# INLINE list #-}
+
+-- | Encode as JSON object
+dict
+    :: (k -> Encoding)                                -- ^ key encoding
+    -> (v -> Encoding)                                -- ^ value encoding
+    -> (forall a. (k -> v -> a -> a) -> a -> m -> a)  -- ^ @foldrWithKey@ - indexed fold
+    -> m                                              -- ^ container
+    -> Encoding
+dict encodeKey encodeVal foldrWithKey = brackets '{' '}' . foldrWithKey go mempty
+  where
+    go k v c = Value (encodeKV k v) <> c
+    encodeKV k v = encodeKey k <> Encoding (char7 ':') <> encodeVal v
+{-# INLINE dict #-}
+
+infixr 6 >*<
+-- | See 'tuple'.
+(>*<) :: Encoding -> Encoding -> Encoding
+Encoding a >*< Encoding b = Encoding $ a <> char7 ',' <> b
+{-# INLINE (>*<) #-}
+
+-- | Encode as a tuple.
+--
+-- @
+-- toEncoding (X a b c) = tuple $
+--     toEncoding a >*<
+--     toEncoding b >*<
+--     toEncoding c
+tuple :: Encoding -> Encoding
+tuple b = Encoding (char7 '[' <> fromEncoding b <> char7 ']')
+{-# INLINE tuple #-}
+
+text :: Text -> Encoding
+text = Encoding . B.text
+
+-------------------------------------------------------------------------------
+-- chars
+-------------------------------------------------------------------------------
+
+comma, colon, openBracket, closeBracket, openCurly, closeCurly :: Encoding
+comma        = Encoding $ char7 ','
+colon        = Encoding $ char7 ':'
+openBracket  = Encoding $ char7 '['
+closeBracket = Encoding $ char7 ']'
+openCurly    = Encoding $ char7 '{'
+closeCurly   = Encoding $ char7 '}'
+

--- a/Data/Aeson/TH.hs
+++ b/Data/Aeson/TH.hs
@@ -140,7 +140,7 @@ import Prelude             ( head )
 import Text.Printf         ( printf )
 import Text.Show           ( show )
 import qualified Data.Aeson as A
-import qualified Data.Aeson.Encoding as E
+import qualified Data.Aeson.Encoding.Internal as E
 import qualified Data.HashMap.Strict as H ( lookup, toList )
 import qualified Data.Map as M ( fromList, findWithDefault )
 import qualified Data.Text as T ( Text, pack, unpack )

--- a/Data/Aeson/TH.hs
+++ b/Data/Aeson/TH.hs
@@ -108,7 +108,6 @@ import Data.Aeson.Types ( Value(..), Parser
                         , defaultTaggedObject
                         )
 import Data.Aeson.Types.Internal ((<?>), JSONPathElement(Key))
-import Data.Aeson.Encoding ( Encoding(..) )
 import Control.Monad       ( liftM2, return, mapM, fail )
 import Data.Bool           ( Bool(False, True), otherwise, (&&), not )
 import Data.Either         ( Either(Left, Right) )
@@ -141,8 +140,7 @@ import Prelude             ( head )
 import Text.Printf         ( printf )
 import Text.Show           ( show )
 import qualified Data.Aeson as A
-import qualified Data.Aeson.Encode.Builder as E
-import qualified Data.Aeson.Encode.Functions as E
+import qualified Data.Aeson.Encoding as E
 import qualified Data.HashMap.Strict as H ( lookup, toList )
 import qualified Data.Map as M ( fromList, findWithDefault )
 import qualified Data.Text as T ( Text, pack, unpack )
@@ -292,7 +290,7 @@ consToEncoding opts cons = do
     matches
         | allNullaryToStringTag opts && all isNullary cons =
               [ match (conP conName [])
-                (normalB $ [|Encoding|] `appE` encStr opts conName) []
+                (normalB $ encStr opts conName) []
               | con <- cons
               , let conName = getConName con
               ]
@@ -459,23 +457,23 @@ isMaybe _                            = False
 infixr 6 <^>
 
 (<:>) :: ExpQ -> ExpQ -> ExpQ
-(<:>) a b = a <^> [|E.char7 ':'|] <^> b
+(<:>) a b = a <^> [|E.colon|] <^> b
 infixr 5 <:>
 
 (<%>) :: ExpQ -> ExpQ -> ExpQ
-(<%>) a b = a <^> [|E.char7 ','|] <^> b
+(<%>) a b = a <^> [|E.comma|] <^> b
 infixr 4 <%>
 
 array :: ExpQ -> ExpQ
-array exp = [|Encoding|] `appE` ([|E.char7 '['|] <^> exp <^> [|E.char7 ']'|])
+array exp = [|E.wrapArray|] `appE` exp
 
 object :: ExpQ -> ExpQ
-object exp = [|Encoding|] `appE` ([|E.char7 '{'|] <^> exp <^> [|E.char7 '}'|])
+object exp = [|E.wrapObject|] `appE` exp 
 
 sumToEncoding :: Options -> Bool -> Name -> Q Exp -> Q Exp
 sumToEncoding opts multiCons conName exp
     | multiCons =
-        let fexp = [|fromEncoding|] `appE` exp in
+        let fexp = exp in
         case sumEncoding opts of
           TwoElemArray ->
             array (encStr opts conName <%> fexp)
@@ -515,7 +513,7 @@ argsToEncoding opts multiCons (NormalC conName ts) = do
             [e] -> return ([|toEncoding|] `appE` varE e)
             -- Multiple arguments are converted to a JSON array.
             es  ->
-              return (array (foldr1 (<%>) [[|E.builder|] `appE` varE x | x <- es]))
+              return (array (foldr1 (<%>) [[|toEncoding|] `appE` varE x | x <- es]))
     match (conP conName $ map varP args)
           (normalB $ sumToEncoding opts multiCons conName js)
           []
@@ -529,7 +527,7 @@ argsToEncoding opts multiCons (RecC conName ts) = case (unwrapUnaryRecords opts,
     let exp = object objBody
 
         objBody = [|mconcat|] `appE`
-                  ([|intersperse (E.char7 ',')|] `appE` pairs)
+                  ([|intersperse E.comma|] `appE` pairs)
         pairs | omitNothingFields opts = infixApp maybeFields
                                                   [|(<>)|]
                                                   restFields
@@ -547,16 +545,16 @@ argsToEncoding opts multiCons (RecC conName ts) = case (unwrapUnaryRecords opts,
             infixApp
               (infixApp
                 (infixE
-                  (Just $ toFieldName field <^> [|E.char7 ':'|])
+                  (Just $ toFieldName field <^> [|E.colon|])
                   [|(<>)|]
                   Nothing)
                 [|(.)|]
-                [|E.builder|])
+                [|toEncoding|])
               [|(<$>)|]
               (varE arg)
 
         toPair (arg, (field, _, _)) =
-          toFieldName field <:> [|E.builder|] `appE` varE arg
+          toFieldName field <:> [|toEncoding|] `appE` varE arg
 
         toFieldName field = [|E.text|] `appE`
                             ([|T.pack|] `appE` fieldLabelExp opts field)
@@ -566,13 +564,13 @@ argsToEncoding opts multiCons (RecC conName ts) = case (unwrapUnaryRecords opts,
           $ if multiCons
             then case sumEncoding opts of
                    TwoElemArray -> array $
-                     encStr opts conName <%> [|fromEncoding|] `appE` exp
+                     encStr opts conName <%>  exp
                    TaggedObject{tagFieldName} -> object $
                      ([|E.text (T.pack tagFieldName)|] <:>
                       encStr opts conName) <%>
                      objBody
                    ObjectWithSingleField -> object $
-                     encStr opts conName <:> [|fromEncoding|] `appE` exp
+                     encStr opts conName <:> exp
             else exp
           ) []
 

--- a/Data/Aeson/TH.hs
+++ b/Data/Aeson/TH.hs
@@ -107,7 +107,8 @@ import Data.Aeson.Types ( Value(..), Parser
                         , defaultOptions
                         , defaultTaggedObject
                         )
-import Data.Aeson.Types.Internal (Encoding(..), (<?>), JSONPathElement(Key))
+import Data.Aeson.Types.Internal ((<?>), JSONPathElement(Key))
+import Data.Aeson.Encoding ( Encoding(..) )
 import Control.Monad       ( liftM2, return, mapM, fail )
 import Data.Bool           ( Bool(False, True), otherwise, (&&), not )
 import Data.Either         ( Either(Left, Right) )

--- a/Data/Aeson/Types.hs
+++ b/Data/Aeson/Types.hs
@@ -97,16 +97,11 @@ module Data.Aeson.Types
 import Data.Aeson.Types.Generic ()
 import Data.Aeson.Types.Instances
 import Data.Aeson.Types.Internal
+import Data.Aeson.Encoding (Encoding, unsafeToEncoding, fromEncoding, Series, pairs)
 
 import Data.Foldable (Foldable, toList)
-import Data.Aeson.Encode.Functions (brackets)
 
 -- | Encode a 'Foldable' as a JSON array.
 foldable :: (Foldable t, ToJSON a) => t a -> Encoding
 foldable = toEncoding . toList
 {-# INLINE foldable #-}
-
--- | Encode a series of key/value pairs, separated by commas.
-pairs :: Series -> Encoding
-pairs = brackets '{' '}'
-{-# INLINE pairs #-}

--- a/Data/Aeson/Types/Class.hs
+++ b/Data/Aeson/Types/Class.hs
@@ -55,12 +55,12 @@ module Data.Aeson.Types.Class
     ) where
 
 import Data.Aeson.Types.Internal
+import Data.Aeson.Encoding.Internal (Encoding, Series)
 import Data.Monoid ((<>))
 import Data.Text (Text)
 import GHC.Generics (Generic, Rep, from, to)
-import Data.Aeson.Encoding (Encoding (..), Series (..), emptyArray_, list)
-import qualified Data.ByteString.Builder as B
-import qualified Data.Aeson.Encode.Builder as E
+import qualified Data.Aeson.Encoding.Internal as E
+import qualified Data.Aeson.Encode.Builder as EB
 import qualified Data.Vector as V
 
 #if !MIN_VERSION_base(4,8,0)
@@ -208,7 +208,7 @@ class ToJSON a where
     -- @
 
     toEncoding :: a -> Encoding
-    toEncoding = Encoding . E.encodeToBuilder . toJSON
+    toEncoding = E.Encoding . EB.encodeToBuilder . toJSON
     {-# INLINE toEncoding #-}
 
     toJSONList :: [a] -> Value
@@ -216,12 +216,7 @@ class ToJSON a where
     {-# INLINE toJSONList #-}
 
     toEncodingList :: [a] -> Encoding
-    toEncodingList [] = emptyArray_
-    toEncodingList (x:xs) = Encoding $
-        B.char7 '[' <> builder x <> commas xs <> B.char7 ']'
-      where
-        commas  = foldr (\v vs -> B.char7 ',' <> builder v <> vs) mempty
-        builder = fromEncoding . toEncoding
+    toEncodingList = listEncoding toEncoding
     {-# INLINE toEncodingList #-}
 
 -- | A type that can be converted from JSON, with the possibility of
@@ -326,10 +321,7 @@ class KeyValue kv where
     infixr 8 .=
 
 instance KeyValue Series where
-    name .= value = Value . Encoding $
-                    E.text name <> B.char7 ':' <> builder value
-      where
-        builder = fromEncoding . toEncoding
+    name .= value = E.Value $ E.text name <> E.colon <> toEncoding value
     {-# INLINE (.=) #-}
 
 instance KeyValue Pair where
@@ -536,7 +528,7 @@ toEncoding2 = liftToEncoding2 toEncoding toEncodingList toEncoding toEncodingLis
 -------------------------------------------------------------------------------
 
 listEncoding :: (a -> Encoding) -> [a] -> Encoding
-listEncoding = list
+listEncoding = E.list
 
 listValue :: (a -> Value) -> [a] -> Value
 listValue f = Array . V.fromList . map f

--- a/Data/Aeson/Types/Generic.hs
+++ b/Data/Aeson/Types/Generic.hs
@@ -24,9 +24,10 @@ module Data.Aeson.Types.Generic ( ) where
 import Control.Applicative ((<|>))
 import Control.Monad ((<=<))
 import Control.Monad.ST (ST)
-import Data.Aeson.Encode.Builder (emptyArray_)
+import Data.Aeson.Encoding (Encoding (..), emptyArray_)
 import Data.Aeson.Encode.Functions (builder)
 import Data.Aeson.Types.Instances
+import Data.Aeson.Encoding ((>*<), tuple)
 import Data.Aeson.Types.Internal
 import Data.Bits (unsafeShiftR)
 import Data.ByteString.Builder as B
@@ -299,8 +300,8 @@ instance (TwoElemArrayEnc a, TwoElemArrayEnc b) => TwoElemArrayEnc (a :+: b) whe
 instance ( GToEncoding a, ConsToEncoding a
          , Constructor c ) => TwoElemArrayEnc (C1 c a) where
     twoElemArrayEnc opts x = fromEncoding . tuple $
-      builder (constructorTagModifier opts (conName (undefined :: t c a p))) >*<
-      gbuilder opts x
+      toEncoding (constructorTagModifier opts (conName (undefined :: t c a p))) >*<
+      gToEncoding opts x
 
 --------------------------------------------------------------------------------
 

--- a/Data/Aeson/Types/Generic.hs
+++ b/Data/Aeson/Types/Generic.hs
@@ -24,14 +24,11 @@ module Data.Aeson.Types.Generic ( ) where
 import Control.Applicative ((<|>))
 import Control.Monad ((<=<))
 import Control.Monad.ST (ST)
-import Data.Aeson.Encoding (Encoding (..), emptyArray_)
-import Data.Aeson.Encode.Functions (builder)
+import Data.Aeson.Encoding (Encoding, (>*<))
+import qualified Data.Aeson.Encoding as E
 import Data.Aeson.Types.Instances
-import Data.Aeson.Encoding ((>*<), tuple)
 import Data.Aeson.Types.Internal
 import Data.Bits (unsafeShiftR)
-import Data.ByteString.Builder as B
-import qualified Data.ByteString.Lazy as BSL (null)
 import Data.DList (DList, toList, empty)
 import Data.Maybe (fromMaybe)
 import Data.Monoid ((<>))
@@ -102,28 +99,27 @@ instance (ToJSON a) => GToEncoding (K1 i a) where
 
 instance GToEncoding U1 where
     -- Empty constructors are encoded to an empty array:
-    gToEncoding _opts _ = emptyArray_
+    gToEncoding _opts _ = E.emptyArray_
 
 instance (ConsToEncoding a) => GToEncoding (C1 c a) where
     -- Constructors need to be encoded differently depending on whether they're
     -- a record or not. This distinction is made by 'consToEncoding':
-    gToEncoding opts = Encoding . consToEncoding opts . unM1
+    gToEncoding opts = consToEncoding opts . unM1
 
 instance ( EncodeProduct a, EncodeProduct b ) => GToEncoding (a :*: b) where
     -- Products are encoded to an array. Here we allocate a mutable vector of
     -- the same size as the product and write the product's elements to it using
     -- 'encodeProduct':
-    gToEncoding opts p = Encoding $
-                         B.char7 '[' <> encodeProduct opts p <> B.char7 ']'
+    gToEncoding opts p = E.tuple $ encodeProduct opts p
 
 instance ( AllNullary    (a :+: b) allNullary
          , SumToEncoding (a :+: b) allNullary ) => GToEncoding (a :+: b) where
     -- If all constructors of a sum datatype are nullary and the
     -- 'allNullaryToStringTag' option is set they are encoded to
     -- strings.  This distinction is made by 'sumToEncoding':
-    gToEncoding opts = Encoding .
-                       (unTagged :: Tagged allNullary B.Builder -> B.Builder) .
-                       sumToEncoding opts
+    gToEncoding opts
+        = (unTagged :: Tagged allNullary Encoding -> Encoding)
+        . sumToEncoding opts
 
 --------------------------------------------------------------------------------
 
@@ -158,14 +154,14 @@ nonAllNullarySumToJSON opts =
 --------------------------------------------------------------------------------
 
 class SumToEncoding f allNullary where
-    sumToEncoding :: Options -> f a -> Tagged allNullary B.Builder
+    sumToEncoding :: Options -> f a -> Tagged allNullary Encoding
 
 instance ( GetConName               f
          , TaggedObjectEnc          f
          , ObjectWithSingleFieldEnc f
          , TwoElemArrayEnc          f ) => SumToEncoding f True where
     sumToEncoding opts
-        | allNullaryToStringTag opts = Tagged . builder .
+        | allNullaryToStringTag opts = Tagged . toEncoding .
                                        constructorTagModifier opts . getConName
         | otherwise = Tagged . nonAllNullarySumToEncoding opts
 
@@ -177,7 +173,7 @@ instance ( TwoElemArrayEnc          f
 nonAllNullarySumToEncoding :: ( TwoElemArrayEnc          f
                               , TaggedObjectEnc          f
                               , ObjectWithSingleFieldEnc f
-                              ) => Options -> f a -> B.Builder
+                              ) => Options -> f a -> Encoding
 nonAllNullarySumToEncoding opts =
     case sumEncoding opts of
       TaggedObject{..}      ->
@@ -222,7 +218,7 @@ instance (GToJSON f) => TaggedObjectPairs' f False where
 --------------------------------------------------------------------------------
 
 class TaggedObjectEnc f where
-    taggedObjectEnc :: Options -> String -> String -> f a -> B.Builder
+    taggedObjectEnc :: Options -> String -> String -> f a -> Encoding
 
 instance ( TaggedObjectEnc a
          , TaggedObjectEnc b ) => TaggedObjectEnc (a :+: b) where
@@ -235,27 +231,27 @@ instance ( IsRecord         a isRecord
          , TaggedObjectEnc' a isRecord
          , Constructor c ) => TaggedObjectEnc (C1 c a) where
     taggedObjectEnc opts tagFieldName contentsFieldName v =
-        B.char7 '{' <>
-        (builder tagFieldName <>
-         B.char7 ':' <>
-         builder (constructorTagModifier opts (conName (undefined :: t c a p)))) <>
-        ((unTagged :: Tagged isRecord B.Builder -> B.Builder) .
+        E.openCurly <>
+        (toEncoding tagFieldName <>
+         E.colon <>
+         toEncoding (constructorTagModifier opts (conName (undefined :: t c a p)))) <>
+        ((unTagged :: Tagged isRecord Encoding -> Encoding) .
          taggedObjectEnc' opts contentsFieldName . unM1 $ v) <>
-        B.char7 '}'
+        E.closeCurly
 
 class TaggedObjectEnc' f isRecord where
-    taggedObjectEnc' :: Options -> String -> f a -> Tagged isRecord B.Builder
+    taggedObjectEnc' :: Options -> String -> f a -> Tagged isRecord Encoding
 
 instance OVERLAPPING_ TaggedObjectEnc' U1 False where
     taggedObjectEnc' _ _ _ = Tagged mempty
 
 instance (RecordToEncoding f) => TaggedObjectEnc' f True where
-    taggedObjectEnc' opts _ = Tagged . (B.char7 ',' <>) . fst . recordToEncoding opts
+    taggedObjectEnc' opts _ = Tagged . (E.comma <>) . fst . recordToEncoding opts
 
 instance (GToEncoding f) => TaggedObjectEnc' f False where
     taggedObjectEnc' opts contentsFieldName =
-        Tagged . (\z -> B.char7 ',' <> builder contentsFieldName <> B.char7 ':' <> z) .
-        gbuilder opts
+        Tagged . (\z -> E.comma <> toEncoding contentsFieldName <> E.colon <> z) .
+        gToEncoding opts
 
 --------------------------------------------------------------------------------
 
@@ -291,7 +287,7 @@ instance ( GToJSON a, ConsToJSON a
 --------------------------------------------------------------------------------
 
 class TwoElemArrayEnc f where
-    twoElemArrayEnc :: Options -> f a -> B.Builder
+    twoElemArrayEnc :: Options -> f a -> Encoding
 
 instance (TwoElemArrayEnc a, TwoElemArrayEnc b) => TwoElemArrayEnc (a :+: b) where
     twoElemArrayEnc opts (L1 x) = twoElemArrayEnc opts x
@@ -299,7 +295,7 @@ instance (TwoElemArrayEnc a, TwoElemArrayEnc b) => TwoElemArrayEnc (a :+: b) whe
 
 instance ( GToEncoding a, ConsToEncoding a
          , Constructor c ) => TwoElemArrayEnc (C1 c a) where
-    twoElemArrayEnc opts x = fromEncoding . tuple $
+    twoElemArrayEnc opts x = E.tuple $
       toEncoding (constructorTagModifier opts (conName (undefined :: t c a p))) >*<
       gToEncoding opts x
 
@@ -330,15 +326,15 @@ instance GToJSON f => ConsToJSON' f False where
 --------------------------------------------------------------------------------
 
 class ConsToEncoding f where
-    consToEncoding :: Options -> f a -> B.Builder
+    consToEncoding :: Options -> f a -> Encoding
 
 class ConsToEncoding' f isRecord where
     consToEncoding' :: Options -> Bool -- ^ Are we a record with one field?
-                    -> f a -> Tagged isRecord B.Builder
+                    -> f a -> Tagged isRecord Encoding 
 
 instance ( IsRecord        f isRecord
          , ConsToEncoding' f isRecord ) => ConsToEncoding f where
-    consToEncoding opts = (unTagged :: Tagged isRecord B.Builder -> B.Builder)
+    consToEncoding opts = (unTagged :: Tagged isRecord Encoding -> Encoding)
                           . consToEncoding' opts (isUnary (undefined :: f a))
 
 instance (RecordToEncoding f) => ConsToEncoding' f True where
@@ -346,10 +342,10 @@ instance (RecordToEncoding f) => ConsToEncoding' f True where
       let (enc, mbVal) = recordToEncoding opts x
       in case (unwrapUnaryRecords opts, isUn, mbVal) of
            (True, True, Just val) -> Tagged val
-           _ -> Tagged $ B.char7 '{' <> enc <> B.char7 '}'
+           _ -> Tagged $ E.wrapObject enc 
 
 instance GToEncoding f => ConsToEncoding' f False where
-    consToEncoding' opts _ = Tagged . gbuilder opts
+    consToEncoding' opts _ = Tagged . gToEncoding opts
 
 --------------------------------------------------------------------------------
 
@@ -380,16 +376,16 @@ class RecordToEncoding f where
     -- 1st element: whole thing
     -- 2nd element: in case the record has only 1 field, just the value
     --              of the field (without the key); 'Nothing' otherwise
-    recordToEncoding :: Options -> f a -> (B.Builder, Maybe B.Builder)
+    recordToEncoding :: Options -> f a -> (Encoding, Maybe Encoding)
 
 instance (RecordToEncoding a, RecordToEncoding b) => RecordToEncoding (a :*: b) where
     recordToEncoding opts (a :*: b) | omitNothingFields opts =
-      (mconcat $ intersperse (B.char7 ',') $
-        filter (not . BSL.null . B.toLazyByteString)
+      (mconcat $ intersperse E.comma $
+        filter (not . E.nullEncoding)
         [fst (recordToEncoding opts a), fst (recordToEncoding opts b)]
       , Nothing)
     recordToEncoding opts (a :*: b) =
-      (fst (recordToEncoding opts a) <> B.char7 ',' <>
+      (fst (recordToEncoding opts a) <> E.comma <>
        fst (recordToEncoding opts b),
        Nothing)
 
@@ -402,11 +398,11 @@ instance OVERLAPPING_ (Selector s, ToJSON a) =>
                                   , K1 Nothing <- k1 = (mempty, Nothing)
     recordToEncoding opts m1 = fieldToEncoding opts m1
 
-fieldToEncoding :: (Selector s, GToEncoding a) => Options -> S1 s a p -> (B.Builder, Maybe B.Builder)
+fieldToEncoding :: (Selector s, GToEncoding a) => Options -> S1 s a p -> (Encoding, Maybe Encoding)
 fieldToEncoding opts m1 =
-  let keyBuilder = builder (fieldLabelModifier opts $ selName m1)
-      valueBuilder = gbuilder opts (unM1 m1)
-  in  (keyBuilder <> B.char7 ':' <> valueBuilder, Just valueBuilder)
+  let keyBuilder = toEncoding (fieldLabelModifier opts $ selName m1)
+      valueBuilder = gToEncoding opts (unM1 m1)
+  in  (keyBuilder <> E.colon <> valueBuilder, Just valueBuilder)
 
 --------------------------------------------------------------------------------
 
@@ -434,20 +430,20 @@ instance OVERLAPPABLE_ (GToJSON a) => WriteProduct a where
 --------------------------------------------------------------------------------
 
 class EncodeProduct f where
-    encodeProduct :: Options -> f a -> B.Builder
+    encodeProduct :: Options -> f a -> Encoding 
 
 instance ( EncodeProduct a
          , EncodeProduct b ) => EncodeProduct (a :*: b) where
     encodeProduct opts (a :*: b) | omitNothingFields opts =
-        mconcat $ intersperse (B.char7 ',') $
-        filter (not . BSL.null . B.toLazyByteString)
+        mconcat $ intersperse E.comma $
+        filter (not . E.nullEncoding)
         [encodeProduct opts a, encodeProduct opts b]
     encodeProduct opts (a :*: b) = encodeProduct opts a <>
-                                   B.char7 ',' <>
+                                   E.comma <>
                                    encodeProduct opts b
 
 instance OVERLAPPABLE_ (GToEncoding a) => EncodeProduct a where
-    encodeProduct opts = gbuilder opts
+    encodeProduct opts = gToEncoding opts
 
 --------------------------------------------------------------------------------
 
@@ -469,7 +465,7 @@ instance ( GToJSON a, ConsToJSON a
 --------------------------------------------------------------------------------
 
 class ObjectWithSingleFieldEnc f where
-    objectWithSingleFieldEnc :: Options -> f a -> B.Builder
+    objectWithSingleFieldEnc :: Options -> f a -> Encoding
 
 instance ( ObjectWithSingleFieldEnc a
          , ObjectWithSingleFieldEnc b ) => ObjectWithSingleFieldEnc (a :+: b) where
@@ -479,15 +475,13 @@ instance ( ObjectWithSingleFieldEnc a
 instance ( GToEncoding a, ConsToEncoding a
          , Constructor c ) => ObjectWithSingleFieldEnc (C1 c a) where
     objectWithSingleFieldEnc opts v =
-      B.char7 '{' <>
-      builder (constructorTagModifier opts
-               (conName (undefined :: t c a p))) <>
-      B.char7 ':' <>
-      gbuilder opts v <>
-      B.char7 '}'
-
-gbuilder :: GToEncoding f => Options -> f a -> Builder
-gbuilder opts = fromEncoding . gToEncoding opts
+      E.openCurly <>
+      toEncoding
+          (constructorTagModifier opts
+          (conName (undefined :: t c a p))) <>
+      E.colon <>
+      gToEncoding opts v <>
+      E.closeCurly
 
 --------------------------------------------------------------------------------
 -- Generic parseJSON

--- a/Data/Aeson/Types/Generic.hs
+++ b/Data/Aeson/Types/Generic.hs
@@ -24,8 +24,8 @@ module Data.Aeson.Types.Generic ( ) where
 import Control.Applicative ((<|>))
 import Control.Monad ((<=<))
 import Control.Monad.ST (ST)
-import Data.Aeson.Encoding (Encoding, (>*<))
-import qualified Data.Aeson.Encoding as E
+import Data.Aeson.Encoding.Internal (Encoding, (>*<))
+import qualified Data.Aeson.Encoding.Internal as E
 import Data.Aeson.Types.Instances
 import Data.Aeson.Types.Internal
 import Data.Bits (unsafeShiftR)

--- a/Data/Aeson/Types/Instances.hs
+++ b/Data/Aeson/Types/Instances.hs
@@ -120,7 +120,7 @@ import Text.ParserCombinators.ReadP (readP_to_S)
 import Foreign.Storable (Storable)
 import Numeric.Natural (Natural)
 import Prelude hiding (foldr)
-import qualified Data.Aeson.Encode.Builder as E
+import qualified Data.Aeson.Encode.Builder as EB
 import qualified Data.Aeson.Parser.Time as Time
 import qualified Data.ByteString.Builder as B
 import qualified Data.ByteString.Lazy as L
@@ -201,7 +201,7 @@ realFloatToJSON d
 
 realFloatToEncoding :: RealFloat a => a -> Encoding
 realFloatToEncoding d
-    | isNaN d || isInfinite d = Encoding E.null_
+    | isNaN d || isInfinite d = Encoding EB.null_
     | otherwise               = toEncoding (Scientific.fromFloatDigits d)
 {-# INLINE realFloatToEncoding #-}
 
@@ -291,7 +291,7 @@ instance ToJSON1 Maybe where
     {-# INLINE liftToJSON #-}
 
     liftToEncoding to _ (Just a) = to a
-    liftToEncoding _  _ Nothing  = Encoding E.null_
+    liftToEncoding _  _ Nothing  = Encoding EB.null_
     {-# INLINE liftToEncoding #-}
 
 instance (ToJSON a) => ToJSON (Maybe a) where
@@ -369,7 +369,7 @@ instance ToJSON Bool where
     toJSON = Bool
     {-# INLINE toJSON #-}
 
-    toEncoding = Encoding . E.bool
+    toEncoding = Encoding . EB.bool
     {-# INLINE toEncoding #-}
 
 instance FromJSON Bool where
@@ -415,10 +415,10 @@ instance ToJSON Char where
     toJSONList = String . T.pack
     {-# INLINE toJSONList #-}
 
-    toEncoding = Encoding . E.string . (:[])
+    toEncoding = Encoding . EB.string . (:[])
     {-# INLINE toEncoding #-}
 
-    toEncodingList = Encoding . E.string
+    toEncodingList = Encoding . EB.string
     {-# INLINE toEncodingList #-}
 
 instance FromJSON Char where
@@ -490,7 +490,7 @@ instance HasResolution a => ToJSON (Fixed a) where
     toJSON = Number . realToFrac
     {-# INLINE toJSON #-}
 
-    toEncoding = Encoding . E.number . realToFrac
+    toEncoding = Encoding . EB.number . realToFrac
     {-# INLINE toEncoding #-}
 
 -- | /WARNING:/ Only parse fixed-precision numbers from trusted input
@@ -643,7 +643,7 @@ instance ToJSON Text where
     toJSON = String
     {-# INLINE toJSON #-}
 
-    toEncoding = Encoding . E.text
+    toEncoding = Encoding . EB.text
     {-# INLINE toEncoding #-}
 
 instance FromJSON Text where
@@ -656,7 +656,7 @@ instance ToJSON LT.Text where
 
     toEncoding t = Encoding $
       B.char7 '"' <>
-      LT.foldrChunks (\x xs -> E.unquoted x <> xs) (B.char7 '"') t
+      LT.foldrChunks (\x xs -> EB.unquoted x <> xs) (B.char7 '"') t
     {-# INLINE toEncoding #-}
 
 instance FromJSON LT.Text where
@@ -716,7 +716,7 @@ instance ToJSON Scientific where
     toJSON = Number
     {-# INLINE toJSON #-}
 
-    toEncoding = Encoding . E.number
+    toEncoding = Encoding . EB.number
     {-# INLINE toEncoding #-}
 
 instance FromJSON Scientific where
@@ -1047,7 +1047,7 @@ instance ToJSON Value where
     toJSON a = a
     {-# INLINE toJSON #-}
 
-    toEncoding = Encoding . E.encodeToBuilder
+    toEncoding = Encoding . EB.encodeToBuilder
     {-# INLINE toEncoding #-}
 
 instance FromJSON Value where
@@ -1078,21 +1078,21 @@ instance FromJSON DotNetTime where
 
 instance ToJSON Day where
     toJSON       = stringEncoding
-    toEncoding z = Encoding (E.quote $ E.day z)
+    toEncoding z = Encoding (EB.quote $ EB.day z)
 
 instance FromJSON Day where
     parseJSON = withText "Day" (Time.run Time.day)
 
 instance ToJSON TimeOfDay where
     toJSON       = stringEncoding
-    toEncoding z = Encoding (E.quote $ E.timeOfDay z)
+    toEncoding z = Encoding (EB.quote $ EB.timeOfDay z)
 
 instance FromJSON TimeOfDay where
     parseJSON = withText "TimeOfDay" (Time.run Time.timeOfDay)
 
 instance ToJSON LocalTime where
     toJSON       = stringEncoding
-    toEncoding z = Encoding (E.quote $ E.localTime z)
+    toEncoding z = Encoding (EB.quote $ EB.localTime z)
 
 instance FromJSON LocalTime where
     parseJSON = withText "LocalTime" (Time.run Time.localTime)
@@ -1100,7 +1100,7 @@ instance FromJSON LocalTime where
 instance ToJSON ZonedTime where
     toJSON = stringEncoding
 
-    toEncoding z = Encoding (E.quote $ E.zonedTime z)
+    toEncoding z = Encoding (EB.quote $ EB.zonedTime z)
 
 formatMillis :: (FormatTime t) => t -> String
 formatMillis = take 3 . formatTime defaultTimeLocale "%q"
@@ -1111,7 +1111,7 @@ instance FromJSON ZonedTime where
 instance ToJSON UTCTime where
     toJSON = stringEncoding
 
-    toEncoding t = Encoding (E.quote $ E.utcTime t)
+    toEncoding t = Encoding (EB.quote $ EB.utcTime t)
 
 -- | Encode something to a JSON string.
 --
@@ -1133,7 +1133,7 @@ instance ToJSON NominalDiffTime where
     toJSON = Number . realToFrac
     {-# INLINE toJSON #-}
 
-    toEncoding = Encoding . E.number . realToFrac
+    toEncoding = Encoding . EB.number . realToFrac
     {-# INLINE toEncoding #-}
 
 -- | /WARNING:/ Only parse lengths of time from trusted input
@@ -1224,7 +1224,7 @@ instance ToJSON (Proxy a) where
     toJSON _ = Null
     {-# INLINE toJSON #-}
 
-    toEncoding _ = Encoding E.null_
+    toEncoding _ = Encoding EB.null_
     {-# INLINE toEncoding #-}
 
 instance FromJSON (Proxy a) where

--- a/Data/Aeson/Types/Instances.hs
+++ b/Data/Aeson/Types/Instances.hs
@@ -87,7 +87,7 @@ module Data.Aeson.Types.Instances
 
 import Data.Aeson.Types.Instances.Tuple ()
 
-import Data.Aeson.Encoding (Encoding (..), emptyArray_, dict, tuple, (>*<))
+import Data.Aeson.Encoding.Internal (Encoding (..), emptyArray_, dict, tuple, (>*<))
 
 import Control.Applicative (Const(..))
 import Data.Aeson.Encode.Functions (builder)

--- a/Data/Aeson/Types/Instances.hs
+++ b/Data/Aeson/Types/Instances.hs
@@ -90,7 +90,7 @@ import Data.Aeson.Types.Instances.Tuple ()
 import Data.Aeson.Encoding (Encoding (..), emptyArray_, dict, tuple, (>*<))
 
 import Control.Applicative (Const(..))
-import Data.Aeson.Encode.Functions (builder, encode)
+import Data.Aeson.Encode.Functions (builder)
 import Data.Aeson.Functions (mapHashKeyVal, mapKey, mapKeyVal)
 import Data.Aeson.Types.Class
 import Data.Aeson.Types.Internal
@@ -1114,8 +1114,16 @@ instance ToJSON UTCTime where
     toEncoding t = Encoding (E.quote $ E.utcTime t)
 
 -- | Encode something to a JSON string.
+--
+-- TODO: remove me, this is a hack
 stringEncoding :: (ToJSON a) => a -> Value
-stringEncoding = String . T.dropAround (== '"') . T.decodeLatin1 . L.toStrict . encode
+stringEncoding = String
+    . T.dropAround (== '"')
+    . T.decodeLatin1
+    . L.toStrict
+    . B.toLazyByteString
+    . fromEncoding
+    . toEncoding 
 {-# INLINE stringEncoding #-}
 
 instance FromJSON UTCTime where

--- a/Data/Aeson/Types/Instances/Tuple.hs
+++ b/Data/Aeson/Types/Instances/Tuple.hs
@@ -10,16 +10,15 @@
 -- Portability: portable
 --
 -- Tuple instances
-module Data.Aeson.Types.Instances.Tuple (tuple, (>*<)) where
+module Data.Aeson.Types.Instances.Tuple () where
 
-import Data.Aeson.Encode.Functions (builder)
+import Data.Aeson.Encoding (tuple, (>*<))
 import Data.Aeson.Types.Class
 import Data.Aeson.Types.Internal
 import Data.Monoid ((<>))
 
 import qualified Data.Vector as V
 import qualified Data.Vector.Mutable as VM (unsafeNew, unsafeWrite)
-import qualified Data.ByteString.Builder as B
 
 #if MIN_VERSION_base(4,8,0)
 #else
@@ -28,15 +27,6 @@ import Control.Applicative ((<$>), (<*>))
 
 parseJSONElemAtIndex :: (Value -> Parser a) -> Int -> V.Vector Value -> Parser a
 parseJSONElemAtIndex p idx ary = p (V.unsafeIndex ary idx) <?> Index idx
-
-(>*<) :: B.Builder -> B.Builder -> B.Builder
-a >*< b = a <> B.char7 ',' <> b
-{-# INLINE (>*<) #-}
-infixr 6 >*<
-
-tuple :: B.Builder -> Encoding
-tuple b = Encoding (B.char7 '[' <> b <> B.char7 ']')
-{-# INLINE tuple #-}
 
 -- Local copy of withArray
 withArray :: String -> (Array -> Parser a) -> Value -> Parser a
@@ -57,8 +47,8 @@ instance ToJSON2 ((,) ) where
     {-# INLINE liftToJSON2 #-}
 
     liftToEncoding2 toA _ toB _ (a, b) = tuple $
-        fromEncoding (toA a) >*<
-        fromEncoding (toB b)
+        toA a >*<
+        toB b
     {-# INLINE liftToEncoding2 #-}
 
 instance (ToJSON a) => ToJSON1 ((,) a) where
@@ -102,9 +92,9 @@ instance (ToJSON a) => ToJSON2 ((,,) a) where
     {-# INLINE liftToJSON2 #-}
 
     liftToEncoding2 toB _ toC _ (a, b, c) = tuple $
-        builder a >*<
-        fromEncoding (toB b) >*<
-        fromEncoding (toC c)
+        toEncoding a >*<
+        toB b >*<
+        toC c
     {-# INLINE liftToEncoding2 #-}
 
 instance (ToJSON a, ToJSON b) => ToJSON1 ((,,) a b) where
@@ -150,10 +140,10 @@ instance (ToJSON a, ToJSON b) => ToJSON2 ((,,,) a b) where
     {-# INLINE liftToJSON2 #-}
 
     liftToEncoding2 toC _ toD _ (a, b, c, d) = tuple $
-        builder a >*<
-        builder b >*<
-        fromEncoding (toC c) >*<
-        fromEncoding (toD d)
+        toEncoding a >*<
+        toEncoding b >*<
+        toC c >*<
+        toD d
     {-# INLINE liftToEncoding2 #-}
 
 instance (ToJSON a, ToJSON b, ToJSON c) => ToJSON1 ((,,,) a b c) where
@@ -201,11 +191,11 @@ instance (ToJSON a, ToJSON b, ToJSON c) => ToJSON2 ((,,,,) a b c) where
     {-# INLINE liftToJSON2 #-}
 
     liftToEncoding2 toD _ toE _ (a, b, c, d, e) = tuple $
-        builder a >*<
-        builder b >*<
-        builder c >*<
-        fromEncoding (toD d) >*<
-        fromEncoding (toE e)
+        toEncoding a >*<
+        toEncoding b >*<
+        toEncoding c >*<
+        toD d >*<
+        toE e
     {-# INLINE liftToEncoding2 #-}
 
 instance (ToJSON a, ToJSON b, ToJSON c, ToJSON d) => ToJSON1 ((,,,,) a b c d) where
@@ -255,12 +245,12 @@ instance (ToJSON a, ToJSON b, ToJSON c, ToJSON d) => ToJSON2 ((,,,,,) a b c d) w
     {-# INLINE liftToJSON2 #-}
 
     liftToEncoding2 toE _ toF _ (a, b, c, d, e, f) = tuple $
-        builder a >*<
-        builder b >*<
-        builder c >*<
-        builder d >*<
-        fromEncoding (toE e) >*<
-        fromEncoding (toF f)
+        toEncoding a >*<
+        toEncoding b >*<
+        toEncoding c >*<
+        toEncoding d >*<
+        toE e >*<
+        toF f
     {-# INLINE liftToEncoding2 #-}
 
 instance (ToJSON a, ToJSON b, ToJSON c, ToJSON d, ToJSON e) => ToJSON1 ((,,,,,) a b c d e) where
@@ -312,13 +302,13 @@ instance (ToJSON a, ToJSON b, ToJSON c, ToJSON d, ToJSON e) => ToJSON2 ((,,,,,,)
     {-# INLINE liftToJSON2 #-}
 
     liftToEncoding2 toF _ toG _ (a, b, c, d, e, f, g) = tuple $
-        builder a >*<
-        builder b >*<
-        builder c >*<
-        builder d >*<
-        builder e >*<
-        fromEncoding (toF f) >*<
-        fromEncoding (toG g)
+        toEncoding a >*<
+        toEncoding b >*<
+        toEncoding c >*<
+        toEncoding d >*<
+        toEncoding e >*<
+        toF f >*<
+        toG g
     {-# INLINE liftToEncoding2 #-}
 
 instance (ToJSON a, ToJSON b, ToJSON c, ToJSON d, ToJSON e, ToJSON f) => ToJSON1 ((,,,,,,) a b c d e f) where
@@ -372,14 +362,14 @@ instance (ToJSON a, ToJSON b, ToJSON c, ToJSON d, ToJSON e, ToJSON f) => ToJSON2
     {-# INLINE liftToJSON2 #-}
 
     liftToEncoding2 toG _ toH _ (a, b, c, d, e, f, g, h) = tuple $
-        builder a >*<
-        builder b >*<
-        builder c >*<
-        builder d >*<
-        builder e >*<
-        builder f >*<
-        fromEncoding (toG g) >*<
-        fromEncoding (toH h)
+        toEncoding a >*<
+        toEncoding b >*<
+        toEncoding c >*<
+        toEncoding d >*<
+        toEncoding e >*<
+        toEncoding f >*<
+        toG g >*<
+        toH h
     {-# INLINE liftToEncoding2 #-}
 
 instance (ToJSON a, ToJSON b, ToJSON c, ToJSON d, ToJSON e, ToJSON f, ToJSON g) => ToJSON1 ((,,,,,,,) a b c d e f g) where
@@ -435,15 +425,15 @@ instance (ToJSON a, ToJSON b, ToJSON c, ToJSON d, ToJSON e, ToJSON f, ToJSON g) 
     {-# INLINE liftToJSON2 #-}
 
     liftToEncoding2 toH _ toI _ (a, b, c, d, e, f, g, h, i) = tuple $
-        builder a >*<
-        builder b >*<
-        builder c >*<
-        builder d >*<
-        builder e >*<
-        builder f >*<
-        builder g >*<
-        fromEncoding (toH h) >*<
-        fromEncoding (toI i)
+        toEncoding a >*<
+        toEncoding b >*<
+        toEncoding c >*<
+        toEncoding d >*<
+        toEncoding e >*<
+        toEncoding f >*<
+        toEncoding g >*<
+        toH h >*<
+        toI i
     {-# INLINE liftToEncoding2 #-}
 
 instance (ToJSON a, ToJSON b, ToJSON c, ToJSON d, ToJSON e, ToJSON f, ToJSON g, ToJSON h) => ToJSON1 ((,,,,,,,,) a b c d e f g h) where
@@ -501,16 +491,16 @@ instance (ToJSON a, ToJSON b, ToJSON c, ToJSON d, ToJSON e, ToJSON f, ToJSON g, 
     {-# INLINE liftToJSON2 #-}
 
     liftToEncoding2 toI _ toJ _ (a, b, c, d, e, f, g, h, i, j) = tuple $
-        builder a >*<
-        builder b >*<
-        builder c >*<
-        builder d >*<
-        builder e >*<
-        builder f >*<
-        builder g >*<
-        builder h >*<
-        fromEncoding (toI i) >*<
-        fromEncoding (toJ j)
+        toEncoding a >*<
+        toEncoding b >*<
+        toEncoding c >*<
+        toEncoding d >*<
+        toEncoding e >*<
+        toEncoding f >*<
+        toEncoding g >*<
+        toEncoding h >*<
+        toI i >*<
+        toJ j
     {-# INLINE liftToEncoding2 #-}
 
 instance (ToJSON a, ToJSON b, ToJSON c, ToJSON d, ToJSON e, ToJSON f, ToJSON g, ToJSON h, ToJSON i) => ToJSON1 ((,,,,,,,,,) a b c d e f g h i) where
@@ -570,17 +560,17 @@ instance (ToJSON a, ToJSON b, ToJSON c, ToJSON d, ToJSON e, ToJSON f, ToJSON g, 
     {-# INLINE liftToJSON2 #-}
 
     liftToEncoding2 toJ _ toK _ (a, b, c, d, e, f, g, h, i, j, k) = tuple $
-        builder a >*<
-        builder b >*<
-        builder c >*<
-        builder d >*<
-        builder e >*<
-        builder f >*<
-        builder g >*<
-        builder h >*<
-        builder i >*<
-        fromEncoding (toJ j) >*<
-        fromEncoding (toK k)
+        toEncoding a >*<
+        toEncoding b >*<
+        toEncoding c >*<
+        toEncoding d >*<
+        toEncoding e >*<
+        toEncoding f >*<
+        toEncoding g >*<
+        toEncoding h >*<
+        toEncoding i >*<
+        toJ j >*<
+        toK k
     {-# INLINE liftToEncoding2 #-}
 
 instance (ToJSON a, ToJSON b, ToJSON c, ToJSON d, ToJSON e, ToJSON f, ToJSON g, ToJSON h, ToJSON i, ToJSON j) => ToJSON1 ((,,,,,,,,,,) a b c d e f g h i j) where
@@ -642,18 +632,18 @@ instance (ToJSON a, ToJSON b, ToJSON c, ToJSON d, ToJSON e, ToJSON f, ToJSON g, 
     {-# INLINE liftToJSON2 #-}
 
     liftToEncoding2 toK _ toL _ (a, b, c, d, e, f, g, h, i, j, k, l) = tuple $
-        builder a >*<
-        builder b >*<
-        builder c >*<
-        builder d >*<
-        builder e >*<
-        builder f >*<
-        builder g >*<
-        builder h >*<
-        builder i >*<
-        builder j >*<
-        fromEncoding (toK k) >*<
-        fromEncoding (toL l)
+        toEncoding a >*<
+        toEncoding b >*<
+        toEncoding c >*<
+        toEncoding d >*<
+        toEncoding e >*<
+        toEncoding f >*<
+        toEncoding g >*<
+        toEncoding h >*<
+        toEncoding i >*<
+        toEncoding j >*<
+        toK k >*<
+        toL l
     {-# INLINE liftToEncoding2 #-}
 
 instance (ToJSON a, ToJSON b, ToJSON c, ToJSON d, ToJSON e, ToJSON f, ToJSON g, ToJSON h, ToJSON i, ToJSON j, ToJSON k) => ToJSON1 ((,,,,,,,,,,,) a b c d e f g h i j k) where
@@ -717,19 +707,19 @@ instance (ToJSON a, ToJSON b, ToJSON c, ToJSON d, ToJSON e, ToJSON f, ToJSON g, 
     {-# INLINE liftToJSON2 #-}
 
     liftToEncoding2 toL _ toM _ (a, b, c, d, e, f, g, h, i, j, k, l, m) = tuple $
-        builder a >*<
-        builder b >*<
-        builder c >*<
-        builder d >*<
-        builder e >*<
-        builder f >*<
-        builder g >*<
-        builder h >*<
-        builder i >*<
-        builder j >*<
-        builder k >*<
-        fromEncoding (toL l) >*<
-        fromEncoding (toM m)
+        toEncoding a >*<
+        toEncoding b >*<
+        toEncoding c >*<
+        toEncoding d >*<
+        toEncoding e >*<
+        toEncoding f >*<
+        toEncoding g >*<
+        toEncoding h >*<
+        toEncoding i >*<
+        toEncoding j >*<
+        toEncoding k >*<
+        toL l >*<
+        toM m
     {-# INLINE liftToEncoding2 #-}
 
 instance (ToJSON a, ToJSON b, ToJSON c, ToJSON d, ToJSON e, ToJSON f, ToJSON g, ToJSON h, ToJSON i, ToJSON j, ToJSON k, ToJSON l) => ToJSON1 ((,,,,,,,,,,,,) a b c d e f g h i j k l) where
@@ -795,20 +785,20 @@ instance (ToJSON a, ToJSON b, ToJSON c, ToJSON d, ToJSON e, ToJSON f, ToJSON g, 
     {-# INLINE liftToJSON2 #-}
 
     liftToEncoding2 toM _ toN _ (a, b, c, d, e, f, g, h, i, j, k, l, m, n) = tuple $
-        builder a >*<
-        builder b >*<
-        builder c >*<
-        builder d >*<
-        builder e >*<
-        builder f >*<
-        builder g >*<
-        builder h >*<
-        builder i >*<
-        builder j >*<
-        builder k >*<
-        builder l >*<
-        fromEncoding (toM m) >*<
-        fromEncoding (toN n)
+        toEncoding a >*<
+        toEncoding b >*<
+        toEncoding c >*<
+        toEncoding d >*<
+        toEncoding e >*<
+        toEncoding f >*<
+        toEncoding g >*<
+        toEncoding h >*<
+        toEncoding i >*<
+        toEncoding j >*<
+        toEncoding k >*<
+        toEncoding l >*<
+        toM m >*<
+        toN n
     {-# INLINE liftToEncoding2 #-}
 
 instance (ToJSON a, ToJSON b, ToJSON c, ToJSON d, ToJSON e, ToJSON f, ToJSON g, ToJSON h, ToJSON i, ToJSON j, ToJSON k, ToJSON l, ToJSON m) => ToJSON1 ((,,,,,,,,,,,,,) a b c d e f g h i j k l m) where
@@ -876,21 +866,21 @@ instance (ToJSON a, ToJSON b, ToJSON c, ToJSON d, ToJSON e, ToJSON f, ToJSON g, 
     {-# INLINE liftToJSON2 #-}
 
     liftToEncoding2 toN _ toO _ (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) = tuple $
-        builder a >*<
-        builder b >*<
-        builder c >*<
-        builder d >*<
-        builder e >*<
-        builder f >*<
-        builder g >*<
-        builder h >*<
-        builder i >*<
-        builder j >*<
-        builder k >*<
-        builder l >*<
-        builder m >*<
-        fromEncoding (toN n) >*<
-        fromEncoding (toO o)
+        toEncoding a >*<
+        toEncoding b >*<
+        toEncoding c >*<
+        toEncoding d >*<
+        toEncoding e >*<
+        toEncoding f >*<
+        toEncoding g >*<
+        toEncoding h >*<
+        toEncoding i >*<
+        toEncoding j >*<
+        toEncoding k >*<
+        toEncoding l >*<
+        toEncoding m >*<
+        toN n >*<
+        toO o
     {-# INLINE liftToEncoding2 #-}
 
 instance (ToJSON a, ToJSON b, ToJSON c, ToJSON d, ToJSON e, ToJSON f, ToJSON g, ToJSON h, ToJSON i, ToJSON j, ToJSON k, ToJSON l, ToJSON m, ToJSON n) => ToJSON1 ((,,,,,,,,,,,,,,) a b c d e f g h i j k l m n) where
@@ -935,5 +925,3 @@ instance (FromJSON a, FromJSON b, FromJSON c, FromJSON d, FromJSON e, FromJSON f
 instance (FromJSON a, FromJSON b, FromJSON c, FromJSON d, FromJSON e, FromJSON f, FromJSON g, FromJSON h, FromJSON i, FromJSON j, FromJSON k, FromJSON l, FromJSON m, FromJSON n, FromJSON o) => FromJSON (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) where
     parseJSON = parseJSON2
     {-# INLINE parseJSON #-}
-
-

--- a/Data/Aeson/Types/Instances/Tuple.hs
+++ b/Data/Aeson/Types/Instances/Tuple.hs
@@ -12,10 +12,9 @@
 -- Tuple instances
 module Data.Aeson.Types.Instances.Tuple () where
 
-import Data.Aeson.Encoding (tuple, (>*<))
+import Data.Aeson.Encoding.Internal (tuple, (>*<))
 import Data.Aeson.Types.Class
 import Data.Aeson.Types.Internal
-import Data.Monoid ((<>))
 
 import qualified Data.Vector as V
 import qualified Data.Vector.Mutable as VM (unsafeNew, unsafeWrite)

--- a/aeson.cabal
+++ b/aeson.cabal
@@ -71,6 +71,7 @@ library
     Data.Aeson
     Data.Aeson.Encode
     Data.Aeson.Encoding
+    Data.Aeson.Encoding.Internal
     Data.Aeson.Internal
     Data.Aeson.Internal.Time
     Data.Aeson.Parser

--- a/aeson.cabal
+++ b/aeson.cabal
@@ -70,6 +70,7 @@ library
   exposed-modules:
     Data.Aeson
     Data.Aeson.Encode
+    Data.Aeson.Encoding
     Data.Aeson.Internal
     Data.Aeson.Internal.Time
     Data.Aeson.Parser

--- a/benchmarks/aeson-benchmarks.cabal
+++ b/benchmarks/aeson-benchmarks.cabal
@@ -16,6 +16,7 @@ library
   exposed-modules:
     Data.Aeson
     Data.Aeson.Encoding
+    Data.Aeson.Encoding.Internal
     Data.Aeson.Encode
     Data.Aeson.Encode.Builder
     Data.Aeson.Encode.Functions

--- a/benchmarks/aeson-benchmarks.cabal
+++ b/benchmarks/aeson-benchmarks.cabal
@@ -15,6 +15,7 @@ library
 
   exposed-modules:
     Data.Aeson
+    Data.Aeson.Encoding
     Data.Aeson.Encode
     Data.Aeson.Encode.Builder
     Data.Aeson.Encode.Functions

--- a/tuple-instances.hs
+++ b/tuple-instances.hs
@@ -1,5 +1,5 @@
 #!/usr/bin/env stack
-{- stack --resolver=lts-5.9 runghc
+{- stack --resolver=lts-6.0 runghc
       --package mtl
       --package dlist
 -}
@@ -45,9 +45,9 @@ tuple n = fold $ flip execState DList.empty $ do
     t ["    liftToEncoding2 ", toPrev, " _ ", toLast, " _ ", vs', " = tuple $" ]
     forM_ (zip [0..] vs) $ \(i, v) -> t . ("        " :) $ case i of
 
-        _ | i == n - 1 -> [ "fromEncoding (", toLast, " ", v, ")" ]
-        _ | i == n - 2 -> [ "fromEncoding (", toPrev, " ", v, ") >*<" ]
-        _ | otherwise  -> [ "builder ", v, " >*<" ]
+        _ | i == n - 1 -> [ toLast, " ", v ]
+        _ | i == n - 2 -> [ toPrev, " ", v, " >*<" ]
+        _ | otherwise  -> [ "toEncoding ", v, " >*<" ]
     t ["    {-# INLINE liftToEncoding2 #-}" ]
     t []
 


### PR DESCRIPTION
This PR makes everything use `Data.Aeson.Encoding` -module, except `.Instances`.
I run some benchmarks, cannot notice any difference (which is good).

If this idea is good, we could merge this before we reorganise instances (https://github.com/bos/aeson/issues/375)