### PR TITLE
Generics and TH support for lifted typeclasses

### DIFF
--- a/Data/Aeson.hs
+++ b/Data/Aeson.hs
@@ -77,9 +77,14 @@ module Data.Aeson
     , GFromJSON(..)
     , GToJSON(..)
     , GToEncoding(..)
+    , Zero
+    , One
     , genericToJSON
+    , genericLiftToJSON
     , genericToEncoding
+    , genericLiftToEncoding
     , genericParseJSON
+    , genericLiftParseJSON
     , defaultOptions
 
     -- * Inspecting @'Value's@

--- a/Data/Aeson/TH.hs
+++ b/Data/Aeson/TH.hs
@@ -1,5 +1,9 @@
-{-# LANGUAGE CPP, FlexibleInstances, NamedFieldPuns,
-    NoImplicitPrelude, UndecidableInstances #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE UndecidableInstances #-}
 #if __GLASGOW_HASKELL__ >= 800
 -- a) THQ works on cross-compilers and unregisterised GHCs
 -- b) may make compilation faster as no dynamic loading is ever needed (not sure about this)
@@ -87,19 +91,32 @@ module Data.Aeson.TH
 
      -- * FromJSON and ToJSON derivation
     , deriveJSON
+    , deriveJSON1
+    , deriveJSON2
 
     , deriveToJSON
+    , deriveToJSON1
+    , deriveToJSON2
     , deriveFromJSON
+    , deriveFromJSON1
+    , deriveFromJSON2
 
     , mkToJSON
+    , mkLiftToJSON
+    , mkLiftToJSON2
     , mkToEncoding
+    , mkLiftToEncoding
+    , mkLiftToEncoding2
     , mkParseJSON
+    , mkLiftParseJSON
+    , mkLiftParseJSON2
     ) where
 
 import Control.Applicative ( pure, (<$>), (<*>) )
-import Data.Aeson ( toJSON, Object, (.=), (.:), (.:?)
-                  , ToJSON, toEncoding, toJSON
-                  , FromJSON, parseJSON
+import Data.Aeson ( Object, (.=), (.:)
+                  , ToJSON(..),  FromJSON(..)
+                  , ToJSON1(..), FromJSON1(..)
+                  , ToJSON2(..), FromJSON2(..)
                   )
 import Data.Aeson.Types ( Value(..), Parser
                         , Options(..)
@@ -107,32 +124,42 @@ import Data.Aeson.Types ( Value(..), Parser
                         , defaultOptions
                         , defaultTaggedObject
                         )
-import Data.Aeson.Types.Internal ((<?>), JSONPathElement(Key))
-import Control.Monad       ( liftM2, return, mapM, fail )
+import Data.Aeson.Types.Instances (parseOptionalFieldWith)
+import Data.Aeson.Types.Internal (Pair, (<?>), JSONPathElement(Key))
+import Control.Monad       ( fail, liftM2, mapM, return, unless, when )
 import Data.Bool           ( Bool(False, True), otherwise, (&&), not )
 import Data.Either         ( Either(Left, Right) )
 import Data.Eq             ( (==) )
+import Data.Foldable       ( concatMap, foldr' )
 import Data.Function       ( ($), (.), flip )
 import Data.Functor        ( fmap )
 import Data.Int            ( Int )
 import Data.List           ( (++), all, any, find, foldl, foldl'
                            , genericLength , intercalate , intersperse, length, map
-                           , partition, zip
+                           , partition, union, zip, zip3
                            )
+import Data.List.NonEmpty  ( NonEmpty((:|)), (<|) )
 import Data.Map            ( Map )
-import Data.Maybe          ( Maybe(Nothing, Just), catMaybes )
+import Data.Maybe          ( Maybe(Nothing, Just), catMaybes, fromMaybe, mapMaybe )
 import Data.Monoid         ( (<>), mconcat )
+import Data.Set            ( Set )
 import Language.Haskell.TH
+#if MIN_VERSION_template_haskell(2,8,0)
+  hiding ( Arity )
+#endif
 import Language.Haskell.TH.Syntax ( VarStrictType )
-import Prelude             ( String, (-), Integer, error, foldr1, fromIntegral
-                           , splitAt, zipWith
+import Prelude             ( Enum(..), Eq(..), Integer, Ord(..), String
+                           , concat, cycle, drop, elem, error, foldr1, fromIntegral
+                           , showChar, showParen, shows, showString, snd, splitAt
+                           , take, unzip, zipWith, (-), (||)
                            )
+#if MIN_VERSION_template_haskell(2,7,0) && !(MIN_VERSION_template_haskell(2,8,0))
+import Language.Haskell.TH.Lib    ( starK )
+#endif
 #if MIN_VERSION_template_haskell(2,8,0) && !(MIN_VERSION_template_haskell(2,10,0))
-import Data.Foldable              ( foldr' )
-import qualified Data.Map as M    ( singleton )
 import Data.List                  ( nub )
 import Language.Haskell.TH.Syntax ( mkNameG_tc )
-import Prelude                    ( concatMap, uncurry )
+import Prelude                    ( uncurry )
 #endif
 #if MIN_VERSION_template_haskell(2,11,0)
 import Prelude             ( head )
@@ -141,8 +168,13 @@ import Text.Printf         ( printf )
 import Text.Show           ( show )
 import qualified Data.Aeson as A
 import qualified Data.Aeson.Encoding.Internal as E
+import qualified Data.Foldable as F ( all )
 import qualified Data.HashMap.Strict as H ( lookup, toList )
-import qualified Data.Map as M ( fromList, findWithDefault )
+import qualified Data.List.NonEmpty as NE ( drop, length, reverse, splitAt )
+import qualified Data.Map as M ( fromList, findWithDefault, keys, lookup
+                               , singleton, size
+                               )
+import qualified Data.Set as Set ( empty, insert, member )
 import qualified Data.Text as T ( Text, pack, unpack )
 import qualified Data.Vector as V ( unsafeIndex, null, length, create, fromList )
 import qualified Data.Vector.Mutable as VM ( unsafeNew, unsafeWrite )
@@ -163,11 +195,33 @@ deriveJSON :: Options
            -- ^ Name of the type for which to generate 'ToJSON' and 'FromJSON'
            -- instances.
            -> Q [Dec]
-deriveJSON opts name =
-    liftM2 (++)
-           (deriveToJSON   opts name)
-           (deriveFromJSON opts name)
+deriveJSON = deriveJSONBoth deriveToJSON deriveFromJSON
 
+-- | Generates both 'ToJSON1' and 'FromJSON1' instance declarations for the given
+-- data type or data family instance constructor.
+--
+-- This is a convienience function which is equivalent to calling both
+-- 'deriveToJSON1' and 'deriveFromJSON1'.
+deriveJSON1 :: Options
+            -- ^ Encoding options.
+            -> Name
+            -- ^ Name of the type for which to generate 'ToJSON1' and 'FromJSON1'
+            -- instances.
+            -> Q [Dec]
+deriveJSON1 = deriveJSONBoth deriveToJSON1 deriveFromJSON1
+
+-- | Generates both 'ToJSON2' and 'FromJSON2' instance declarations for the given
+-- data type or data family instance constructor.
+--
+-- This is a convienience function which is equivalent to calling both
+-- 'deriveToJSON2' and 'deriveFromJSON2'.
+deriveJSON2 :: Options
+            -- ^ Encoding options.
+            -> Name
+            -- ^ Name of the type for which to generate 'ToJSON2' and 'FromJSON2'
+            -- instances.
+            -> Q [Dec]
+deriveJSON2 = deriveJSONBoth deriveToJSON2 deriveFromJSON2
 
 --------------------------------------------------------------------------------
 -- ToJSON
@@ -190,69 +244,130 @@ deriveToJSON :: Options
              -- ^ Name of the type for which to generate a 'ToJSON' instance
              -- declaration.
              -> Q [Dec]
-deriveToJSON opts name =
-    withType name $ \name' tvbs cons mbTys -> fmap (:[]) $ fromCons name' tvbs cons mbTys
-  where
-    fromCons :: Name -> [TyVarBndr] -> [Con] -> Maybe [Type] -> Q Dec
-    fromCons name' tvbs cons mbTys = do
-        (instanceCxt, instanceType) <- buildTypeInstance name' ''ToJSON tvbs mbTys
-        instanceD (return instanceCxt)
-                  (return instanceType)
-                  [ funD 'toJSON
-                         [ clause []
-                                  (normalB $ consToValue opts cons)
-                                  []
-                         ]
-                  , funD 'toEncoding
-                         [ clause []
-                                  (normalB $ consToEncoding opts cons)
-                                  []
-                         ]
-                  ]
+deriveToJSON = deriveToJSONCommon toJSONClass
+
+-- | Generates a 'ToJSON1' instance declaration for the given data type or
+-- data family instance constructor.
+deriveToJSON1 :: Options
+              -- ^ Encoding options.
+              -> Name
+              -- ^ Name of the type for which to generate a 'ToJSON1' instance
+              -- declaration.
+              -> Q [Dec]
+deriveToJSON1 = deriveToJSONCommon toJSON1Class
+
+-- | Generates a 'ToJSON2' instance declaration for the given data type or
+-- data family instance constructor.
+deriveToJSON2 :: Options
+              -- ^ Encoding options.
+              -> Name
+              -- ^ Name of the type for which to generate a 'ToJSON2' instance
+              -- declaration.
+              -> Q [Dec]
+deriveToJSON2 = deriveToJSONCommon toJSON2Class
+
+deriveToJSONCommon :: JSONClass
+                   -- ^ The ToJSON variant being derived.
+                   -> Options
+                   -- ^ Encoding options.
+                   -> Name
+                   -- ^ Name of the type for which to generate an instance.
+                   -> Q [Dec]
+deriveToJSONCommon = deriveJSONClass [ (ToJSON,     \jc _ -> consToValue    jc)
+                                     , (ToEncoding, \jc _ -> consToEncoding jc)
+                                     ]
 
 -- | Generates a lambda expression which encodes the given data type or
 -- data family instance constructor as a 'Value'.
 mkToJSON :: Options -- ^ Encoding options.
          -> Name -- ^ Name of the type to encode.
          -> Q Exp
-mkToJSON opts name = withType name (\_ _ cons _ -> consToValue opts cons)
+mkToJSON = mkToJSONCommon toJSONClass
+
+-- | Generates a lambda expression which encodes the given data type or
+-- data family instance constructor as a 'Value' by using the given encoding
+-- function on occurrences of the last type parameter.
+mkLiftToJSON :: Options -- ^ Encoding options.
+             -> Name -- ^ Name of the type to encode.
+             -> Q Exp
+mkLiftToJSON = mkToJSONCommon toJSON1Class
+
+-- | Generates a lambda expression which encodes the given data type or
+-- data family instance constructor as a 'Value' by using the given encoding
+-- functions on occurrences of the last two type parameters.
+mkLiftToJSON2 :: Options -- ^ Encoding options.
+              -> Name -- ^ Name of the type to encode.
+              -> Q Exp
+mkLiftToJSON2 = mkToJSONCommon toJSON2Class
+
+mkToJSONCommon :: JSONClass -- ^ Which class's method is being derived.
+               -> Options -- ^ Encoding options.
+               -> Name -- ^ Name of the encoded type.
+               -> Q Exp
+mkToJSONCommon = mkFunCommon (\jc _ -> consToValue jc)
 
 -- | Generates a lambda expression which encodes the given data type or
 -- data family instance constructor as a JSON string.
 mkToEncoding :: Options -- ^ Encoding options.
              -> Name -- ^ Name of the type to encode.
              -> Q Exp
-mkToEncoding opts name = withType name (\_ _ cons _ -> consToEncoding opts cons)
+mkToEncoding = mkToEncodingCommon toJSONClass
+
+-- | Generates a lambda expression which encodes the given data type or
+-- data family instance constructor as a JSON string by using the given encoding
+-- function on occurrences of the last type parameter.
+mkLiftToEncoding :: Options -- ^ Encoding options.
+                 -> Name -- ^ Name of the type to encode.
+                 -> Q Exp
+mkLiftToEncoding = mkToEncodingCommon toJSON1Class
+
+-- | Generates a lambda expression which encodes the given data type or
+-- data family instance constructor as a JSON string by using the given encoding
+-- functions on occurrences of the last two type parameters.
+mkLiftToEncoding2 :: Options -- ^ Encoding options.
+                  -> Name -- ^ Name of the type to encode.
+                  -> Q Exp
+mkLiftToEncoding2 = mkToEncodingCommon toJSON2Class
+
+mkToEncodingCommon :: JSONClass -- ^ Which class's method is being derived.
+                   -> Options -- ^ Encoding options.
+                   -> Name -- ^ Name of the encoded type.
+                   -> Q Exp
+mkToEncodingCommon = mkFunCommon (\jc _ -> consToEncoding jc)
 
 -- | Helper function used by both 'deriveToJSON' and 'mkToJSON'. Generates
 -- code to generate a 'Value' of a number of constructors. All constructors
 -- must be from the same type.
-consToValue :: Options
-           -- ^ Encoding options.
-           -> [Con]
-           -- ^ Constructors for which to generate JSON generating code.
-           -> Q Exp
+consToValue :: JSONClass
+            -- ^ The ToJSON variant being derived.
+            -> Options
+            -- ^ Encoding options.
+            -> [Con]
+            -- ^ Constructors for which to generate JSON generating code.
+            -> Q Exp
 
-consToValue _ [] = error $ "Data.Aeson.TH.consToValue: "
-                          ++ "Not a single constructor given!"
+consToValue _ _ [] = error $ "Data.Aeson.TH.consToValue: "
+                            ++ "Not a single constructor given!"
 
--- A single constructor is directly encoded. The constructor itself may be
--- forgotten.
-consToValue opts [con] = do
+consToValue jc opts cons = do
     value <- newName "value"
-    lam1E (varP value) $ caseE (varE value) [argsToValue opts False con]
-
-consToValue opts cons = do
-    value <- newName "value"
-    lam1E (varP value) $ caseE (varE value) matches
+    tjs   <- newNameList "_tj"  $ arityInt jc
+    tjls  <- newNameList "_tjl" $ arityInt jc
+    let zippedTJs      = zip tjs tjls
+        interleavedTJs = interleave tjs tjls
+    lamE (map varP $ interleavedTJs ++ [value]) $
+        caseE (varE value) (matches zippedTJs)
   where
-    matches
-        | allNullaryToStringTag opts && all isNullary cons =
+    matches tjs = case cons of
+      -- A single constructor is directly encoded. The constructor itself may be
+      -- forgotten.
+      [con] -> [argsToValue jc tjs opts False con]
+      _ | allNullaryToStringTag opts && all isNullary cons ->
               [ match (conP conName []) (normalB $ conStr opts conName) []
               | con <- cons
               , let conName = getConName con
               ]
-        | otherwise = [argsToValue opts True con | con <- cons]
+        | otherwise -> [argsToValue jc tjs opts True con | con <- cons]
 
 conStr :: Options -> Name -> Q Exp
 conStr opts = appE [|String|] . conTxt opts
@@ -266,35 +381,39 @@ conStringE opts = stringE . constructorTagModifier opts . nameBase
 -- | Helper function used by both 'deriveToJSON' and 'mkToEncoding'. Generates
 -- code to write out a value for a number of constructors. All constructors
 -- must be from the same type.
-consToEncoding :: Options
-                  -- ^ Encoding options.
+consToEncoding :: JSONClass
+               -- ^ The ToJSON variant being derived.
+               -> Options
+               -- ^ Encoding options.
                -> [Con]
                -- ^ Constructors for which to generate JSON generating code.
                -> Q Exp
 
-consToEncoding _ [] = error $ "Data.Aeson.TH.consToEncoding: "
-                      ++ "Not a single constructor given!"
+consToEncoding _ _ [] = error $ "Data.Aeson.TH.consToEncoding: "
+                        ++ "Not a single constructor given!"
 
--- A single constructor is directly encoded. The constructor itself may be
--- forgotten.
-consToEncoding opts [con] = do
+consToEncoding jc opts cons = do
     value <- newName "value"
-    lam1E (varP value) $ caseE (varE value) [argsToEncoding opts False con]
-
--- Encode just the name of the constructor of a sum type iff all the
--- constructors are nullary.
-consToEncoding opts cons = do
-    value <- newName "value"
-    lam1E (varP value) $ caseE (varE value) matches
+    tes   <- newNameList "_te"  $ arityInt jc
+    tels  <- newNameList "_tel" $ arityInt jc
+    let zippedTEs      = zip tes tels
+        interleavedTEs = interleave tes tels
+    lamE (map varP $ interleavedTEs ++ [value]) $
+        caseE (varE value) (matches zippedTEs)
   where
-    matches
-        | allNullaryToStringTag opts && all isNullary cons =
+    matches tes = case cons of
+      -- A single constructor is directly encoded. The constructor itself may be
+      -- forgotten.
+      [con] -> [argsToEncoding jc tes opts False con]
+      -- Encode just the name of the constructor of a sum type iff all the
+      -- constructors are nullary.
+      _ | allNullaryToStringTag opts && all isNullary cons ->
               [ match (conP conName [])
                 (normalB $ encStr opts conName) []
               | con <- cons
               , let conName = getConName con
               ]
-        | otherwise = [argsToEncoding opts True con | con <- cons]
+        | otherwise -> [argsToEncoding jc tes opts True con | con <- cons]
 
 encStr :: Options -> Name -> Q Exp
 encStr opts = appE [|E.text|] . conTxt opts
@@ -332,20 +451,25 @@ nullarySumToValue opts multiCons conName =
       _ -> sumToValue opts multiCons conName [e|toJSON ([] :: [()])|]
 
 -- | Generates code to generate the JSON encoding of a single constructor.
-argsToValue :: Options -> Bool -> Con -> Q Match
+argsToValue :: JSONClass -> [(Name, Name)] -> Options -> Bool -> Con -> Q Match
 -- Nullary constructors. Generates code that explicitly matches against the
 -- constructor even though it doesn't contain data. This is useful to prevent
 -- type errors.
-argsToValue  opts multiCons (NormalC conName []) =
+argsToValue jc tjs opts multiCons (NormalC conName []) = do
+    ([], _) <- reifyConTys jc tjs conName
     match (conP conName [])
           (normalB (nullarySumToValue opts multiCons conName))
           []
 
 -- Polyadic constructors with special case for unary constructors.
-argsToValue opts multiCons (NormalC conName ts) = do
+argsToValue jc tjs opts multiCons (NormalC conName ts) = do
+    (argTys, tvMap) <- reifyConTys jc tjs conName
     let len = length ts
-    args <- mapM newName ["arg" ++ show n | n <- [1..len]]
-    js <- case [[|toJSON|] `appE` varE arg | arg <- args] of
+    args <- newNameList "arg" len
+    js <- case [ dispatchToJSON jc conName tvMap argTy
+                   `appE` varE arg
+               | (arg, argTy) <- zip args argTys
+               ] of
             -- Single argument is directly converted.
             [e] -> return e
             -- Multiple arguments are converted to a JSON array.
@@ -370,10 +494,11 @@ argsToValue opts multiCons (NormalC conName ts) = do
           []
 
 -- Records.
-argsToValue opts multiCons (RecC conName ts) = case (unwrapUnaryRecords opts, not multiCons, ts) of
-  (True,True,[(_,st,ty)]) -> argsToValue opts multiCons (NormalC conName [(st,ty)])
+argsToValue jc tjs opts multiCons (RecC conName ts) = case (unwrapUnaryRecords opts, not multiCons, ts) of
+  (True,True,[(_,st,ty)]) -> argsToValue jc tjs opts multiCons (NormalC conName [(st,ty)])
   _ -> do
-    args <- mapM newName ["arg" ++ show n | (_, n) <- zip ts [1 :: Integer ..]]
+    (argTys, tvMap) <- reifyConTys jc tjs conName
+    args <- newNameList "arg" $ length ts
     let exp = [|A.object|] `appE` pairs
 
         pairs | omitNothingFields opts = infixApp maybeFields
@@ -381,7 +506,7 @@ argsToValue opts multiCons (RecC conName ts) = case (unwrapUnaryRecords opts, no
                                                   restFields
               | otherwise = listE $ map toPair argCons
 
-        argCons = zip args ts
+        argCons = zip3 args argTys ts
 
         maybeFields = [|catMaybes|] `appE` listE (map maybeToPair maybes)
 
@@ -389,17 +514,18 @@ argsToValue opts multiCons (RecC conName ts) = case (unwrapUnaryRecords opts, no
 
         (maybes, rest) = partition isMaybe argCons
 
-        maybeToPair (arg, (field, _, _)) =
-            infixApp (infixE (Just $ toFieldName field)
-                             [|(.=)|]
-                             Nothing)
+        maybeToPair (arg, argTy, (field, _, _)) =
+            infixApp ([|keyValuePairWith|]
+                        `appE` dispatchToJSON jc conName tvMap argTy
+                        `appE` toFieldName field)
                      [|(<$>)|]
                      (varE arg)
 
-        toPair (arg, (field, _, _)) =
-            infixApp (toFieldName field)
-                     [|(.=)|]
-                     (varE arg)
+        toPair (arg, argTy, (field, _, _)) =
+            [|keyValuePairWith|]
+              `appE` dispatchToJSON jc conName tvMap argTy
+              `appE` toFieldName field
+              `appE` varE arg
 
         toFieldName field = [|T.pack|] `appE` fieldLabelExp opts field
 
@@ -424,33 +550,35 @@ argsToValue opts multiCons (RecC conName ts) = case (unwrapUnaryRecords opts, no
           ) []
 
 -- Infix constructors.
-argsToValue opts multiCons (InfixC _ conName _) = do
+argsToValue jc tjs opts multiCons (InfixC _ conName _) = do
+    ([alTy, arTy], tvMap) <- reifyConTys jc tjs conName
     al <- newName "argL"
     ar <- newName "argR"
     match (infixP (varP al) conName (varP ar))
           ( normalB
           $ sumToValue opts multiCons conName
-          $ [|toJSON|] `appE` listE [ [|toJSON|] `appE` varE a
-                                    | a <- [al,ar]
+          $ [|toJSON|] `appE` listE [ dispatchToJSON jc conName tvMap aTy
+                                        `appE` varE a
+                                    | (a, aTy) <- [(al,alTy), (ar,arTy)]
                                     ]
           )
           []
 -- Existentially quantified constructors.
-argsToValue opts multiCons (ForallC _ _ con) =
-    argsToValue opts multiCons con
+argsToValue jc tjs opts multiCons (ForallC _ _ con) =
+    argsToValue jc tjs opts multiCons con
 
 #if MIN_VERSION_template_haskell(2,11,0)
 -- GADTs.
-argsToValue opts multiCons (GadtC conNames ts _) =
-    argsToValue opts multiCons $ NormalC (head conNames) ts
+argsToValue jc tjs opts multiCons (GadtC conNames ts _) =
+    argsToValue jc tjs opts multiCons $ NormalC (head conNames) ts
 
-argsToValue opts multiCons (RecGadtC conNames ts _) =
-    argsToValue opts multiCons $ RecC (head conNames) ts
+argsToValue jc tjs opts multiCons (RecGadtC conNames ts _) =
+    argsToValue jc tjs opts multiCons $ RecC (head conNames) ts
 #endif
 
-isMaybe :: (a, (b, c, Type)) -> Bool
-isMaybe (_, (_, _, AppT (ConT t) _)) = t == ''Maybe
-isMaybe _                            = False
+isMaybe :: (a, b, (c, d, Type)) -> Bool
+isMaybe (_, _, (_, _, AppT (ConT t) _)) = t == ''Maybe
+isMaybe _                               = False
 
 (<^>) :: ExpQ -> ExpQ -> ExpQ
 (<^>) a b = infixApp a [|(<>)|] b
@@ -468,7 +596,7 @@ array :: ExpQ -> ExpQ
 array exp = [|E.wrapArray|] `appE` exp
 
 object :: ExpQ -> ExpQ
-object exp = [|E.wrapObject|] `appE` exp 
+object exp = [|E.wrapObject|] `appE` exp
 
 sumToEncoding :: Options -> Bool -> Name -> Q Exp -> Q Exp
 sumToEncoding opts multiCons conName exp
@@ -495,35 +623,41 @@ nullarySumToEncoding opts multiCons conName =
       _ -> sumToEncoding opts multiCons conName [e|toEncoding ([] :: [()])|]
 
 -- | Generates code to generate the JSON encoding of a single constructor.
-argsToEncoding :: Options -> Bool -> Con -> Q Match
+argsToEncoding :: JSONClass -> [(Name, Name)] -> Options -> Bool -> Con -> Q Match
 -- Nullary constructors. Generates code that explicitly matches against the
 -- constructor even though it doesn't contain data. This is useful to prevent
 -- type errors.
-argsToEncoding  opts multiCons (NormalC conName []) =
+argsToEncoding jc tes opts multiCons (NormalC conName []) = do
+    ([], _) <- reifyConTys jc tes conName
     match (conP conName [])
           (normalB (nullarySumToEncoding opts multiCons conName))
           []
 
 -- Polyadic constructors with special case for unary constructors.
-argsToEncoding opts multiCons (NormalC conName ts) = do
+argsToEncoding jc tes opts multiCons (NormalC conName ts) = do
+    (argTys, tvMap) <- reifyConTys jc tes conName
     let len = length ts
-    args <- mapM newName ["arg" ++ show n | n <- [1..len]]
-    js <- case args of
+    args <- newNameList "arg" len
+    js <- case zip args argTys of
             -- Single argument is directly converted.
-            [e] -> return ([|toEncoding|] `appE` varE e)
+            [(e,eTy)] -> return (dispatchToEncoding jc conName tvMap eTy
+                                   `appE` varE e)
             -- Multiple arguments are converted to a JSON array.
             es  ->
-              return (array (foldr1 (<%>) [[|toEncoding|] `appE` varE x | x <- es]))
+              return (array (foldr1 (<%>) [ dispatchToEncoding jc conName tvMap xTy
+                                              `appE` varE x
+                                          | (x,xTy) <- es
+                                          ]))
     match (conP conName $ map varP args)
           (normalB $ sumToEncoding opts multiCons conName js)
           []
 
 -- Records.
-argsToEncoding opts multiCons (RecC conName ts) = case (unwrapUnaryRecords opts, not multiCons, ts) of
-  (True,True,[(_,st,ty)]) -> argsToEncoding opts multiCons (NormalC conName [(st,ty)])
+argsToEncoding jc tes opts multiCons (RecC conName ts) = case (unwrapUnaryRecords opts, not multiCons, ts) of
+  (True,True,[(_,st,ty)]) -> argsToEncoding jc tes opts multiCons (NormalC conName [(st,ty)])
   _ -> do
-    args <- mapM newName ["arg" ++ show n | (_, n) <- zip ts [1 :: Integer ..]]
-
+    args <- newNameList "arg" $ length ts
+    (argTys, tvMap) <- reifyConTys jc tes conName
     let exp = object objBody
 
         objBody = [|mconcat|] `appE`
@@ -533,7 +667,7 @@ argsToEncoding opts multiCons (RecC conName ts) = case (unwrapUnaryRecords opts,
                                                   restFields
               | otherwise = listE (map toPair argCons)
 
-        argCons = zip args ts
+        argCons = zip3 args argTys ts
 
         maybeFields = [|catMaybes|] `appE` listE (map maybeToPair maybes)
 
@@ -541,7 +675,7 @@ argsToEncoding opts multiCons (RecC conName ts) = case (unwrapUnaryRecords opts,
 
         (maybes, rest) = partition isMaybe argCons
 
-        maybeToPair (arg, (field, _, _)) =
+        maybeToPair (arg, argTy, (field, _, _)) =
             infixApp
               (infixApp
                 (infixE
@@ -549,12 +683,14 @@ argsToEncoding opts multiCons (RecC conName ts) = case (unwrapUnaryRecords opts,
                   [|(<>)|]
                   Nothing)
                 [|(.)|]
-                [|toEncoding|])
+                (dispatchToEncoding jc conName tvMap argTy))
               [|(<$>)|]
               (varE arg)
 
-        toPair (arg, (field, _, _)) =
-          toFieldName field <:> [|toEncoding|] `appE` varE arg
+        toPair (arg, argTy, (field, _, _)) =
+          toFieldName field
+            <:> dispatchToEncoding jc conName tvMap argTy
+                  `appE` varE arg
 
         toFieldName field = [|E.text|] `appE`
                             ([|T.pack|] `appE` fieldLabelExp opts field)
@@ -575,28 +711,30 @@ argsToEncoding opts multiCons (RecC conName ts) = case (unwrapUnaryRecords opts,
           ) []
 
 -- Infix constructors.
-argsToEncoding opts multiCons (InfixC _ conName _) = do
+argsToEncoding jc tes opts multiCons (InfixC _ conName _) = do
     al <- newName "argL"
     ar <- newName "argR"
+    ([alTy,arTy], tvMap) <- reifyConTys jc tes conName
     match (infixP (varP al) conName (varP ar))
           ( normalB
           $ sumToEncoding opts multiCons conName
-          $ [|toEncoding|] `appE` listE [ [|toJSON|] `appE` varE a
-                                        | a <- [al,ar]
-                                        ]
+          $ array (foldr1 (<%>) [ dispatchToEncoding jc conName tvMap aTy
+                                    `appE` varE a
+                                | (a,aTy) <- [(al,alTy), (ar,arTy)]
+                                ])
           )
           []
 -- Existentially quantified constructors.
-argsToEncoding opts multiCons (ForallC _ _ con) =
-    argsToEncoding opts multiCons con
+argsToEncoding jc tes opts multiCons (ForallC _ _ con) =
+    argsToEncoding jc tes opts multiCons con
 
 #if MIN_VERSION_template_haskell(2,11,0)
 -- GADTs.
-argsToEncoding opts multiCons (GadtC conNames ts _) =
-    argsToEncoding opts multiCons $ NormalC (head conNames) ts
+argsToEncoding jc tes opts multiCons (GadtC conNames ts _) =
+    argsToEncoding jc tes opts multiCons $ NormalC (head conNames) ts
 
-argsToEncoding opts multiCons (RecGadtC conNames ts _) =
-    argsToEncoding opts multiCons $ RecC (head conNames) ts
+argsToEncoding jc tes opts multiCons (RecGadtC conNames ts _) =
+    argsToEncoding jc tes opts multiCons $ RecC (head conNames) ts
 #endif
 
 --------------------------------------------------------------------------------
@@ -611,33 +749,73 @@ deriveFromJSON :: Options
                -- ^ Name of the type for which to generate a 'FromJSON' instance
                -- declaration.
                -> Q [Dec]
-deriveFromJSON opts name =
-    withType name $ \name' tvbs cons mbTys -> fmap (:[]) $ fromCons name' tvbs cons mbTys
-  where
-    fromCons :: Name -> [TyVarBndr] -> [Con] -> Maybe [Type] -> Q Dec
-    fromCons name' tvbs cons mbTys = do
-        (instanceCxt, instanceType) <- buildTypeInstance name' ''FromJSON tvbs mbTys
-        instanceD (return instanceCxt)
-                  (return instanceType)
-                  [ funD 'parseJSON
-                         [ clause []
-                                  (normalB $ consFromJSON name' opts cons)
-                                  []
-                         ]
-                  ]
+deriveFromJSON = deriveFromJSONCommon fromJSONClass
+
+-- | Generates a 'FromJSON1' instance declaration for the given data type or
+-- data family instance constructor.
+deriveFromJSON1 :: Options
+                -- ^ Encoding options.
+                -> Name
+                -- ^ Name of the type for which to generate a 'FromJSON1' instance
+                -- declaration.
+                -> Q [Dec]
+deriveFromJSON1 = deriveFromJSONCommon fromJSON1Class
+
+-- | Generates a 'FromJSON2' instance declaration for the given data type or
+-- data family instance constructor.
+deriveFromJSON2 :: Options
+                -- ^ Encoding options.
+                -> Name
+                -- ^ Name of the type for which to generate a 'FromJSON3' instance
+                -- declaration.
+                -> Q [Dec]
+deriveFromJSON2 = deriveFromJSONCommon fromJSON2Class
+
+deriveFromJSONCommon :: JSONClass
+                     -- ^ The FromJSON variant being derived.
+                     -> Options
+                     -- ^ Encoding options.
+                     -> Name
+                     -- ^ Name of the type for which to generate an instance.
+                     -- declaration.
+                     -> Q [Dec]
+deriveFromJSONCommon = deriveJSONClass [(ParseJSON, consFromJSON)]
 
 -- | Generates a lambda expression which parses the JSON encoding of the given
 -- data type or data family instance constructor.
 mkParseJSON :: Options -- ^ Encoding options.
             -> Name -- ^ Name of the encoded type.
             -> Q Exp
-mkParseJSON opts name =
-    withType name (\name' _ cons _ -> consFromJSON name' opts cons)
+mkParseJSON = mkParseJSONCommon fromJSONClass
+
+-- | Generates a lambda expression which parses the JSON encoding of the given
+-- data type or data family instance constructor by using the given parsing
+-- function on occurrences of the last type parameter.
+mkLiftParseJSON :: Options -- ^ Encoding options.
+                -> Name -- ^ Name of the encoded type.
+                -> Q Exp
+mkLiftParseJSON = mkParseJSONCommon fromJSON1Class
+
+-- | Generates a lambda expression which parses the JSON encoding of the given
+-- data type or data family instance constructor by using the given parsing
+-- functions on occurrences of the last two type parameters.
+mkLiftParseJSON2 :: Options -- ^ Encoding options.
+                 -> Name -- ^ Name of the encoded type.
+                 -> Q Exp
+mkLiftParseJSON2 = mkParseJSONCommon fromJSON2Class
+
+mkParseJSONCommon :: JSONClass -- ^ Which class's method is being derived.
+                  -> Options -- ^ Encoding options.
+                  -> Name -- ^ Name of the encoded type.
+                  -> Q Exp
+mkParseJSONCommon = mkFunCommon consFromJSON
 
 -- | Helper function used by both 'deriveFromJSON' and 'mkParseJSON'. Generates
 -- code to parse the JSON encoding of a number of constructors. All constructors
 -- must be from the same type.
-consFromJSON :: Name
+consFromJSON :: JSONClass
+             -- ^ The FromJSON variant being derived.
+             -> Name
              -- ^ Name of the type to which the constructors belong.
              -> Options
              -- ^ Encoding options
@@ -645,21 +823,25 @@ consFromJSON :: Name
              -- ^ Constructors for which to generate JSON parsing code.
              -> Q Exp
 
-consFromJSON _ _ [] = error $ "Data.Aeson.TH.consFromJSON: "
+consFromJSON _ _ _ [] = error $ "Data.Aeson.TH.consFromJSON: "
                               ++ "Not a single constructor given!"
 
-consFromJSON tName opts [con] = do
+consFromJSON jc tName opts cons = do
   value <- newName "value"
-  lam1E (varP value) (parseArgs tName opts con (Right value))
-
-consFromJSON tName opts cons = do
-  value <- newName "value"
-  lam1E (varP value) $ caseE (varE value) $
-    if allNullaryToStringTag opts && all isNullary cons
-    then allNullaryMatches
-    else mixedMatches
+  pjs   <- newNameList "_pj"  $ arityInt jc
+  pjls  <- newNameList "_pjl" $ arityInt jc
+  let zippedPJs      = zip pjs pjls
+      interleavedPJs = interleave pjs pjls
+  lamE (map varP $ interleavedPJs ++ [value]) $ lamExpr value zippedPJs
 
   where
+    lamExpr value pjs = case cons of
+      [con] -> parseArgs jc pjs tName opts con (Right value)
+      _     -> caseE (varE value) $
+                   if allNullaryToStringTag opts && all isNullary cons
+                   then allNullaryMatches
+                   else mixedMatches pjs
+
     allNullaryMatches =
       [ do txt <- newName "txt"
            match (conP 'String [varP txt])
@@ -693,12 +875,12 @@ consFromJSON tName opts cons = do
                  []
       ]
 
-    mixedMatches =
+    mixedMatches pjs =
         case sumEncoding opts of
           TaggedObject {tagFieldName, contentsFieldName} ->
-            parseObject $ parseTaggedObject tagFieldName contentsFieldName
+            parseObject $ parseTaggedObject pjs tagFieldName contentsFieldName
           ObjectWithSingleField ->
-            parseObject $ parseObjectWithSingleField
+            parseObject $ parseObjectWithSingleField pjs
           TwoElemArray ->
             [ do arr <- newName "array"
                  match (conP 'Array [varP arr])
@@ -706,7 +888,7 @@ consFromJSON tName opts cons = do
                         [ liftM2 (,) (normalG $ infixApp ([|V.length|] `appE` varE arr)
                                                          [|(==)|]
                                                          (litE $ integerL 2))
-                                     (parse2ElemArray arr)
+                                     (parse2ElemArray pjs arr)
                         , liftM2 (,) (normalG [|otherwise|])
                                      (([|not2ElemArray|]
                                        `appE` (litE $ stringL $ show tName)
@@ -737,16 +919,16 @@ consFromJSON tName opts cons = do
                    []
         ]
 
-    parseTaggedObject typFieldName valFieldName obj = do
+    parseTaggedObject pjs typFieldName valFieldName obj = do
       conKey <- newName "conKey"
       doE [ bindS (varP conKey)
                   (infixApp (varE obj)
                             [|(.:)|]
                             ([|T.pack|] `appE` stringE typFieldName))
-          , noBindS $ parseContents conKey (Left (valFieldName, obj)) 'conNotFoundFailTaggedObject
+          , noBindS $ parseContents pjs conKey (Left (valFieldName, obj)) 'conNotFoundFailTaggedObject
           ]
 
-    parse2ElemArray arr = do
+    parse2ElemArray pjs arr = do
       conKey <- newName "conKey"
       conVal <- newName "conVal"
       let letIx n ix =
@@ -761,7 +943,8 @@ consFromJSON tName opts cons = do
            (caseE (varE conKey)
                   [ do txt <- newName "txt"
                        match (conP 'String [varP txt])
-                             (normalB $ parseContents txt
+                             (normalB $ parseContents pjs
+                                                      txt
                                                       (Right conVal)
                                                       'conNotFoundFail2ElemArray
                              )
@@ -777,12 +960,12 @@ consFromJSON tName opts cons = do
                   ]
            )
 
-    parseObjectWithSingleField obj = do
+    parseObjectWithSingleField pjs obj = do
       conKey <- newName "conKey"
       conVal <- newName "conVal"
       caseE ([e|H.toList|] `appE` varE obj)
             [ match (listP [tupP [varP conKey, varP conVal]])
-                    (normalB $ parseContents conKey (Right conVal) 'conNotFoundFailObjectSingleField)
+                    (normalB $ parseContents pjs conKey (Right conVal) 'conNotFoundFailObjectSingleField)
                     []
             , do other <- newName "other"
                  match (varP other)
@@ -793,7 +976,7 @@ consFromJSON tName opts cons = do
                        []
             ]
 
-    parseContents conKey contents errorFun =
+    parseContents pjs conKey contents errorFun =
         caseE (varE conKey)
               [ match wildP
                       ( guardedB $
@@ -801,7 +984,7 @@ consFromJSON tName opts cons = do
                                                      [|(==)|]
                                                      ([|T.pack|] `appE`
                                                         conNameExp opts con)
-                             e <- parseArgs tName opts con contents
+                             e <- parseArgs jc pjs tName opts con contents
                              return (g, e)
                         | con <- cons
                         ]
@@ -845,30 +1028,40 @@ parseNullaryMatches tName conName =
     , matchFailed tName conName "Array"
     ]
 
-parseUnaryMatches :: Name -> [Q Match]
-parseUnaryMatches conName =
+parseUnaryMatches :: JSONClass -> TyVarMap -> Type -> Name -> [Q Match]
+parseUnaryMatches jc tvMap argTy conName =
     [ do arg <- newName "arg"
          match (varP arg)
                ( normalB $ infixApp (conE conName)
                                     [|(<$>)|]
-                                    ([|parseJSON|] `appE` varE arg)
+                                    (dispatchParseJSON jc conName tvMap argTy
+                                      `appE` varE arg)
                )
                []
     ]
 
-parseRecord :: Options -> Name -> Name -> [VarStrictType] -> Name -> ExpQ
-parseRecord opts tName conName ts obj =
+parseRecord :: JSONClass
+            -> TyVarMap
+            -> [Type]
+            -> Options
+            -> Name
+            -> Name
+            -> [VarStrictType]
+            -> Name
+            -> ExpQ
+parseRecord jc tvMap argTys opts tName conName ts obj =
     foldl' (\a b -> infixApp a [|(<*>)|] b)
            (infixApp (conE conName) [|(<$>)|] x)
            xs
     where
       x:xs = [ [|lookupField|]
+               `appE` dispatchParseJSON jc conName tvMap argTy
                `appE` (litE $ stringL $ show tName)
                `appE` (litE $ stringL $ constructorTagModifier opts $ nameBase conName)
                `appE` (varE obj)
                `appE` ( [|T.pack|] `appE` fieldLabelExp opts field
                       )
-             | (field, _, _) <- ts
+             | ((field, _, _), argTy) <- zip ts argTys
              ]
 
 getValField :: Name -> String -> [MatchQ] -> Q Exp
@@ -881,80 +1074,93 @@ getValField obj valFieldName matches = do
       , noBindS $ caseE (varE val) matches
       ]
 
+matchCases :: Either (String, Name) Name -> [MatchQ] -> Q Exp
+matchCases (Left (valFieldName, obj)) = getValField obj valFieldName
+matchCases (Right valName)            = caseE (varE valName)
+
 -- | Generates code to parse the JSON encoding of a single constructor.
-parseArgs :: Name -- ^ Name of the type to which the constructor belongs.
+parseArgs :: JSONClass -- ^ The FromJSON variant being derived.
+          -> [(Name, Name)] -- ^ The names of the encoding/decoding function arguments.
+          -> Name -- ^ Name of the type to which the constructor belongs.
           -> Options -- ^ Encoding options.
           -> Con -- ^ Constructor for which to generate JSON parsing code.
           -> Either (String, Name) Name -- ^ Left (valFieldName, objName) or
                                         --   Right valName
           -> Q Exp
 -- Nullary constructors.
-parseArgs _ _ (NormalC conName []) (Left _) =
+parseArgs jc pjs _ _ (NormalC conName []) (Left _) = do
+  ([], _) <- reifyConTys jc pjs conName
   [|pure|] `appE` conE conName
-parseArgs tName _ (NormalC conName []) (Right valName) =
+parseArgs jc pjs tName _ (NormalC conName []) (Right valName) = do
+  ([], _) <- reifyConTys jc pjs conName
   caseE (varE valName) $ parseNullaryMatches tName conName
 
 -- Unary constructors.
-parseArgs _ _ (NormalC conName [_]) (Left (valFieldName, obj)) =
-  getValField obj valFieldName $ parseUnaryMatches conName
-parseArgs _ _ (NormalC conName [_]) (Right valName) =
-  caseE (varE valName) $ parseUnaryMatches conName
+parseArgs jc pjs _ _ (NormalC conName [_]) contents = do
+  ([argTy], tvMap) <- reifyConTys jc pjs conName
+  matchCases contents $ parseUnaryMatches jc tvMap argTy conName
 
 -- Polyadic constructors.
-parseArgs tName _ (NormalC conName ts) (Left (valFieldName, obj)) =
-    getValField obj valFieldName $ parseProduct tName conName $ genericLength ts
-parseArgs tName _ (NormalC conName ts) (Right valName) =
-    caseE (varE valName) $ parseProduct tName conName $ genericLength ts
+parseArgs jc pjs tName _ (NormalC conName ts) contents = do
+    (argTys, tvMap) <- reifyConTys jc pjs conName
+    let len = genericLength ts
+    matchCases contents $ parseProduct jc tvMap argTys tName conName len
 
 -- Records.
-parseArgs tName opts (RecC conName ts) (Left (_, obj)) =
-    parseRecord opts tName conName ts obj
-parseArgs tName opts (RecC conName ts) (Right valName) = case (unwrapUnaryRecords opts,ts) of
-  (True,[(_,st,ty)])-> parseArgs tName opts (NormalC conName [(st,ty)]) (Right valName)
+parseArgs jc pjs tName opts (RecC conName ts) (Left (_, obj)) = do
+    (argTys, tvMap) <- reifyConTys jc pjs conName
+    parseRecord jc tvMap argTys opts tName conName ts obj
+parseArgs jc pjs tName opts (RecC conName ts) (Right valName) = case (unwrapUnaryRecords opts,ts) of
+  (True,[(_,st,ty)])-> parseArgs jc pjs tName opts (NormalC conName [(st,ty)]) (Right valName)
   _ -> do
     obj <- newName "recObj"
+    (argTys, tvMap) <- reifyConTys jc pjs conName
     caseE (varE valName)
-      [ match (conP 'Object [varP obj]) (normalB $ parseRecord opts tName conName ts obj) []
+      [ match (conP 'Object [varP obj]) (normalB $
+          parseRecord jc tvMap argTys opts tName conName ts obj) []
       , matchFailed tName conName "Object"
       ]
 
 -- Infix constructors. Apart from syntax these are the same as
 -- polyadic constructors.
-parseArgs tName _ (InfixC _ conName _) (Left (valFieldName, obj)) =
-    getValField obj valFieldName $ parseProduct tName conName 2
-parseArgs tName _ (InfixC _ conName _) (Right valName) =
-    caseE (varE valName) $ parseProduct tName conName 2
+parseArgs jc pjs tName _ (InfixC _ conName _) contents = do
+    (argTys, tvMap) <- reifyConTys jc pjs conName
+    matchCases contents $ parseProduct jc tvMap argTys tName conName 2
 
 -- Existentially quantified constructors. We ignore the quantifiers
 -- and proceed with the contained constructor.
-parseArgs tName opts (ForallC _ _ con) contents =
-    parseArgs tName opts con contents
+parseArgs jc pjs tName opts (ForallC _ _ con) contents =
+    parseArgs jc pjs tName opts con contents
 
 #if MIN_VERSION_template_haskell(2,11,0)
 -- GADTs. We ignore the refined return type and proceed as if it were a
 -- NormalC or RecC.
-parseArgs tName opts (GadtC conNames ts _) contents =
-    parseArgs tName opts (NormalC (head conNames) ts) contents
+parseArgs jc pjs tName opts (GadtC conNames ts _) contents =
+    parseArgs jc pjs tName opts (NormalC (head conNames) ts) contents
 
-parseArgs tName opts (RecGadtC conNames ts _) contents =
-    parseArgs tName opts (RecC (head conNames) ts) contents
+parseArgs jc pjs tName opts (RecGadtC conNames ts _) contents =
+    parseArgs jc pjs tName opts (RecC (head conNames) ts) contents
 #endif
 
 -- | Generates code to parse the JSON encoding of an n-ary
 -- constructor.
-parseProduct :: Name -- ^ Name of the type to which the constructor belongs.
+parseProduct :: JSONClass -- ^ The FromJSON variant being derived.
+             -> TyVarMap -- ^ Maps the last type variables to their decoding
+                         --   function arguments.
+             -> [Type] -- ^ The argument types of the constructor.
+             -> Name -- ^ Name of the type to which the constructor belongs.
              -> Name -- ^ 'Con'structor name.
              -> Integer -- ^ 'Con'structor arity.
              -> [Q Match]
-parseProduct tName conName numArgs =
+parseProduct jc tvMap argTys tName conName numArgs =
     [ do arr <- newName "arr"
          -- List of: "parseJSON (arr `V.unsafeIndex` <IX>)"
-         let x:xs = [ [|parseJSON|]
+         let x:xs = [ dispatchParseJSON jc conName tvMap argTy
                       `appE`
                       infixApp (varE arr)
                                [|V.unsafeIndex|]
                                (litE $ integerL ix)
-                    | ix <- [0 .. numArgs - 1]
+                    | (argTy, ix) <- zip argTys [0 .. numArgs - 1]
                     ]
          match (conP 'Array [varP arr])
                (normalB $ condE ( infixApp ([|V.length|] `appE` varE arr)
@@ -976,7 +1182,6 @@ parseProduct tName conName numArgs =
                []
     , matchFailed tName conName "Array"
     ]
-
 
 --------------------------------------------------------------------------------
 -- Parsing errors
@@ -1002,17 +1207,25 @@ parseTypeMismatch tName conName expected actual =
           , actual
           ]
 
-class (FromJSON a) => LookupField a where
-    lookupField :: String -> String -> Object -> T.Text -> Parser a
+class LookupField a where
+    lookupField :: (Value -> Parser a) -> String -> String
+                -> Object -> T.Text -> Parser a
 
-instance OVERLAPPABLE_ (FromJSON a) => LookupField a where
-    lookupField tName rec obj key =
-        case H.lookup key obj of
-          Nothing -> unknownFieldFail tName rec (T.unpack key)
-          Just v  -> parseJSON v <?> Key key
+instance OVERLAPPABLE_ LookupField a where
+    lookupField = lookupFieldWith
 
-instance (FromJSON a) => LookupField (Maybe a) where
-    lookupField _ _ = (.:?)
+instance LookupField (Maybe a) where
+    lookupField pj _ _ = parseOptionalFieldWith pj
+
+lookupFieldWith :: (Value -> Parser a) -> String -> String
+                -> Object -> T.Text -> Parser a
+lookupFieldWith pj tName rec obj key =
+    case H.lookup key obj of
+      Nothing -> unknownFieldFail tName rec (T.unpack key)
+      Just v  -> pj v <?> Key key
+
+keyValuePairWith :: (v -> Value) -> T.Text -> v -> Pair
+keyValuePairWith tj name value = (name, tj value)
 
 unknownFieldFail :: String -> String -> String -> Parser fail
 unknownFieldFail tName rec key =
@@ -1063,6 +1276,120 @@ parseTypeMismatch' conName tName expected actual =
     fail $ printf "When parsing the constructor %s of type %s expected %s but got %s."
                   conName tName expected actual
 
+--------------------------------------------------------------------------------
+-- Shared ToJSON and FromJSON code
+--------------------------------------------------------------------------------
+
+-- | Functionality common to 'deriveJSON', 'deriveJSON1', and 'deriveJSON2'.
+deriveJSONBoth :: (Options -> Name -> Q [Dec])
+               -- ^ Function which derives a flavor of 'ToJSON'.
+               -> (Options -> Name -> Q [Dec])
+               -- ^ Function which derives a flavor of 'FromJSON'.
+               -> Options
+               -- ^ Encoding options.
+               -> Name
+               -- ^ Name of the type for which to generate 'ToJSON' and 'FromJSON'
+               -- instances.
+               -> Q [Dec]
+deriveJSONBoth dtj dfj opts name =
+    liftM2 (++) (dtj opts name) (dfj opts name)
+
+-- | Functionality common to @deriveToJSON(1)(2)@ and @deriveFromJSON(1)(2)@.
+deriveJSONClass :: [(JSONFun, JSONClass -> Name -> Options -> [Con] -> Q Exp)]
+                -- ^ The class methods and the functions which derive them.
+                -> JSONClass
+                -- ^ The class for which to generate an instance.
+                -> Options
+                -- ^ Encoding options.
+                -> Name
+                -- ^ Name of the type for which to generate a class instance
+                -- declaration.
+                -> Q [Dec]
+deriveJSONClass consFuns jc opts name =
+    withType name $ \name' ctxt tvbs cons mbTys ->
+        fmap (:[]) $ fromCons name' ctxt tvbs cons mbTys
+  where
+    fromCons :: Name -> Cxt -> [TyVarBndr] -> [Con] -> Maybe [Type] -> Q Dec
+    fromCons name' ctxt tvbs cons mbTys = do
+      (instanceCxt, instanceType)
+        <- buildTypeInstance name' jc ctxt tvbs mbTys
+      instanceD (return instanceCxt)
+                (return instanceType)
+                (methodDecs name' cons)
+
+    methodDecs :: Name -> [Con] -> [Q Dec]
+    methodDecs name' cons = flip map consFuns $ \(jf, jfMaker) ->
+      funD (jsonFunValName jf (arity jc))
+           [ clause []
+                    (normalB $ jfMaker jc name' opts cons)
+                    []
+           ]
+
+mkFunCommon :: (JSONClass -> Name -> Options -> [Con] -> Q Exp)
+            -- ^ The function which derives the expression.
+            -> JSONClass
+            -- ^ Which class's method is being derived.
+            -> Options
+            -- ^ Encoding options.
+            -> Name
+            -- ^ Name of the encoded type.
+            -> Q Exp
+mkFunCommon consFun jc opts name = withType name fromCons
+  where
+    fromCons :: Name -> Cxt -> [TyVarBndr] -> [Con] -> Maybe [Type] -> Q Exp
+    fromCons name' ctxt tvbs cons mbTys = do
+        -- We force buildTypeInstance here since it performs some checks for whether
+        -- or not the provided datatype's kind matches the derived method's
+        -- typeclass, and produces errors if it can't.
+        !_ <- buildTypeInstance name' jc ctxt tvbs mbTys
+        consFun jc name' opts cons
+
+dispatchFunByType :: JSONClass
+                  -> JSONFun
+                  -> Name
+                  -> TyVarMap
+                  -> Bool -- True if we are using the function argument that works
+                          -- on lists (e.g., [a] -> Value). False is we are using
+                          -- the function argument that works on single values
+                          -- (e.g., a -> Value).
+                  -> Type
+                  -> Q Exp
+dispatchFunByType _ jf _ tvMap list (VarT tyName) =
+    varE $ case M.lookup tyName tvMap of
+                Just (tfjExp, tfjlExp) -> if list then tfjlExp else tfjExp
+                Nothing                -> jsonFunValOrListName list jf Arity0
+dispatchFunByType jc jf conName tvMap list (SigT ty _) =
+    dispatchFunByType jc jf conName tvMap list ty
+dispatchFunByType jc jf conName tvMap list (ForallT _ _ ty) =
+    dispatchFunByType jc jf conName tvMap list ty
+dispatchFunByType jc jf conName tvMap list ty = do
+    let tyCon :: Type
+        tyArgs :: [Type]
+        tyCon :| tyArgs = unapplyTy ty
+
+        numLastArgs :: Int
+        numLastArgs = min (arityInt jc) (length tyArgs)
+
+        lhsArgs, rhsArgs :: [Type]
+        (lhsArgs, rhsArgs) = splitAt (length tyArgs - numLastArgs) tyArgs
+
+        tyVarNames :: [Name]
+        tyVarNames = M.keys tvMap
+
+    itf <- isTyFamily tyCon
+    if any (`mentionsName` tyVarNames) lhsArgs
+          || itf && any (`mentionsName` tyVarNames) tyArgs
+       then outOfPlaceTyVarError jc conName
+       else appsE $ [ varE . jsonFunValOrListName list jf $ toEnum numLastArgs]
+                   ++ zipWith (dispatchFunByType jc jf conName tvMap)
+                              (cycle [False,True])
+                              (interleave rhsArgs rhsArgs)
+
+dispatchToJSON, dispatchToEncoding, dispatchParseJSON
+  :: JSONClass -> Name -> TyVarMap -> Type -> Q Exp
+dispatchToJSON     jc n tvMap = dispatchFunByType jc ToJSON     n tvMap False
+dispatchToEncoding jc n tvMap = dispatchFunByType jc ToEncoding n tvMap False
+dispatchParseJSON  jc n tvMap = dispatchFunByType jc ParseJSON  n tvMap False
 
 --------------------------------------------------------------------------------
 -- Utility functions
@@ -1077,12 +1404,13 @@ parseTypeMismatch' conName tName expected actual =
 
 -- Any other value will result in an exception.
 withType :: Name
-         -> (Name -> [TyVarBndr] -> [Con] -> Maybe [Type] -> Q a)
+         -> (Name -> Cxt -> [TyVarBndr] -> [Con] -> Maybe [Type] -> Q a)
          -- ^ Function that generates the actual code. Will be applied
-         -- to the datatype/data family 'Name', type variable binders and
-         -- constructors extracted from the given 'Name'. If the 'Name' is
-         -- from a data family instance constructor, it will also have its
-         -- instantiated types; otherwise, it will be 'Nothing'.
+         -- to the datatype/data family 'Name', datatype context, type
+         -- variable binders and constructors extracted from the given
+         -- 'Name'. If the 'Name' is from a data family instance
+         -- constructor, it will also have its instantiated types;
+         -- otherwise, it will be 'Nothing'.
          -> Q a
          -- ^ Resulting value in the 'Q'uasi monad.
 withType name f = do
@@ -1091,13 +1419,13 @@ withType name f = do
       TyConI dec ->
         case dec of
 #if MIN_VERSION_template_haskell(2,11,0)
-          DataD    _ _ tvbs _ cons _ -> f name tvbs cons Nothing
-          NewtypeD _ _ tvbs _ con  _ -> f name tvbs [con] Nothing
+          DataD    ctxt _ tvbs _ cons _ -> f name ctxt tvbs cons Nothing
+          NewtypeD ctxt _ tvbs _ con  _ -> f name ctxt tvbs [con] Nothing
 #else
-          DataD    _ _ tvbs   cons _ -> f name tvbs cons Nothing
-          NewtypeD _ _ tvbs   con  _ -> f name tvbs [con] Nothing
+          DataD    ctxt _ tvbs   cons _ -> f name ctxt tvbs cons Nothing
+          NewtypeD ctxt _ tvbs   con  _ -> f name ctxt tvbs [con] Nothing
 #endif
-          other -> error $ ns ++ "Unsupported type: " ++ show other
+          other -> fail $ ns ++ "Unsupported type: " ++ show other
 #if MIN_VERSION_template_haskell(2,11,0)
       DataConI _ _ parentName   -> do
 #else
@@ -1121,24 +1449,24 @@ withType name f = do
                   _ -> error $ ns ++ "Must be a data or newtype instance."
              in case instDec of
 #if MIN_VERSION_template_haskell(2,11,0)
-                  Just (DataInstD    _ _ instTys _ cons _) -> f parentName tvbs cons $ Just instTys
-                  Just (NewtypeInstD _ _ instTys _ con  _) -> f parentName tvbs [con] $ Just instTys
+                  Just (DataInstD    ctxt _ instTys _ cons _) -> f parentName ctxt tvbs cons $ Just instTys
+                  Just (NewtypeInstD ctxt _ instTys _ con  _) -> f parentName ctxt tvbs [con] $ Just instTys
 #else
-                  Just (DataInstD    _ _ instTys   cons _) -> f parentName tvbs cons $ Just instTys
-                  Just (NewtypeInstD _ _ instTys   con  _) -> f parentName tvbs [con] $ Just instTys
+                  Just (DataInstD    ctxt _ instTys   cons _) -> f parentName ctxt tvbs cons $ Just instTys
+                  Just (NewtypeInstD ctxt _ instTys   con  _) -> f parentName ctxt tvbs [con] $ Just instTys
 #endif
-                  _ -> error $ ns ++
+                  _ -> fail $ ns ++
                     "Could not find data or newtype instance constructor."
-          _ -> error $ ns ++ "Data constructor " ++ show name ++
+          _ -> fail $ ns ++ "Data constructor " ++ show name ++
             " is not from a data family instance constructor."
 #if MIN_VERSION_template_haskell(2,11,0)
       FamilyI DataFamilyD{} _ ->
 #else
       FamilyI (FamilyD DataFam _ _ _) _ ->
 #endif
-        error $ ns ++
+        fail $ ns ++
           "Cannot use a data family name. Use a data family instance constructor instead."
-      _ -> error $ ns ++ "I need the name of a plain data type constructor, "
+      _ -> fail $ ns ++ "I need the name of a plain data type constructor, "
                       ++ "or a data family instance constructor."
   where
     ns :: String
@@ -1147,8 +1475,10 @@ withType name f = do
 -- | Infer the context and instance head needed for a FromJSON or ToJSON instance.
 buildTypeInstance :: Name
                   -- ^ The type constructor or data family name
-                  -> Name
-                  -- ^ The typeclass name ('ToJSON' or 'FromJSON')
+                  -> JSONClass
+                  -- ^ The typeclass to derive
+                  -> Cxt
+                  -- ^ The datatype context
                   -> [TyVarBndr]
                   -- ^ The type variables from the data type/data family declaration
                   -> Maybe [Type]
@@ -1157,31 +1487,21 @@ buildTypeInstance :: Name
                   -> Q (Cxt, Type)
                   -- ^ The resulting 'Cxt' and 'Type' to use in a class instance
 -- Plain data type/newtype case
-buildTypeInstance tyConName constraint tvbs Nothing =
+buildTypeInstance tyConName jc dataCxt tvbs Nothing =
     let varTys :: [Type]
         varTys = map tvbToType tvbs
-    in buildTypeInstanceFromTys tyConName constraint varTys False
+    in buildTypeInstanceFromTys tyConName jc dataCxt varTys False
 -- Data family instance case
 --
 -- The CPP is present to work around a couple of annoying old GHC bugs.
 -- See Note [Polykinded data families in Template Haskell]
-buildTypeInstance dataFamName constraint tvbs (Just instTysAndKinds) = do
+buildTypeInstance dataFamName jc dataCxt tvbs (Just instTysAndKinds) = do
 #if !(MIN_VERSION_template_haskell(2,8,0)) || MIN_VERSION_template_haskell(2,10,0)
     let instTys :: [Type]
         instTys = zipWith stealKindForType tvbs instTysAndKinds
 #else
     let kindVarNames :: [Name]
         kindVarNames = nub $ concatMap (tyVarNamesOfType . tvbKind) tvbs
-
-        -- Gets all of the type/kind variable names mentioned somewhere in a Type.
-        tyVarNamesOfType :: Type -> [Name]
-        tyVarNamesOfType = go
-          where
-            go :: Type -> [Name]
-            go (AppT t1 t2) = go t1 ++ go t2
-            go (SigT t k)   = go t  ++ go k
-            go (VarT n)     = [n]
-            go _            = []
 
         numKindVars :: Int
         numKindVars = length kindVarNames
@@ -1208,10 +1528,6 @@ buildTypeInstance dataFamName constraint tvbs (Just instTysAndKinds) = do
             starKindName :: Name
             starKindName = mkNameG_tc "ghc-prim" "GHC.Prim" "*"
 
-        -- Generate a list of fresh names with a common prefix, and numbered suffixes.
-        newNameList :: String -> Int -> Q [Name]
-        newNameList prefix n = mapM (newName . (prefix ++) . show) [1..n]
-
     -- If we run this code with GHC 7.8, we might have to generate extra type
     -- variables to compensate for any type variables that Template Haskell
     -- eta-reduced away.
@@ -1224,9 +1540,6 @@ buildTypeInstance dataFamName constraint tvbs (Just instTysAndKinds) = do
         --   determine their kind by using stealKindForType. Therefore, we mark
         --   them as VarT to ensure they will be given an explicit kind annotation
         --   (and so the kind inference machinery has the right information).
-
-        substNameWithKind :: Name -> Kind -> Type -> Type
-        substNameWithKind n k = substType (M.singleton n k)
 
         substNamesWithKinds :: [(Name, Kind)] -> Type -> Type
         substNamesWithKinds nks t = foldr' (uncurry substNameWithKind) t nks
@@ -1246,50 +1559,147 @@ buildTypeInstance dataFamName constraint tvbs (Just instTysAndKinds) = do
                   -- grab the correct kind.
                 $ zipWith stealKindForType tvbs (givenTys ++ xTys)
 #endif
-    buildTypeInstanceFromTys dataFamName constraint instTys True
+    buildTypeInstanceFromTys dataFamName jc dataCxt instTys True
 
 -- For the given Types, generate an instance context and head.
 buildTypeInstanceFromTys :: Name
                          -- ^ The type constructor or data family name
-                         -> Name
-                         -- ^ The typeclass name ('ToJSON' or 'FromJSON')
+                         -> JSONClass
+                         -- ^ The typeclass to derive
+                         -> Cxt
+                         -- ^ The datatype context
                          -> [Type]
                          -- ^ The types to instantiate the instance with
                          -> Bool
                          -- ^ True if it's a data family, False otherwise
                          -> Q (Cxt, Type)
-buildTypeInstanceFromTys tyConName constraint varTysOrig isDataFamily = do
-    -- Make sure to expand through type/kind synonyms! Otherwise, we won't
-    -- be able to infer constraints as accurately.
+buildTypeInstanceFromTys tyConName jc dataCxt varTysOrig isDataFamily = do
+    -- Make sure to expand through type/kind synonyms! Otherwise, the
+    -- eta-reduction check might get tripped up over type variables in a
+    -- synonym that are actually dropped.
+    -- (See GHC Trac #11416 for a scenario where this actually happened.)
     varTysExp <- mapM expandSyn varTysOrig
 
-    let preds    :: [Maybe Pred]
-        -- Derive instance constraints for type variables of kind *
-        preds = map (deriveConstraint constraint) varTysExp
+    let remainingLength :: Int
+        remainingLength = length varTysOrig - arityInt jc
 
-        varTys :: [Type]
+        droppedTysExp :: [Type]
+        droppedTysExp = drop remainingLength varTysExp
+
+        droppedStarKindStati :: [StarKindStatus]
+        droppedStarKindStati = map canRealizeKindStar droppedTysExp
+
+    -- Check there are enough types to drop and that all of them are either of
+    -- kind * or kind k (for some kind variable k). If not, throw an error.
+    when (remainingLength < 0 || any (== NotKindStar) droppedStarKindStati) $
+      derivingKindError jc tyConName
+
+    let droppedKindVarNames :: [Name]
+        droppedKindVarNames = catKindVarNames droppedStarKindStati
+
+        -- Substitute kind * for any dropped kind variables
+        varTysExpSubst :: [Type]
+        varTysExpSubst = map (substNamesWithKindStar droppedKindVarNames) varTysExp
+
+        remainingTysExpSubst, droppedTysExpSubst :: [Type]
+        (remainingTysExpSubst, droppedTysExpSubst) =
+          splitAt remainingLength varTysExpSubst
+
+        -- All of the type variables mentioned in the dropped types
+        -- (post-synonym expansion)
+        droppedTyVarNames :: [Name]
+        droppedTyVarNames = concatMap tyVarNamesOfType droppedTysExpSubst
+
+    -- If any of the dropped types were polykinded, ensure that they are of kind *
+    -- after substituting * for the dropped kind variables. If not, throw an error.
+    unless (all hasKindStar droppedTysExpSubst) $
+      derivingKindError jc tyConName
+
+    let preds    :: [Maybe Pred]
+        kvNames  :: [[Name]]
+        kvNames' :: [Name]
+        -- Derive instance constraints (and any kind variables which are specialized
+        -- to * in those constraints)
+        (preds, kvNames) = unzip $ map (deriveConstraint jc) remainingTysExpSubst
+        kvNames' = concat kvNames
+
+        -- Substitute the kind variables specialized in the constraints with *
+        remainingTysExpSubst' :: [Type]
+        remainingTysExpSubst' =
+          map (substNamesWithKindStar kvNames') remainingTysExpSubst
+
+        -- We now substitute all of the specialized-to-* kind variable names with
+        -- *, but in the original types, not the synonym-expanded types. The reason
+        -- we do this is a superficial one: we want the derived instance to resemble
+        -- the datatype written in source code as closely as possible. For example,
+        -- for the following data family instance:
+        --
+        --   data family Fam a
+        --   newtype instance Fam String = Fam String
+        --
+        -- We'd want to generate the instance:
+        --
+        --   instance C (Fam String)
+        --
+        -- Not:
+        --
+        --   instance C (Fam [Char])
+        remainingTysOrigSubst :: [Type]
+        remainingTysOrigSubst =
+          map (substNamesWithKindStar (union droppedKindVarNames kvNames'))
+            $ take remainingLength varTysOrig
+
+        remainingTysOrigSubst' :: [Type]
         -- See Note [Kind signatures in derived instances] for an explanation
         -- of the isDataFamily check.
-        varTys =
+        remainingTysOrigSubst' =
           if isDataFamily
-             then varTysOrig
-             else map unSigT varTysOrig
+             then remainingTysOrigSubst
+             else map unSigT remainingTysOrigSubst
 
         instanceCxt :: Cxt
         instanceCxt = catMaybes preds
 
         instanceType :: Type
-        instanceType = AppT (ConT constraint)
-                     $ applyTyCon tyConName varTys
+        instanceType = AppT (ConT $ jsonClassName jc)
+                     $ applyTyCon tyConName remainingTysOrigSubst'
 
+    -- If the datatype context mentions any of the dropped type variables,
+    -- we can't derive an instance, so throw an error.
+    when (any (`predMentionsName` droppedTyVarNames) dataCxt) $
+      datatypeContextError tyConName instanceType
+    -- Also ensure the dropped types can be safely eta-reduced. Otherwise,
+    -- throw an error.
+    unless (canEtaReduce remainingTysExpSubst' droppedTysExpSubst) $
+      etaReductionError instanceType
     return (instanceCxt, instanceType)
 
--- | Attempt to derive a constraint on a Type. If it's of kind *,
--- we give it Just a ToJSON/FromJSON constraint. Otherwise, return Nothing.
-deriveConstraint :: Name -> Type -> Maybe Pred
-deriveConstraint constraint t
-  | isTyVar t && hasKindStar t = Just $ applyCon constraint $ varTToName t
-  | otherwise                  = Nothing
+-- | Attempt to derive a constraint on a Type. If successful, return
+-- Just the constraint and any kind variable names constrained to *.
+-- Otherwise, return Nothing and the empty list.
+--
+-- See Note [Type inference in derived instances] for the heuristics used to
+-- come up with constraints.
+deriveConstraint :: JSONClass -> Type -> (Maybe Pred, [Name])
+deriveConstraint jc t
+  | not (isTyVar t) = (Nothing, [])
+  | hasKindStar t   = (Just (applyCon (jcConstraint Arity0) tName), [])
+  | otherwise = case hasKindVarChain 1 t of
+      Just ns | jcArity >= Arity1
+              -> (Just (applyCon (jcConstraint Arity1) tName), ns)
+      _ -> case hasKindVarChain 2 t of
+           Just ns | jcArity == Arity2
+                   -> (Just (applyCon (jcConstraint Arity2) tName), ns)
+           _ -> (Nothing, [])
+  where
+    tName :: Name
+    tName = varTToName t
+
+    jcArity :: Arity
+    jcArity = arity jc
+
+    jcConstraint :: Arity -> Name
+    jcConstraint = jsonClassName . JSONClass (direction jc)
 
 {-
 Note [Polykinded data families in Template Haskell]
@@ -1372,7 +1782,134 @@ knowing which instance we are talking about. To avoid this scenario, we always
 include explicit kind signatures in data family instances. There is a chance that
 the inferred kind signatures will be incorrect, but if so, we can always fall back
 on the mk- functions.
+
+Note [Type inference in derived instances]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Type inference is can be tricky to get right, and we want to avoid recreating the
+entirety of GHC's type inferencer in Template Haskell. For this reason, we will
+probably never come up with derived instance contexts that are as accurate as
+GHC's. But that doesn't mean we can't do anything! There are a couple of simple
+things we can do to make instance contexts that work for 80% of use cases:
+
+1. If one of the last type parameters is polykinded, then its kind will be
+   specialized to * in the derived instance. We note what kind variable the type
+   parameter had and substitute it with * in the other types as well. For example,
+   imagine you had
+
+     data Data (a :: k) (b :: k)
+
+   Then you'd want to derived instance to be:
+
+     instance C (Data (a :: *))
+
+   Not:
+
+     instance C (Data (a :: k))
+
+2. We naïvely come up with instance constraints using the following criteria:
+
+   (i)   If there's a type parameter n of kind *, generate a ToJSON n/FromJSON n
+         constraint.
+   (ii)  If there's a type parameter n of kind k1 -> k2 (where k1/k2 are * or kind
+         variables), then generate a ToJSON1 n/FromJSON1 n constraint, and if
+         k1/k2 are kind variables, then substitute k1/k2 with * elsewhere in the
+         types. We must consider the case where they are kind variables because
+         you might have a scenario like this:
+
+           newtype Compose (f :: k2 -> *) (g :: k1 -> k2) (a :: k1)
+             = Compose (f (g a))
+
+         Which would have a derived ToJSON1 instance of:
+
+           instance (ToJSON1 f, ToJSON1 g) => ToJSON1 (Compose f g) where ...
+   (iii) If there's a type parameter n of kind k1 -> k2 -> k3 (where k1/k2/k3 are
+         * or kind variables), then generate a ToJSON2 n/FromJSON2 n constraint
+         and perform kind substitution as in the other cases.
 -}
+
+-- Determines the types of a constructor's arguments as well as the last type
+-- parameters (mapped to their encoding/decoding functions), expanding through
+-- any type synonyms.
+--
+-- The type parameters are determined on a constructor-by-constructor basis since
+-- they may be refined to be particular types in a GADT.
+reifyConTys :: JSONClass
+            -> [(Name, Name)]
+            -> Name
+            -> Q ([Type], TyVarMap)
+reifyConTys jc tpjs conName = do
+    info  <- reify conName
+    (ctxt, uncTy) <- case info of
+        DataConI _ ty _
+#if !(MIN_VERSION_template_haskell(2,11,0))
+                _
+#endif
+                -> fmap uncurryTy (expandSyn ty)
+        _ -> error "Must be a data constructor"
+    let (argTys, [resTy]) = NE.splitAt (NE.length uncTy - 1) uncTy
+        unapResTy = unapplyTy resTy
+        -- If one of the last type variables is refined to a particular type
+        -- (i.e., not truly polymorphic), we mark it with Nothing and filter
+        -- it out later, since we only apply encoding/decoding functions to
+        -- arguments of a type that it (1) one of the last type variables,
+        -- and (2) of a truly polymorphic type.
+        jArity = arityInt jc
+        mbTvNames = map varTToName_maybe $
+                        NE.drop (NE.length unapResTy - jArity) unapResTy
+        -- We use M.fromList to ensure that if there are any duplicate type
+        -- variables (as can happen in a GADT), the rightmost type variable gets
+        -- associated with the show function.
+        --
+        -- See Note [Matching functions with GADT type variables]
+        tvMap = M.fromList
+                    . catMaybes -- Drop refined types
+                    $ zipWith (\mbTvName tpj ->
+                                  fmap (\tvName -> (tvName, tpj)) mbTvName)
+                              mbTvNames tpjs
+    if (any (`predMentionsName` M.keys tvMap) ctxt
+         || M.size tvMap < jArity)
+         && not (allowExQuant jc)
+       then existentialContextError conName
+       else return (argTys, tvMap)
+
+{-
+Note [Matching functions with GADT type variables]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When deriving ToJSON2, there is a tricky corner case to consider:
+
+  data Both a b where
+    BothCon :: x -> x -> Both x x
+
+Which encoding functions should be applied to which arguments of BothCon?
+We have a choice, since both the function of type (a -> Value) and of type
+(b -> Value) can be applied to either argument. In such a scenario, the
+second encoding function takes precedence over the first encoding function, so the
+derived ToJSON2 instance would be something like:
+
+  instance ToJSON2 Both where
+    liftToJSON2 tj1 tj2 p (BothCon x1 x2) = Array $ create $ do
+      mv <- unsafeNew 2
+      unsafeWrite mv 0 (tj1 x1)
+      unsafeWrite mv 1 (tj2 x2)
+      return mv
+
+This is not an arbitrary choice, as this definition ensures that
+liftToJSON2 toJSON = liftToJSON for a derived ToJSON1 instance for
+Both.
+-}
+
+-- A mapping of type variable Names to their encoding/decoding function Names.
+-- For example, in a ToJSON2 declaration, a TyVarMap might look like
+--
+-- { a ~> (tj1, tjl1)
+-- , b ~> (tj2, tjl2) }
+--
+-- where a and b are the last two type variables of the datatype, tj1 and tjl1 are
+-- the function arguments of types (a -> Value) and ([a] -> Value), and tj2 and tjl2
+-- are the function arguments of types (b -> Value) and ([b] -> Value).
+type TyVarMap = Map Name (Name, Name)
 
 -- | If a VarT is missing an explicit kind signature, steal it from a TyVarBndr.
 stealKindForType :: TyVarBndr -> Type -> Type
@@ -1402,12 +1939,67 @@ hasKindStar (SigT _ StarK) = True
 #endif
 hasKindStar _              = False
 
+-- Returns True is a kind is equal to *, or if it is a kind variable.
+isStarOrVar :: Kind -> Bool
+#if MIN_VERSION_template_haskell(2,8,0)
+isStarOrVar StarT  = True
+isStarOrVar VarT{} = True
+#else
+isStarOrVar StarK  = True
+#endif
+isStarOrVar _      = False
+
+-- Generate a list of fresh names with a common prefix, and numbered suffixes.
+newNameList :: String -> Int -> Q [Name]
+newNameList prefix len = mapM newName [prefix ++ show n | n <- [1..len]]
+
+-- Gets all of the type/kind variable names mentioned somewhere in a Type.
+tyVarNamesOfType :: Type -> [Name]
+tyVarNamesOfType = go
+  where
+    go :: Type -> [Name]
+    go (AppT t1 t2) = go t1 ++ go t2
+    go (SigT t _k)  = go t
+#if MIN_VERSION_template_haskell(2,8,0)
+                           ++ go _k
+#endif
+    go (VarT n)     = [n]
+    go _            = []
+
+-- | Gets all of the type/kind variable names mentioned somewhere in a Kind.
+tyVarNamesOfKind :: Kind -> [Name]
+#if MIN_VERSION_template_haskell(2,8,0)
+tyVarNamesOfKind = tyVarNamesOfType
+#else
+tyVarNamesOfKind _ = [] -- There are no kind variables
+#endif
+
+-- | @hasKindVarChain n kind@ Checks if @kind@ is of the form
+-- k_0 -> k_1 -> ... -> k_(n-1), where k0, k1, ..., and k_(n-1) can be * or
+-- kind variables.
+hasKindVarChain :: Int -> Type -> Maybe [Name]
+hasKindVarChain kindArrows t =
+  let uk = uncurryKind (tyKind t)
+  in if (NE.length uk - 1 == kindArrows) && F.all isStarOrVar uk
+        then Just (concatMap tyVarNamesOfKind uk)
+        else Nothing
+
+-- | If a Type is a SigT, returns its kind signature. Otherwise, return *.
+tyKind :: Type -> Kind
+tyKind (SigT _ k) = k
+tyKind _          = starK
+
+-- | Extract Just the Name from a type variable. If the argument Type is not a
+-- type variable, return Nothing.
+varTToName_maybe :: Type -> Maybe Name
+varTToName_maybe (VarT n)   = Just n
+varTToName_maybe (SigT t _) = varTToName_maybe t
+varTToName_maybe _          = Nothing
+
 -- | Extract the Name from a type variable. If the argument Type is not a
 -- type variable, throw an error.
 varTToName :: Type -> Name
-varTToName (VarT n)   = n
-varTToName (SigT t _) = varTToName t
-varTToName _          = error "Not a type variable!"
+varTToName = fromMaybe (error "Not a type variable!") . varTToName_maybe
 
 -- | Extracts the name from a constructor.
 getConName :: Con -> Name
@@ -1420,6 +2012,10 @@ getConName (GadtC    names _ _) = head names
 getConName (RecGadtC names _ _) = head names
 #endif
 
+interleave :: [a] -> [a] -> [a]
+interleave (a1:a1s) (a2:a2s) = a1:a2:interleave a1s a2s
+interleave _        _        = []
+
 -- | Fully applies a type constructor to its type variables.
 applyTyCon :: Name -> [Type] -> Type
 applyTyCon = foldl' AppT . ConT
@@ -1430,10 +2026,121 @@ isTyVar (VarT _)   = True
 isTyVar (SigT t _) = isTyVar t
 isTyVar _          = False
 
+-- | Is the given type a type family constructor (and not a data family constructor)?
+isTyFamily :: Type -> Q Bool
+isTyFamily (ConT n) = do
+    info <- reify n
+    return $ case info of
+#if MIN_VERSION_template_haskell(2,11,0)
+         FamilyI OpenTypeFamilyD{} _       -> True
+#else
+         FamilyI (FamilyD TypeFam _ _ _) _ -> True
+#endif
+#if MIN_VERSION_template_haskell(2,9,0)
+         FamilyI ClosedTypeFamilyD{} _     -> True
+#endif
+         _ -> False
+isTyFamily _ = return False
+
 -- | Peel off a kind signature from a Type (if it has one).
 unSigT :: Type -> Type
 unSigT (SigT t _) = t
 unSigT t          = t
+
+-- | Are all of the items in a list (which have an ordering) distinct?
+--
+-- This uses Set (as opposed to nub) for better asymptotic time complexity.
+allDistinct :: Ord a => [a] -> Bool
+allDistinct = allDistinct' Set.empty
+  where
+    allDistinct' :: Ord a => Set a -> [a] -> Bool
+    allDistinct' uniqs (x:xs)
+        | x `Set.member` uniqs = False
+        | otherwise            = allDistinct' (Set.insert x uniqs) xs
+    allDistinct' _ _           = True
+
+-- | Does the given type mention any of the Names in the list?
+mentionsName :: Type -> [Name] -> Bool
+mentionsName = go
+  where
+    go :: Type -> [Name] -> Bool
+    go (AppT t1 t2) names = go t1 names || go t2 names
+    go (SigT t _k)  names = go t names
+#if MIN_VERSION_template_haskell(2,8,0)
+                              || go _k names
+#endif
+    go (VarT n)     names = n `elem` names
+    go _            _     = False
+
+-- | Does an instance predicate mention any of the Names in the list?
+predMentionsName :: Pred -> [Name] -> Bool
+#if MIN_VERSION_template_haskell(2,10,0)
+predMentionsName = mentionsName
+#else
+predMentionsName (ClassP n tys) names = n `elem` names || any (`mentionsName` names) tys
+predMentionsName (EqualP t1 t2) names = mentionsName t1 names || mentionsName t2 names
+#endif
+
+-- | Split an applied type into its individual components. For example, this:
+--
+-- @
+-- Either Int Char
+-- @
+--
+-- would split to this:
+--
+-- @
+-- [Either, Int, Char]
+-- @
+unapplyTy :: Type -> NonEmpty Type
+unapplyTy = NE.reverse . go
+  where
+    go :: Type -> NonEmpty Type
+    go (AppT t1 t2)    = t2 <| go t1
+    go (SigT t _)      = go t
+    go (ForallT _ _ t) = go t
+    go t               = t :| []
+
+-- | Split a type signature by the arrows on its spine. For example, this:
+--
+-- @
+-- forall a b. (a ~ b) => (a -> b) -> Char -> ()
+-- @
+--
+-- would split to this:
+--
+-- @
+-- (a ~ b, [a -> b, Char, ()])
+-- @
+uncurryTy :: Type -> (Cxt, NonEmpty Type)
+uncurryTy (AppT (AppT ArrowT t1) t2) =
+  let (ctxt, tys) = uncurryTy t2
+  in (ctxt, t1 <| tys)
+uncurryTy (SigT t _) = uncurryTy t
+uncurryTy (ForallT _ ctxt t) =
+  let (ctxt', tys) = uncurryTy t
+  in (ctxt ++ ctxt', tys)
+uncurryTy t = ([], t :| [])
+
+-- | Like uncurryType, except on a kind level.
+uncurryKind :: Kind -> NonEmpty Kind
+#if MIN_VERSION_template_haskell(2,8,0)
+uncurryKind = snd . uncurryTy
+#else
+uncurryKind (ArrowK k1 k2) = k1 <| uncurryKind k2
+uncurryKind k              = k :| []
+#endif
+
+createKindChain :: Int -> Kind
+createKindChain = go starK
+  where
+    go :: Kind -> Int -> Kind
+    go k !0 = k
+#if MIN_VERSION_template_haskell(2,8,0)
+    go k !n = go (AppT (AppT ArrowT StarT) k) (n - 1)
+#else
+    go k !n = go (ArrowK StarK k) (n - 1)
+#endif
 
 -- | Makes a string literal expression from a constructor's name.
 conNameExp :: Options -> Con -> Q Exp
@@ -1465,6 +2172,22 @@ applyCon con t =
 #else
           ClassP con [VarT t]
 #endif
+
+-- | Checks to see if the last types in a data family instance can be safely eta-
+-- reduced (i.e., dropped), given the other types. This checks for three conditions:
+--
+-- (1) All of the dropped types are type variables
+-- (2) All of the dropped types are distinct
+-- (3) None of the remaining types mention any of the dropped types
+canEtaReduce :: [Type] -> [Type] -> Bool
+canEtaReduce remaining dropped =
+       all isTyVar dropped
+    && allDistinct droppedNames -- Make sure not to pass something of type [Type], since Type
+                                -- didn't have an Ord instance until template-haskell-2.10.0.0
+    && not (any (`mentionsName` droppedNames) remaining)
+  where
+    droppedNames :: [Name]
+    droppedNames = map varTToName dropped
 
 -------------------------------------------------------------------------------
 -- Expanding type synonyms
@@ -1507,6 +2230,7 @@ expandSynApp t ts = do
     return $ foldl' AppT t' ts
 
 type TypeSubst = Map Name Type
+type KindSubst = Map Name Kind
 
 mkSubst :: [TyVarBndr] -> [Type] -> TypeSubst
 mkSubst vs ts =
@@ -1526,3 +2250,182 @@ substType subs (SigT t k)      = SigT (substType subs t)
                                       k
 #endif
 substType _ t                  = t
+
+substKind :: KindSubst -> Type -> Type
+#if MIN_VERSION_template_haskell(2,8,0)
+substKind = substType
+#else
+substKind _ t = t -- There are no kind variables!
+#endif
+
+substNameWithKind :: Name -> Kind -> Type -> Type
+substNameWithKind n k = substKind (M.singleton n k)
+
+substNamesWithKindStar :: [Name] -> Type -> Type
+substNamesWithKindStar ns t = foldr' (flip substNameWithKind starK) t ns
+
+-------------------------------------------------------------------------------
+-- Error messages
+-------------------------------------------------------------------------------
+
+-- | Either the given data type doesn't have enough type variables, or one of
+-- the type variables to be eta-reduced cannot realize kind *.
+derivingKindError :: JSONClass -> Name -> Q a
+derivingKindError jc tyConName = fail
+  . showString "Cannot derive well-kinded instance of form ‘"
+  . showString className
+  . showChar ' '
+  . showParen True
+    ( showString (nameBase tyConName)
+    . showString " ..."
+    )
+  . showString "‘\n\tClass "
+  . showString className
+  . showString " expects an argument of kind "
+  . showString (pprint . createKindChain $ arityInt jc)
+  $ ""
+  where
+    className :: String
+    className = nameBase $ jsonClassName jc
+
+-- | One of the last type variables cannot be eta-reduced (see the canEtaReduce
+-- function for the criteria it would have to meet).
+etaReductionError :: Type -> Q a
+etaReductionError instanceType = fail $
+    "Cannot eta-reduce to an instance of form \n\tinstance (...) => "
+    ++ pprint instanceType
+
+-- | The data type has a DatatypeContext which mentions one of the eta-reduced
+-- type variables.
+datatypeContextError :: Name -> Type -> Q a
+datatypeContextError dataName instanceType = fail
+    . showString "Can't make a derived instance of ‘"
+    . showString (pprint instanceType)
+    . showString "‘:\n\tData type ‘"
+    . showString (nameBase dataName)
+    . showString "‘ must not have a class context involving the last type argument(s)"
+    $ ""
+
+-- | The data type mentions one of the n eta-reduced type variables in a place other
+-- than the last nth positions of a data type in a constructor's field.
+outOfPlaceTyVarError :: JSONClass -> Name -> a
+outOfPlaceTyVarError jc conName = error
+    . showString "Constructor ‘"
+    . showString (nameBase conName)
+    . showString "‘ must only use its last "
+    . shows n
+    . showString " type variable(s) within the last "
+    . shows n
+    . showString " argument(s) of a data type"
+    $ ""
+  where
+    n :: Int
+    n = arityInt jc
+
+-- | The data type has an existential constraint which mentions one of the
+-- eta-reduced type variables.
+existentialContextError :: Name -> a
+existentialContextError conName = error
+  . showString "Constructor ‘"
+  . showString (nameBase conName)
+  . showString "‘ must be truly polymorphic in the last argument(s) of the data type"
+  $ ""
+
+-------------------------------------------------------------------------------
+-- Class-specific constants
+-------------------------------------------------------------------------------
+
+-- | A representation of the arity of the ToJSON/FromJSON typeclass being derived.
+data Arity = Arity0 | Arity1 | Arity2
+  deriving (Enum, Eq, Ord)
+
+-- | Whether ToJSON(1)(2) or FromJSON(1)(2) is being derived.
+data Direction = To | From
+
+-- | A representation of which typeclass method is being spliced in.
+data JSONFun = ToJSON | ToEncoding | ParseJSON
+
+-- | A representation of which typeclass is being derived.
+data JSONClass = JSONClass { direction :: Direction, arity :: Arity }
+
+toJSONClass, toJSON1Class, toJSON2Class,
+    fromJSONClass, fromJSON1Class, fromJSON2Class :: JSONClass
+toJSONClass    = JSONClass To   Arity0
+toJSON1Class   = JSONClass To   Arity1
+toJSON2Class   = JSONClass To   Arity2
+fromJSONClass  = JSONClass From Arity0
+fromJSON1Class = JSONClass From Arity1
+fromJSON2Class = JSONClass From Arity2
+
+jsonClassName :: JSONClass -> Name
+jsonClassName (JSONClass To   Arity0) = ''ToJSON
+jsonClassName (JSONClass To   Arity1) = ''ToJSON1
+jsonClassName (JSONClass To   Arity2) = ''ToJSON2
+jsonClassName (JSONClass From Arity0) = ''FromJSON
+jsonClassName (JSONClass From Arity1) = ''FromJSON1
+jsonClassName (JSONClass From Arity2) = ''FromJSON2
+
+jsonFunValName :: JSONFun -> Arity -> Name
+jsonFunValName ToJSON     Arity0 = 'toJSON
+jsonFunValName ToJSON     Arity1 = 'liftToJSON
+jsonFunValName ToJSON     Arity2 = 'liftToJSON2
+jsonFunValName ToEncoding Arity0 = 'toEncoding
+jsonFunValName ToEncoding Arity1 = 'liftToEncoding
+jsonFunValName ToEncoding Arity2 = 'liftToEncoding2
+jsonFunValName ParseJSON  Arity0 = 'parseJSON
+jsonFunValName ParseJSON  Arity1 = 'liftParseJSON
+jsonFunValName ParseJSON  Arity2 = 'liftParseJSON2
+
+jsonFunListName :: JSONFun -> Arity -> Name
+jsonFunListName ToJSON     Arity0 = 'toJSONList
+jsonFunListName ToJSON     Arity1 = 'liftToJSONList
+jsonFunListName ToJSON     Arity2 = 'liftToJSONList2
+jsonFunListName ToEncoding Arity0 = 'toEncodingList
+jsonFunListName ToEncoding Arity1 = 'liftToEncodingList
+jsonFunListName ToEncoding Arity2 = 'liftToEncodingList2
+jsonFunListName ParseJSON  Arity0 = 'parseJSONList
+jsonFunListName ParseJSON  Arity1 = 'liftParseJSONList
+jsonFunListName ParseJSON  Arity2 = 'liftParseJSONList2
+
+jsonFunValOrListName :: Bool -- e.g., toJSONList if True, toJSON if False
+                     -> JSONFun -> Arity -> Name
+jsonFunValOrListName False = jsonFunValName
+jsonFunValOrListName True  = jsonFunListName
+
+arityInt :: JSONClass -> Int
+arityInt = fromEnum . arity
+
+allowExQuant :: JSONClass -> Bool
+allowExQuant (JSONClass To _) = True
+allowExQuant _                = False
+
+-------------------------------------------------------------------------------
+-- StarKindStatus
+-------------------------------------------------------------------------------
+
+-- | Whether a type is not of kind *, is of kind *, or is a kind variable.
+data StarKindStatus = NotKindStar
+                    | KindStar
+                    | IsKindVar Name
+  deriving Eq
+
+-- | Does a Type have kind * or k (for some kind variable k)?
+canRealizeKindStar :: Type -> StarKindStatus
+canRealizeKindStar t
+  | hasKindStar t = KindStar
+  | otherwise = case t of
+#if MIN_VERSION_template_haskell(2,8,0)
+                     SigT _ (VarT k) -> IsKindVar k
+#endif
+                     _               -> NotKindStar
+
+-- | Returns 'Just' the kind variable 'Name' of a 'StarKindStatus' if it exists.
+-- Otherwise, returns 'Nothing'.
+starKindStatusToName :: StarKindStatus -> Maybe Name
+starKindStatusToName (IsKindVar n) = Just n
+starKindStatusToName _             = Nothing
+
+-- | Concat together all of the StarKindStatuses that are IsKindVar and extract
+-- the kind variables' Names out.
+catKindVarNames :: [StarKindStatus] -> [Name]
+catKindVarNames = mapMaybe starKindStatusToName

--- a/Data/Aeson/Types.hs
+++ b/Data/Aeson/Types.hs
@@ -61,9 +61,14 @@ module Data.Aeson.Types
     , GFromJSON(..)
     , GToJSON(..)
     , GToEncoding(..)
+    , Zero
+    , One
     , genericToJSON
+    , genericLiftToJSON
     , genericToEncoding
+    , genericLiftToEncoding
     , genericParseJSON
+    , genericLiftParseJSON
 
     -- * Inspecting @'Value's@
     , withObject

--- a/Data/Aeson/Types/Generic.hs
+++ b/Data/Aeson/Types/Generic.hs
@@ -30,9 +30,10 @@ import Data.Aeson.Types.Instances
 import Data.Aeson.Types.Internal
 import Data.Bits (unsafeShiftR)
 import Data.DList (DList, toList, empty)
+import Data.List (intersperse)
 import Data.Maybe (fromMaybe)
 import Data.Monoid ((<>))
-import Data.List (intersperse)
+import Data.Proxy (Proxy(..))
 import Data.Text (Text, pack, unpack)
 import GHC.Generics
 import qualified Data.HashMap.Strict as H
@@ -47,211 +48,280 @@ import Data.Monoid (mempty, mconcat)
 --------------------------------------------------------------------------------
 -- Generic toJSON
 
-instance OVERLAPPABLE_ (GToJSON a) => GToJSON (M1 i c a) where
+instance OVERLAPPABLE_ (GToJSON arity a) => GToJSON arity (M1 i c a) where
     -- Meta-information, which is not handled elsewhere, is ignored:
-    gToJSON opts = gToJSON opts . unM1
+    gToJSON opts pa tj tjl = gToJSON opts pa tj tjl . unM1
 
-instance (ToJSON a) => GToJSON (K1 i a) where
+instance (ToJSON a) => GToJSON arity (K1 i a) where
     -- Constant values are encoded using their ToJSON instance:
-    gToJSON _opts = toJSON . unK1
+    gToJSON _opts _ _ _ = toJSON . unK1
 
-instance GToJSON U1 where
+instance GToJSON One Par1 where
+    -- Direct occurrences of the last type parameter are encoded with the
+    -- function passed in as an argument:
+    gToJSON _opts _ tj _ = tj . unPar1
+
+instance (ToJSON1 f) => GToJSON One (Rec1 f) where
+    -- Recursive occurrences of the last type parameter are encoded using their
+    -- ToJSON1 instance:
+    gToJSON _opts _ tj tjl = liftToJSON tj tjl . unRec1
+
+instance GToJSON arity U1 where
     -- Empty constructors are encoded to an empty array:
-    gToJSON _opts _ = emptyArray
+    gToJSON _opts _ _ _ _ = emptyArray
 
-instance (ConsToJSON a) => GToJSON (C1 c a) where
+instance (ConsToJSON arity a) => GToJSON arity (C1 c a) where
     -- Constructors need to be encoded differently depending on whether they're
     -- a record or not. This distinction is made by 'consToJSON':
-    gToJSON opts = consToJSON opts . unM1
+    gToJSON opts pa tj tjl = consToJSON opts pa tj tjl . unM1
 
-instance ( WriteProduct a, WriteProduct b
-         , ProductSize  a, ProductSize  b ) => GToJSON (a :*: b) where
+instance ( WriteProduct arity a, WriteProduct arity b
+         , ProductSize        a, ProductSize        b
+         ) => GToJSON arity (a :*: b) where
     -- Products are encoded to an array. Here we allocate a mutable vector of
     -- the same size as the product and write the product's elements to it using
     -- 'writeProduct':
-    gToJSON opts p =
+    gToJSON opts pa tj tjl p =
         Array $ V.create $ do
           mv <- VM.unsafeNew lenProduct
-          writeProduct opts mv 0 lenProduct p
+          writeProduct opts pa mv 0 lenProduct tj tjl p
           return mv
         where
           lenProduct = (unTagged2 :: Tagged2 (a :*: b) Int -> Int)
                        productSize
 
-instance ( AllNullary (a :+: b) allNullary
-         , SumToJSON  (a :+: b) allNullary ) => GToJSON (a :+: b) where
+instance ( AllNullary       (a :+: b) allNullary
+         , SumToJSON  arity (a :+: b) allNullary
+         ) => GToJSON arity (a :+: b) where
     -- If all constructors of a sum datatype are nullary and the
     -- 'allNullaryToStringTag' option is set they are encoded to
     -- strings.  This distinction is made by 'sumToJSON':
-    gToJSON opts = (unTagged :: Tagged allNullary Value -> Value)
-                 . sumToJSON opts
+    gToJSON opts pa tj tjl = (unTagged :: Tagged allNullary Value -> Value)
+                           . sumToJSON opts pa tj tjl
+
+instance (ToJSON1 f, GToJSON One g) => GToJSON One (f :.: g) where
+    -- If an occurrence of the last type parameter is nested inside two
+    -- composed types, it is encoded by using the outermost type's ToJSON1
+    -- instance to generically encode the innermost type:
+    gToJSON opts pa tj tjl =
+      let gtj = gToJSON opts pa tj tjl in
+      liftToJSON gtj (listValue gtj) . unComp1
 
 --------------------------------------------------------------------------------
 -- Generic toEncoding
 
-instance OVERLAPPABLE_ (GToEncoding a) => GToEncoding (M1 i c a) where
+instance OVERLAPPABLE_ (GToEncoding arity a) => GToEncoding arity (M1 i c a) where
     -- Meta-information, which is not handled elsewhere, is ignored:
-    gToEncoding opts = gToEncoding opts . unM1
+    gToEncoding opts pa te tel = gToEncoding opts pa te tel . unM1
 
-instance (ToJSON a) => GToEncoding (K1 i a) where
+instance (ToJSON a) => GToEncoding arity (K1 i a) where
     -- Constant values are encoded using their ToJSON instance:
-    gToEncoding _opts = toEncoding . unK1
+    gToEncoding _opts _ _ _ = toEncoding . unK1
 
-instance GToEncoding U1 where
+instance GToEncoding One Par1 where
+    -- Direct occurrences of the last type parameter are encoded with the
+    -- function passed in as an argument:
+    gToEncoding _opts _ te _ = te . unPar1
+
+instance (ToJSON1 f) => GToEncoding One (Rec1 f) where
+    -- Recursive occurrences of the last type parameter are encoded using their
+    -- ToEncoding1 instance:
+    gToEncoding _opts _ te tel = liftToEncoding te tel . unRec1
+
+instance GToEncoding arity U1 where
     -- Empty constructors are encoded to an empty array:
-    gToEncoding _opts _ = E.emptyArray_
+    gToEncoding _opts _ _ _ _ = E.emptyArray_
 
-instance (ConsToEncoding a) => GToEncoding (C1 c a) where
+instance (ConsToEncoding arity a) => GToEncoding arity (C1 c a) where
     -- Constructors need to be encoded differently depending on whether they're
     -- a record or not. This distinction is made by 'consToEncoding':
-    gToEncoding opts = consToEncoding opts . unM1
+    gToEncoding opts pa te tel = consToEncoding opts pa te tel . unM1
 
-instance ( EncodeProduct a, EncodeProduct b ) => GToEncoding (a :*: b) where
+instance ( EncodeProduct  arity a
+         , EncodeProduct  arity b
+         ) => GToEncoding arity (a :*: b) where
     -- Products are encoded to an array. Here we allocate a mutable vector of
     -- the same size as the product and write the product's elements to it using
     -- 'encodeProduct':
-    gToEncoding opts p = E.tuple $ encodeProduct opts p
+    gToEncoding opts pa te tel p = E.tuple $ encodeProduct opts pa te tel p
 
-instance ( AllNullary    (a :+: b) allNullary
-         , SumToEncoding (a :+: b) allNullary ) => GToEncoding (a :+: b) where
+instance ( AllNullary           (a :+: b) allNullary
+         , SumToEncoding  arity (a :+: b) allNullary
+         ) => GToEncoding arity (a :+: b) where
     -- If all constructors of a sum datatype are nullary and the
     -- 'allNullaryToStringTag' option is set they are encoded to
     -- strings.  This distinction is made by 'sumToEncoding':
-    gToEncoding opts
+    gToEncoding opts pa te tel
         = (unTagged :: Tagged allNullary Encoding -> Encoding)
-        . sumToEncoding opts
+        . sumToEncoding opts pa te tel
+
+instance (ToJSON1 f, GToEncoding One g) => GToEncoding One (f :.: g) where
+    -- If an occurrence of the last type parameter is nested inside two
+    -- composed types, it is encoded by using the outermost type's ToJSON1
+    -- instance to generically encode the innermost type:
+    gToEncoding opts pa te tel =
+      let gte = gToEncoding opts pa te tel in
+      liftToEncoding gte (listEncoding gte) . unComp1
 
 --------------------------------------------------------------------------------
 
-class SumToJSON f allNullary where
-    sumToJSON :: Options -> f a -> Tagged allNullary Value
+class SumToJSON arity f allNullary where
+    sumToJSON :: Options -> Proxy arity
+              -> (a -> Value) -> ([a] -> Value)
+              -> f a -> Tagged allNullary Value
 
-instance ( GetConName               f
-         , TaggedObjectPairs        f
-         , ObjectWithSingleFieldObj f
-         , TwoElemArrayObj          f ) => SumToJSON f True where
-    sumToJSON opts
+instance ( GetConName                     f
+         , TaggedObjectPairs        arity f
+         , ObjectWithSingleFieldObj arity f
+         , TwoElemArrayObj          arity f
+         ) => SumToJSON arity f True where
+    sumToJSON opts pa tj tjl
         | allNullaryToStringTag opts = Tagged . String . pack
                                      . constructorTagModifier opts . getConName
-        | otherwise = Tagged . nonAllNullarySumToJSON opts
+        | otherwise = Tagged . nonAllNullarySumToJSON opts pa tj tjl
 
-instance ( TwoElemArrayObj          f
-         , TaggedObjectPairs        f
-         , ObjectWithSingleFieldObj f ) => SumToJSON f False where
-    sumToJSON opts = Tagged . nonAllNullarySumToJSON opts
+instance ( TwoElemArrayObj          arity f
+         , TaggedObjectPairs        arity f
+         , ObjectWithSingleFieldObj arity f
+         ) => SumToJSON arity f False where
+    sumToJSON opts pa tj tjl = Tagged . nonAllNullarySumToJSON opts pa tj tjl
 
-nonAllNullarySumToJSON :: ( TwoElemArrayObj          f
-                          , TaggedObjectPairs        f
-                          , ObjectWithSingleFieldObj f
-                          ) => Options -> f a -> Value
-nonAllNullarySumToJSON opts =
+nonAllNullarySumToJSON :: ( TwoElemArrayObj          arity f
+                          , TaggedObjectPairs        arity f
+                          , ObjectWithSingleFieldObj arity f
+                          ) => Options -> Proxy arity
+                            -> (a -> Value) -> ([a] -> Value)
+                            -> f a -> Value
+nonAllNullarySumToJSON opts pa tj tjl =
     case sumEncoding opts of
       TaggedObject{..}      ->
-        object . taggedObjectPairs opts tagFieldName contentsFieldName
-      ObjectWithSingleField -> Object . objectWithSingleFieldObj opts
-      TwoElemArray          -> Array  . twoElemArrayObj opts
+        object . taggedObjectPairs opts pa tagFieldName contentsFieldName tj tjl
+      ObjectWithSingleField -> Object . objectWithSingleFieldObj opts pa tj tjl
+      TwoElemArray          -> Array  . twoElemArrayObj opts pa tj tjl
 
 --------------------------------------------------------------------------------
 
-class SumToEncoding f allNullary where
-    sumToEncoding :: Options -> f a -> Tagged allNullary Encoding
+class SumToEncoding arity f allNullary where
+    sumToEncoding :: Options -> Proxy arity
+                  -> (a -> Encoding) -> ([a] -> Encoding)
+                  -> f a -> Tagged allNullary Encoding
 
-instance ( GetConName               f
-         , TaggedObjectEnc          f
-         , ObjectWithSingleFieldEnc f
-         , TwoElemArrayEnc          f ) => SumToEncoding f True where
-    sumToEncoding opts
+instance ( GetConName                     f
+         , TaggedObjectEnc          arity f
+         , ObjectWithSingleFieldEnc arity f
+         , TwoElemArrayEnc          arity f
+         ) => SumToEncoding arity f True where
+    sumToEncoding opts pa te tel
         | allNullaryToStringTag opts = Tagged . toEncoding .
                                        constructorTagModifier opts . getConName
-        | otherwise = Tagged . nonAllNullarySumToEncoding opts
+        | otherwise = Tagged . nonAllNullarySumToEncoding opts pa te tel
 
-instance ( TwoElemArrayEnc          f
-         , TaggedObjectEnc          f
-         , ObjectWithSingleFieldEnc f ) => SumToEncoding f False where
-    sumToEncoding opts = Tagged . nonAllNullarySumToEncoding opts
+instance ( TwoElemArrayEnc          arity f
+         , TaggedObjectEnc          arity f
+         , ObjectWithSingleFieldEnc arity f
+         ) => SumToEncoding arity f False where
+    sumToEncoding opts pa te tel = Tagged . nonAllNullarySumToEncoding opts pa te tel
 
-nonAllNullarySumToEncoding :: ( TwoElemArrayEnc          f
-                              , TaggedObjectEnc          f
-                              , ObjectWithSingleFieldEnc f
-                              ) => Options -> f a -> Encoding
-nonAllNullarySumToEncoding opts =
+nonAllNullarySumToEncoding :: ( TwoElemArrayEnc          arity f
+                              , TaggedObjectEnc          arity f
+                              , ObjectWithSingleFieldEnc arity f
+                              ) => Options -> Proxy arity
+                                -> (a -> Encoding) -> ([a] -> Encoding)
+                                -> f a -> Encoding
+nonAllNullarySumToEncoding opts pa te tel =
     case sumEncoding opts of
       TaggedObject{..}      ->
-        taggedObjectEnc opts tagFieldName contentsFieldName
-      ObjectWithSingleField -> objectWithSingleFieldEnc opts
-      TwoElemArray          -> twoElemArrayEnc opts
+        taggedObjectEnc opts pa tagFieldName contentsFieldName te tel
+      ObjectWithSingleField -> objectWithSingleFieldEnc opts pa te tel
+      TwoElemArray          -> twoElemArrayEnc opts pa te tel
 
 --------------------------------------------------------------------------------
 
-class TaggedObjectPairs f where
-    taggedObjectPairs :: Options -> String -> String -> f a -> [Pair]
+class TaggedObjectPairs arity f where
+    taggedObjectPairs :: Options -> Proxy arity
+                      -> String -> String
+                      -> (a -> Value) -> ([a] -> Value)
+                      -> f a -> [Pair]
 
-instance ( TaggedObjectPairs a
-         , TaggedObjectPairs b ) => TaggedObjectPairs (a :+: b) where
-    taggedObjectPairs opts tagFieldName contentsFieldName (L1 x) =
-        taggedObjectPairs opts tagFieldName contentsFieldName     x
-    taggedObjectPairs opts tagFieldName contentsFieldName (R1 x) =
-        taggedObjectPairs opts tagFieldName contentsFieldName     x
+instance ( TaggedObjectPairs arity a
+         , TaggedObjectPairs arity b
+         ) => TaggedObjectPairs arity (a :+: b) where
+    taggedObjectPairs opts pa tagFieldName contentsFieldName tj tjl (L1 x) =
+        taggedObjectPairs opts pa tagFieldName contentsFieldName tj tjl x
+    taggedObjectPairs opts pa tagFieldName contentsFieldName tj tjl (R1 x) =
+        taggedObjectPairs opts pa tagFieldName contentsFieldName tj tjl x
 
-instance ( IsRecord           a isRecord
-         , TaggedObjectPairs' a isRecord
-         , Constructor c ) => TaggedObjectPairs (C1 c a) where
-    taggedObjectPairs opts tagFieldName contentsFieldName =
+instance ( IsRecord                 a isRecord
+         , TaggedObjectPairs' arity a isRecord
+         , Constructor c
+         ) => TaggedObjectPairs arity (C1 c a) where
+    taggedObjectPairs opts pa tagFieldName contentsFieldName tj tjl =
         (pack tagFieldName .= constructorTagModifier opts
                                  (conName (undefined :: t c a p)) :) .
         (unTagged :: Tagged isRecord [Pair] -> [Pair]) .
-          taggedObjectPairs' opts contentsFieldName . unM1
+          taggedObjectPairs' opts pa contentsFieldName tj tjl . unM1
 
-class TaggedObjectPairs' f isRecord where
-    taggedObjectPairs' :: Options -> String -> f a -> Tagged isRecord [Pair]
+class TaggedObjectPairs' arity f isRecord where
+    taggedObjectPairs' :: Options -> Proxy arity
+                       -> String -> (a -> Value) -> ([a] -> Value)
+                       -> f a -> Tagged isRecord [Pair]
 
-instance OVERLAPPING_ TaggedObjectPairs' U1 False where
-    taggedObjectPairs' _ _ _ = Tagged []
+instance OVERLAPPING_ TaggedObjectPairs' arity U1 False where
+    taggedObjectPairs' _ _ _ _ _ _ = Tagged []
 
-instance (RecordToPairs f) => TaggedObjectPairs' f True where
-    taggedObjectPairs' opts _ = Tagged . toList . recordToPairs opts
+instance (RecordToPairs arity f) => TaggedObjectPairs' arity f True where
+    taggedObjectPairs' opts pa _ tj tjl =
+      Tagged . toList . recordToPairs opts pa tj tjl
 
-instance (GToJSON f) => TaggedObjectPairs' f False where
-    taggedObjectPairs' opts contentsFieldName =
-        Tagged . (:[]) . (pack contentsFieldName .=) . gToJSON opts
+instance (GToJSON arity f) => TaggedObjectPairs' arity f False where
+    taggedObjectPairs' opts pa contentsFieldName tj tjl =
+        Tagged . (:[]) . (pack contentsFieldName .=) . gToJSON opts pa tj tjl
 
 --------------------------------------------------------------------------------
 
-class TaggedObjectEnc f where
-    taggedObjectEnc :: Options -> String -> String -> f a -> Encoding
+class TaggedObjectEnc arity f where
+    taggedObjectEnc :: Options -> Proxy arity
+                    -> String -> String
+                    -> (a -> Encoding) -> ([a] -> Encoding)
+                    -> f a -> Encoding
 
-instance ( TaggedObjectEnc a
-         , TaggedObjectEnc b ) => TaggedObjectEnc (a :+: b) where
-    taggedObjectEnc opts tagFieldName contentsFieldName (L1 x) =
-        taggedObjectEnc opts tagFieldName contentsFieldName     x
-    taggedObjectEnc opts tagFieldName contentsFieldName (R1 x) =
-        taggedObjectEnc opts tagFieldName contentsFieldName     x
+instance ( TaggedObjectEnc    arity a
+         , TaggedObjectEnc    arity b
+         ) => TaggedObjectEnc arity (a :+: b) where
+    taggedObjectEnc opts pa tagFieldName contentsFieldName te tel (L1 x) =
+        taggedObjectEnc opts pa tagFieldName contentsFieldName te tel x
+    taggedObjectEnc opts pa tagFieldName contentsFieldName te tel (R1 x) =
+        taggedObjectEnc opts pa tagFieldName contentsFieldName te tel x
 
-instance ( IsRecord         a isRecord
-         , TaggedObjectEnc' a isRecord
-         , Constructor c ) => TaggedObjectEnc (C1 c a) where
-    taggedObjectEnc opts tagFieldName contentsFieldName v =
+instance ( IsRecord               a isRecord
+         , TaggedObjectEnc' arity a isRecord
+         , Constructor c
+         ) => TaggedObjectEnc arity (C1 c a) where
+    taggedObjectEnc opts pa tagFieldName contentsFieldName te tel v =
         E.openCurly <>
         (toEncoding tagFieldName <>
          E.colon <>
          toEncoding (constructorTagModifier opts (conName (undefined :: t c a p)))) <>
         ((unTagged :: Tagged isRecord Encoding -> Encoding) .
-         taggedObjectEnc' opts contentsFieldName . unM1 $ v) <>
+         taggedObjectEnc' opts pa contentsFieldName te tel . unM1 $ v) <>
         E.closeCurly
 
-class TaggedObjectEnc' f isRecord where
-    taggedObjectEnc' :: Options -> String -> f a -> Tagged isRecord Encoding
+class TaggedObjectEnc' arity f isRecord where
+    taggedObjectEnc' :: Options -> Proxy arity
+                     -> String -> (a -> Encoding) -> ([a] -> Encoding)
+                     -> f a -> Tagged isRecord Encoding
 
-instance OVERLAPPING_ TaggedObjectEnc' U1 False where
-    taggedObjectEnc' _ _ _ = Tagged mempty
+instance OVERLAPPING_ TaggedObjectEnc' arity U1 False where
+    taggedObjectEnc' _ _ _ _ _ _ = Tagged mempty
 
-instance (RecordToEncoding f) => TaggedObjectEnc' f True where
-    taggedObjectEnc' opts _ = Tagged . (E.comma <>) . fst . recordToEncoding opts
+instance (RecordToEncoding arity f) => TaggedObjectEnc' arity f True where
+    taggedObjectEnc' opts pa _ te tel = Tagged . (E.comma <>) . fst
+                                               . recordToEncoding opts pa te tel
 
-instance (GToEncoding f) => TaggedObjectEnc' f False where
-    taggedObjectEnc' opts contentsFieldName =
+instance (GToEncoding arity f) => TaggedObjectEnc' arity f False where
+    taggedObjectEnc' opts pa contentsFieldName te tel =
         Tagged . (\z -> E.comma <> toEncoding contentsFieldName <> E.colon <> z) .
-        gToEncoding opts
+        gToEncoding opts pa te tel
 
 --------------------------------------------------------------------------------
 
@@ -268,283 +338,369 @@ instance (Constructor c) => GetConName (C1 c a) where
 
 --------------------------------------------------------------------------------
 
-class TwoElemArrayObj f where
-    twoElemArrayObj :: Options -> f a -> V.Vector Value
+class TwoElemArrayObj arity f where
+    twoElemArrayObj :: Options -> Proxy arity
+                    -> (a -> Value) -> ([a] -> Value)
+                    -> f a -> V.Vector Value
 
-instance (TwoElemArrayObj a, TwoElemArrayObj b) => TwoElemArrayObj (a :+: b) where
-    twoElemArrayObj opts (L1 x) = twoElemArrayObj opts x
-    twoElemArrayObj opts (R1 x) = twoElemArrayObj opts x
+instance ( TwoElemArrayObj arity a
+         , TwoElemArrayObj arity b
+         ) => TwoElemArrayObj arity (a :+: b) where
+    twoElemArrayObj opts pa tj tjl (L1 x) = twoElemArrayObj opts pa tj tjl x
+    twoElemArrayObj opts pa tj tjl (R1 x) = twoElemArrayObj opts pa tj tjl x
 
-instance ( GToJSON a, ConsToJSON a
-         , Constructor c ) => TwoElemArrayObj (C1 c a) where
-    twoElemArrayObj opts x = V.create $ do
+instance ( GToJSON    arity a
+         , ConsToJSON arity a
+         , Constructor c
+         ) => TwoElemArrayObj arity (C1 c a) where
+    twoElemArrayObj opts pa tj tjl x = V.create $ do
       mv <- VM.unsafeNew 2
       VM.unsafeWrite mv 0 $ String $ pack $ constructorTagModifier opts
                                    $ conName (undefined :: t c a p)
-      VM.unsafeWrite mv 1 $ gToJSON opts x
+      VM.unsafeWrite mv 1 $ gToJSON opts pa tj tjl x
       return mv
 
 --------------------------------------------------------------------------------
 
-class TwoElemArrayEnc f where
-    twoElemArrayEnc :: Options -> f a -> Encoding
+class TwoElemArrayEnc arity f where
+    twoElemArrayEnc :: Options -> Proxy arity
+                    -> (a -> Encoding) -> ([a] -> Encoding)
+                    -> f a -> Encoding
 
-instance (TwoElemArrayEnc a, TwoElemArrayEnc b) => TwoElemArrayEnc (a :+: b) where
-    twoElemArrayEnc opts (L1 x) = twoElemArrayEnc opts x
-    twoElemArrayEnc opts (R1 x) = twoElemArrayEnc opts x
+instance ( TwoElemArrayEnc    arity a
+         , TwoElemArrayEnc    arity b
+         ) => TwoElemArrayEnc arity (a :+: b) where
+    twoElemArrayEnc opts pa te tel (L1 x) = twoElemArrayEnc opts pa te tel x
+    twoElemArrayEnc opts pa te tel (R1 x) = twoElemArrayEnc opts pa te tel x
 
-instance ( GToEncoding a, ConsToEncoding a
-         , Constructor c ) => TwoElemArrayEnc (C1 c a) where
-    twoElemArrayEnc opts x = E.tuple $
+instance ( GToEncoding    arity a
+         , ConsToEncoding arity a
+         , Constructor c
+         ) => TwoElemArrayEnc arity (C1 c a) where
+    twoElemArrayEnc opts pa te tel x = E.tuple $
       toEncoding (constructorTagModifier opts (conName (undefined :: t c a p))) >*<
-      gToEncoding opts x
+      gToEncoding opts pa te tel x
 
 --------------------------------------------------------------------------------
 
-class ConsToJSON f where
-    consToJSON     :: Options -> f a -> Value
+class ConsToJSON arity f where
+    consToJSON     :: Options -> Proxy arity
+                   -> (a -> Value) -> ([a] -> Value)
+                   -> f a -> Value
 
-class ConsToJSON' f isRecord where
-    consToJSON'     :: Options -> Bool -- ^ Are we a record with one field?
+class ConsToJSON' arity f isRecord where
+    consToJSON'     :: Options -> Proxy arity
+                    -> Bool -- ^ Are we a record with one field?
+                    -> (a -> Value) -> ([a] -> Value)
                     -> f a -> Tagged isRecord Value
 
-instance ( IsRecord    f isRecord
-         , ConsToJSON' f isRecord ) => ConsToJSON f where
-    consToJSON opts = (unTagged :: Tagged isRecord Value -> Value)
-                    . consToJSON' opts (isUnary (undefined :: f a))
+instance ( IsRecord          f isRecord
+         , ConsToJSON' arity f isRecord
+         ) => ConsToJSON arity f where
+    consToJSON opts pa tj tjl =
+        (unTagged :: Tagged isRecord Value -> Value)
+      . consToJSON' opts pa (isUnary (undefined :: f a)) tj tjl
 
-instance (RecordToPairs f) => ConsToJSON' f True where
-    consToJSON' opts isUn f = let
-      vals = toList $ recordToPairs opts f
+instance (RecordToPairs arity f) => ConsToJSON' arity f True where
+    consToJSON' opts pa isUn tj tjl f = let
+      vals = toList $ recordToPairs opts pa tj tjl f
       in case (unwrapUnaryRecords opts,isUn,vals) of
         (True,True,[(_,val)]) -> Tagged val
         _ -> Tagged $ object vals
 
-instance GToJSON f => ConsToJSON' f False where
-    consToJSON' opts _ = Tagged . gToJSON opts
+instance GToJSON arity f => ConsToJSON' arity f False where
+    consToJSON' opts pa _ tj tjl = Tagged . gToJSON opts pa tj tjl
 
 --------------------------------------------------------------------------------
 
-class ConsToEncoding f where
-    consToEncoding :: Options -> f a -> Encoding
+class ConsToEncoding arity f where
+    consToEncoding :: Options -> Proxy arity
+                   -> (a -> Encoding) -> ([a] -> Encoding)
+                   -> f a -> Encoding
 
-class ConsToEncoding' f isRecord where
-    consToEncoding' :: Options -> Bool -- ^ Are we a record with one field?
-                    -> f a -> Tagged isRecord Encoding 
+class ConsToEncoding' arity f isRecord where
+    consToEncoding' :: Options -> Proxy arity
+                    -> Bool -- ^ Are we a record with one field?
+                    -> (a -> Encoding) -> ([a] -> Encoding)
+                    -> f a -> Tagged isRecord Encoding
 
-instance ( IsRecord        f isRecord
-         , ConsToEncoding' f isRecord ) => ConsToEncoding f where
-    consToEncoding opts = (unTagged :: Tagged isRecord Encoding -> Encoding)
-                          . consToEncoding' opts (isUnary (undefined :: f a))
+instance ( IsRecord                f isRecord
+         , ConsToEncoding'   arity f isRecord
+         ) => ConsToEncoding arity f where
+    consToEncoding opts pa te tel =
+        (unTagged :: Tagged isRecord Encoding -> Encoding)
+      . consToEncoding' opts pa (isUnary (undefined :: f a)) te tel
 
-instance (RecordToEncoding f) => ConsToEncoding' f True where
-    consToEncoding' opts isUn x =
-      let (enc, mbVal) = recordToEncoding opts x
+instance (RecordToEncoding arity f) => ConsToEncoding' arity f True where
+    consToEncoding' opts pa isUn te tel x =
+      let (enc, mbVal) = recordToEncoding opts pa te tel x
       in case (unwrapUnaryRecords opts, isUn, mbVal) of
            (True, True, Just val) -> Tagged val
-           _ -> Tagged $ E.wrapObject enc 
+           _ -> Tagged $ E.wrapObject enc
 
-instance GToEncoding f => ConsToEncoding' f False where
-    consToEncoding' opts _ = Tagged . gToEncoding opts
+instance GToEncoding arity f => ConsToEncoding' arity f False where
+    consToEncoding' opts pa _ te tel = Tagged . gToEncoding opts pa te tel
 
 --------------------------------------------------------------------------------
 
-class RecordToPairs f where
-    recordToPairs    :: Options -> f a -> DList Pair
+class RecordToPairs arity f where
+    recordToPairs    :: Options -> Proxy arity
+                     -> (a -> Value) -> ([a] -> Value)
+                     -> f a -> DList Pair
 
-instance (RecordToPairs a, RecordToPairs b) => RecordToPairs (a :*: b) where
-    recordToPairs opts (a :*: b) = recordToPairs opts a <>
-                                   recordToPairs opts b
+instance ( RecordToPairs arity a
+         , RecordToPairs arity b
+         ) => RecordToPairs arity (a :*: b) where
+    recordToPairs opts pa tj tjl (a :*: b) = recordToPairs opts pa tj tjl a <>
+                                             recordToPairs opts pa tj tjl b
 
-instance (Selector s, GToJSON a) => RecordToPairs (S1 s a) where
+instance (Selector s, GToJSON arity a) => RecordToPairs arity (S1 s a) where
     recordToPairs = fieldToPair
 
 instance OVERLAPPING_ (Selector s, ToJSON a) =>
-  RecordToPairs (S1 s (K1 i (Maybe a))) where
-    recordToPairs opts (M1 k1) | omitNothingFields opts
-                               , K1 Nothing <- k1 = empty
-    recordToPairs opts m1 = fieldToPair opts m1
+  RecordToPairs arity (S1 s (K1 i (Maybe a))) where
+    recordToPairs opts _ _ _ (M1 k1) | omitNothingFields opts
+                                     , K1 Nothing <- k1 = empty
+    recordToPairs opts pa tj tjl m1 = fieldToPair opts pa tj tjl m1
 
-fieldToPair :: (Selector s, GToJSON a) => Options -> S1 s a p -> DList Pair
-fieldToPair opts m1 = pure ( pack $ fieldLabelModifier opts $ selName m1
-                           , gToJSON opts (unM1 m1)
-                           )
+fieldToPair :: (Selector s, GToJSON arity a)
+            => Options -> Proxy arity
+            -> (p -> Value) -> ([p] -> Value)
+            -> S1 s a p -> DList Pair
+fieldToPair opts pa tj tjl m1 = pure ( pack $ fieldLabelModifier opts $ selName m1
+                                     , gToJSON opts pa tj tjl (unM1 m1)
+                                     )
 
 --------------------------------------------------------------------------------
 
-class RecordToEncoding f where
+class RecordToEncoding arity f where
     -- 1st element: whole thing
     -- 2nd element: in case the record has only 1 field, just the value
     --              of the field (without the key); 'Nothing' otherwise
-    recordToEncoding :: Options -> f a -> (Encoding, Maybe Encoding)
+    recordToEncoding :: Options -> Proxy arity
+                     -> (a -> Encoding) -> ([a] -> Encoding)
+                     -> f a -> (Encoding, Maybe Encoding)
 
-instance (RecordToEncoding a, RecordToEncoding b) => RecordToEncoding (a :*: b) where
-    recordToEncoding opts (a :*: b) | omitNothingFields opts =
+instance ( RecordToEncoding    arity a
+         , RecordToEncoding    arity b
+         ) => RecordToEncoding arity (a :*: b) where
+    recordToEncoding opts pa te tel (a :*: b) | omitNothingFields opts =
       (mconcat $ intersperse E.comma $
         filter (not . E.nullEncoding)
-        [fst (recordToEncoding opts a), fst (recordToEncoding opts b)]
+        [ fst (recordToEncoding opts pa te tel a)
+        , fst (recordToEncoding opts pa te tel b) ]
       , Nothing)
-    recordToEncoding opts (a :*: b) =
-      (fst (recordToEncoding opts a) <> E.comma <>
-       fst (recordToEncoding opts b),
+    recordToEncoding opts pa te tel (a :*: b) =
+      (fst (recordToEncoding opts pa te tel a) <> E.comma <>
+       fst (recordToEncoding opts pa te tel b),
        Nothing)
 
-instance (Selector s, GToEncoding a) => RecordToEncoding (S1 s a) where
+instance (Selector s, GToEncoding arity a) => RecordToEncoding arity (S1 s a) where
     recordToEncoding = fieldToEncoding
 
 instance OVERLAPPING_ (Selector s, ToJSON a) =>
-  RecordToEncoding (S1 s (K1 i (Maybe a))) where
-    recordToEncoding opts (M1 k1) | omitNothingFields opts
-                                  , K1 Nothing <- k1 = (mempty, Nothing)
-    recordToEncoding opts m1 = fieldToEncoding opts m1
+  RecordToEncoding arity (S1 s (K1 i (Maybe a))) where
+    recordToEncoding opts _ _ _ (M1 k1) | omitNothingFields opts
+                                        , K1 Nothing <- k1 = (mempty, Nothing)
+    recordToEncoding opts pa te tel m1 = fieldToEncoding opts pa te tel m1
 
-fieldToEncoding :: (Selector s, GToEncoding a) => Options -> S1 s a p -> (Encoding, Maybe Encoding)
-fieldToEncoding opts m1 =
+fieldToEncoding :: (Selector s, GToEncoding arity a)
+                => Options -> Proxy arity
+                -> (p -> Encoding) -> ([p] -> Encoding)
+                -> S1 s a p -> (Encoding, Maybe Encoding)
+fieldToEncoding opts pa te tel m1 =
   let keyBuilder = toEncoding (fieldLabelModifier opts $ selName m1)
-      valueBuilder = gToEncoding opts (unM1 m1)
+      valueBuilder = gToEncoding opts pa te tel (unM1 m1)
   in  (keyBuilder <> E.colon <> valueBuilder, Just valueBuilder)
 
 --------------------------------------------------------------------------------
 
-class WriteProduct f where
+class WriteProduct arity f where
     writeProduct :: Options
+                 -> Proxy arity
                  -> VM.MVector s Value
                  -> Int -- ^ index
                  -> Int -- ^ length
+                 -> (a -> Value)
+                 -> ([a] -> Value)
                  -> f a
                  -> ST s ()
 
-instance ( WriteProduct a
-         , WriteProduct b ) => WriteProduct (a :*: b) where
-    writeProduct opts mv ix len (a :*: b) = do
-      writeProduct opts mv ix  lenL a
-      writeProduct opts mv ixR lenR b
+instance ( WriteProduct arity a
+         , WriteProduct arity b
+         ) => WriteProduct arity (a :*: b) where
+    writeProduct opts pa mv ix len tj tjl (a :*: b) = do
+      writeProduct opts pa mv ix  lenL tj tjl a
+      writeProduct opts pa mv ixR lenR tj tjl b
         where
           lenL = len `unsafeShiftR` 1
           lenR = len - lenL
           ixR  = ix  + lenL
 
-instance OVERLAPPABLE_ (GToJSON a) => WriteProduct a where
-    writeProduct opts mv ix _ = VM.unsafeWrite mv ix . gToJSON opts
+instance OVERLAPPABLE_ (GToJSON arity a) => WriteProduct arity a where
+    writeProduct opts pa mv ix _ tj tjl =
+      VM.unsafeWrite mv ix . gToJSON opts pa tj tjl
 
 --------------------------------------------------------------------------------
 
-class EncodeProduct f where
-    encodeProduct :: Options -> f a -> Encoding 
+class EncodeProduct arity f where
+    encodeProduct :: Options -> Proxy arity
+                  -> (a -> Encoding) -> ([a] -> Encoding)
+                  -> f a -> Encoding
 
-instance ( EncodeProduct a
-         , EncodeProduct b ) => EncodeProduct (a :*: b) where
-    encodeProduct opts (a :*: b) | omitNothingFields opts =
+instance ( EncodeProduct    arity a
+         , EncodeProduct    arity b
+         ) => EncodeProduct arity (a :*: b) where
+    encodeProduct opts pa te tel (a :*: b) | omitNothingFields opts =
         mconcat $ intersperse E.comma $
         filter (not . E.nullEncoding)
-        [encodeProduct opts a, encodeProduct opts b]
-    encodeProduct opts (a :*: b) = encodeProduct opts a <>
-                                   E.comma <>
-                                   encodeProduct opts b
+        [encodeProduct opts pa te tel a, encodeProduct opts pa te tel b]
+    encodeProduct opts pa te tel (a :*: b) = encodeProduct opts pa te tel a <>
+                                             E.comma <>
+                                             encodeProduct opts pa te tel b
 
-instance OVERLAPPABLE_ (GToEncoding a) => EncodeProduct a where
+instance OVERLAPPABLE_ (GToEncoding arity a) => EncodeProduct arity a where
     encodeProduct opts = gToEncoding opts
 
 --------------------------------------------------------------------------------
 
-class ObjectWithSingleFieldObj f where
-    objectWithSingleFieldObj :: Options -> f a -> Object
+class ObjectWithSingleFieldObj arity f where
+    objectWithSingleFieldObj :: Options -> Proxy arity
+                             -> (a -> Value) -> ([a] -> Value)
+                             -> f a -> Object
 
-instance ( ObjectWithSingleFieldObj a
-         , ObjectWithSingleFieldObj b ) => ObjectWithSingleFieldObj (a :+: b) where
-    objectWithSingleFieldObj opts (L1 x) = objectWithSingleFieldObj opts x
-    objectWithSingleFieldObj opts (R1 x) = objectWithSingleFieldObj opts x
+instance ( ObjectWithSingleFieldObj arity a
+         , ObjectWithSingleFieldObj arity b
+         ) => ObjectWithSingleFieldObj arity (a :+: b) where
+    objectWithSingleFieldObj opts pa tj tjl (L1 x) =
+      objectWithSingleFieldObj opts pa tj tjl x
+    objectWithSingleFieldObj opts pa tj tjl (R1 x) =
+      objectWithSingleFieldObj opts pa tj tjl x
 
-instance ( GToJSON a, ConsToJSON a
-         , Constructor c ) => ObjectWithSingleFieldObj (C1 c a) where
-    objectWithSingleFieldObj opts = H.singleton typ . gToJSON opts
+instance ( GToJSON    arity a
+         , ConsToJSON arity a
+         , Constructor c
+         ) => ObjectWithSingleFieldObj arity (C1 c a) where
+    objectWithSingleFieldObj opts pa tj tjl = H.singleton typ . gToJSON opts pa tj tjl
         where
           typ = pack $ constructorTagModifier opts $
                          conName (undefined :: t c a p)
 
 --------------------------------------------------------------------------------
 
-class ObjectWithSingleFieldEnc f where
-    objectWithSingleFieldEnc :: Options -> f a -> Encoding
+class ObjectWithSingleFieldEnc arity f where
+    objectWithSingleFieldEnc :: Options -> Proxy arity
+                             -> (a -> Encoding) -> ([a] -> Encoding)
+                             -> f a -> Encoding
 
-instance ( ObjectWithSingleFieldEnc a
-         , ObjectWithSingleFieldEnc b ) => ObjectWithSingleFieldEnc (a :+: b) where
-    objectWithSingleFieldEnc opts (L1 x) = objectWithSingleFieldEnc opts x
-    objectWithSingleFieldEnc opts (R1 x) = objectWithSingleFieldEnc opts x
+instance ( ObjectWithSingleFieldEnc    arity a
+         , ObjectWithSingleFieldEnc    arity b
+         ) => ObjectWithSingleFieldEnc arity (a :+: b) where
+    objectWithSingleFieldEnc opts pa te tel (L1 x) =
+      objectWithSingleFieldEnc opts pa te tel x
+    objectWithSingleFieldEnc opts pa te tel (R1 x) =
+      objectWithSingleFieldEnc opts pa te tel x
 
-instance ( GToEncoding a, ConsToEncoding a
-         , Constructor c ) => ObjectWithSingleFieldEnc (C1 c a) where
-    objectWithSingleFieldEnc opts v =
+instance ( GToEncoding    arity a
+         , ConsToEncoding arity a
+         , Constructor c
+         ) => ObjectWithSingleFieldEnc arity (C1 c a) where
+    objectWithSingleFieldEnc opts pa te tel v =
       E.openCurly <>
       toEncoding
           (constructorTagModifier opts
           (conName (undefined :: t c a p))) <>
       E.colon <>
-      gToEncoding opts v <>
+      gToEncoding opts pa te tel v <>
       E.closeCurly
 
 --------------------------------------------------------------------------------
 -- Generic parseJSON
 
-instance OVERLAPPABLE_ (GFromJSON a) => GFromJSON (M1 i c a) where
+instance OVERLAPPABLE_ (GFromJSON arity a) => GFromJSON arity (M1 i c a) where
     -- Meta-information, which is not handled elsewhere, is just added to the
     -- parsed value:
-    gParseJSON opts = fmap M1 . gParseJSON opts
+    gParseJSON opts pa pj pjl = fmap M1 . gParseJSON opts pa pj pjl
 
-instance (FromJSON a) => GFromJSON (K1 i a) where
+instance (FromJSON a) => GFromJSON arity (K1 i a) where
     -- Constant values are decoded using their FromJSON instance:
-    gParseJSON _opts = fmap K1 . parseJSON
+    gParseJSON _opts _ _ _ = fmap K1 . parseJSON
 
-instance GFromJSON U1 where
+instance GFromJSON One Par1 where
+    -- Direct occurrences of the last type parameter are decoded with the
+    -- function passed in as an argument:
+    gParseJSON _opts _ pj _ = fmap Par1 . pj
+
+instance (FromJSON1 f) => GFromJSON One (Rec1 f) where
+    -- Recursive occurrences of the last type parameter are decoded using their
+    -- FromJSON1 instance:
+    gParseJSON _opts _ pj pjl = fmap Rec1 . liftParseJSON pj pjl
+
+instance GFromJSON arity U1 where
     -- Empty constructors are expected to be encoded as an empty array:
-    gParseJSON _opts v
+    gParseJSON _opts _ _ _ v
         | isEmptyArray v = pure U1
         | otherwise      = typeMismatch "unit constructor (U1)" v
 
-instance (ConsFromJSON a) => GFromJSON (C1 c a) where
+instance (ConsFromJSON arity a) => GFromJSON arity (C1 c a) where
     -- Constructors need to be decoded differently depending on whether they're
     -- a record or not. This distinction is made by consParseJSON:
-    gParseJSON opts = fmap M1 . consParseJSON opts
+    gParseJSON opts pa pj pjl = fmap M1 . consParseJSON opts pa pj pjl
 
-instance ( FromProduct a, FromProduct b
-         , ProductSize a, ProductSize b ) => GFromJSON (a :*: b) where
+instance ( FromProduct arity a, FromProduct arity b
+         , ProductSize       a, ProductSize       b
+         ) => GFromJSON arity (a :*: b) where
     -- Products are expected to be encoded to an array. Here we check whether we
     -- got an array of the same size as the product, then parse each of the
     -- product's elements using parseProduct:
-    gParseJSON opts = withArray "product (:*:)" $ \arr ->
+    gParseJSON opts pa pj pjl = withArray "product (:*:)" $ \arr ->
       let lenArray = V.length arr
           lenProduct = (unTagged2 :: Tagged2 (a :*: b) Int -> Int)
                        productSize in
       if lenArray == lenProduct
-      then parseProduct opts arr 0 lenProduct
+      then parseProduct opts pa arr 0 lenProduct pj pjl
       else fail $ "When expecting a product of " ++ show lenProduct ++
                   " values, encountered an Array of " ++ show lenArray ++
                   " elements instead"
 
-instance ( AllNullary (a :+: b) allNullary
-         , ParseSum   (a :+: b) allNullary ) => GFromJSON   (a :+: b) where
+instance ( AllNullary         (a :+: b) allNullary
+         , ParseSum     arity (a :+: b) allNullary
+         ) => GFromJSON arity (a :+: b) where
     -- If all constructors of a sum datatype are nullary and the
     -- 'allNullaryToStringTag' option is set they are expected to be
     -- encoded as strings.  This distinction is made by 'parseSum':
-    gParseJSON opts = (unTagged :: Tagged allNullary (Parser ((a :+: b) d)) ->
-                                                     (Parser ((a :+: b) d)))
-                    . parseSum opts
+    gParseJSON opts pa pj pjl =
+      (unTagged :: Tagged allNullary (Parser ((a :+: b) d)) ->
+                                     (Parser ((a :+: b) d)))
+                 . parseSum opts pa pj pjl
+
+instance (FromJSON1 f, GFromJSON One g) => GFromJSON One (f :.: g) where
+    -- If an occurrence of the last type parameter is nested inside two
+    -- composed types, it is decoded by using the outermost type's FromJSON1
+    -- instance to generically decode the innermost type:
+    gParseJSON opts pa pj pjl =
+      let gpj = gParseJSON opts pa pj pjl in
+      fmap Comp1 . liftParseJSON gpj (listParser gpj)
 
 --------------------------------------------------------------------------------
 
-class ParseSum f allNullary where
-    parseSum :: Options -> Value -> Tagged allNullary (Parser (f a))
+class ParseSum arity f allNullary where
+    parseSum :: Options -> Proxy arity
+             -> (Value -> Parser a) -> (Value -> Parser [a])
+             -> Value -> Tagged allNullary (Parser (f a))
 
-instance ( SumFromString    (a :+: b)
-         , FromPair         (a :+: b)
-         , FromTaggedObject (a :+: b) ) => ParseSum (a :+: b) True where
-    parseSum opts
+instance ( SumFromString          (a :+: b)
+         , FromPair         arity (a :+: b)
+         , FromTaggedObject arity (a :+: b)
+         ) => ParseSum      arity (a :+: b) True where
+    parseSum opts pa pj pjl
         | allNullaryToStringTag opts = Tagged . parseAllNullarySum    opts
-        | otherwise                  = Tagged . parseNonAllNullarySum opts
+        | otherwise                  = Tagged . parseNonAllNullarySum opts pa pj pjl
 
-instance ( FromPair         (a :+: b)
-         , FromTaggedObject (a :+: b) ) => ParseSum (a :+: b) False where
-    parseSum opts = Tagged . parseNonAllNullarySum opts
+instance ( FromPair         arity (a :+: b)
+         , FromTaggedObject arity (a :+: b)
+         ) => ParseSum      arity (a :+: b) False where
+    parseSum opts pa pj pjl = Tagged . parseNonAllNullarySum opts pa pj pjl
 
 --------------------------------------------------------------------------------
 
@@ -569,22 +725,24 @@ instance (Constructor c) => SumFromString (C1 c U1) where
 
 --------------------------------------------------------------------------------
 
-parseNonAllNullarySum :: ( FromPair                       (a :+: b)
-                         , FromTaggedObject               (a :+: b)
-                         ) => Options -> Value -> Parser ((a :+: b) c)
-parseNonAllNullarySum opts =
+parseNonAllNullarySum :: ( FromPair         arity (a :+: b)
+                         , FromTaggedObject arity (a :+: b)
+                         ) => Options -> Proxy arity
+                           -> (Value -> Parser c) -> (Value -> Parser [c])
+                           -> Value -> Parser ((a :+: b) c)
+parseNonAllNullarySum opts pa pj pjl =
     case sumEncoding opts of
       TaggedObject{..} ->
           withObject "Object" $ \obj -> do
             tag <- obj .: pack tagFieldName
             fromMaybe (notFound tag) $
-              parseFromTaggedObject opts contentsFieldName obj tag
+              parseFromTaggedObject opts pa contentsFieldName obj pj pjl tag
 
       ObjectWithSingleField ->
           withObject "Object" $ \obj ->
             case H.toList obj of
               [pair@(tag, _)] -> fromMaybe (notFound tag) $
-                                   parsePair opts pair
+                                   parsePair opts pa pj pjl pair
               _ -> fail "Object doesn't have a single field"
 
       TwoElemArray ->
@@ -592,27 +750,30 @@ parseNonAllNullarySum opts =
             if V.length arr == 2
             then case V.unsafeIndex arr 0 of
                    String tag -> fromMaybe (notFound tag) $
-                                   parsePair opts (tag, V.unsafeIndex arr 1)
+                                   parsePair opts pa pj pjl (tag, V.unsafeIndex arr 1)
                    _ -> fail "First element is not a String"
             else fail "Array doesn't have 2 elements"
 
 --------------------------------------------------------------------------------
 
-class FromTaggedObject f where
-    parseFromTaggedObject :: Options -> String -> Object -> Text
-                          -> Maybe (Parser (f a))
+class FromTaggedObject arity f where
+    parseFromTaggedObject :: Options -> Proxy arity
+                          -> String -> Object
+                          -> (Value -> Parser a) -> (Value -> Parser [a])
+                          -> Text -> Maybe (Parser (f a))
 
-instance (FromTaggedObject a, FromTaggedObject b) =>
-    FromTaggedObject (a :+: b) where
-        parseFromTaggedObject opts contentsFieldName obj tag =
-            (fmap L1 <$> parseFromTaggedObject opts contentsFieldName obj tag) <|>
-            (fmap R1 <$> parseFromTaggedObject opts contentsFieldName obj tag)
+instance ( FromTaggedObject arity a, FromTaggedObject arity b) =>
+    FromTaggedObject arity (a :+: b) where
+        parseFromTaggedObject opts pa contentsFieldName obj pj pjl tag =
+            (fmap L1 <$> parseFromTaggedObject opts pa contentsFieldName obj pj pjl tag) <|>
+            (fmap R1 <$> parseFromTaggedObject opts pa contentsFieldName obj pj pjl tag)
 
-instance ( FromTaggedObject' f
-         , Constructor c ) => FromTaggedObject (C1 c f) where
-    parseFromTaggedObject opts contentsFieldName obj tag
+instance ( FromTaggedObject' arity f
+         , Constructor c
+         ) => FromTaggedObject arity (C1 c f) where
+    parseFromTaggedObject opts pa contentsFieldName obj pj pjl tag
         | tag == name = Just $ M1 <$> parseFromTaggedObject'
-                                        opts contentsFieldName obj
+                                        opts pa contentsFieldName pj pjl obj
         | otherwise = Nothing
         where
           name = pack $ constructorTagModifier opts $
@@ -620,81 +781,97 @@ instance ( FromTaggedObject' f
 
 --------------------------------------------------------------------------------
 
-class FromTaggedObject' f where
-    parseFromTaggedObject' :: Options -> String -> Object -> Parser (f a)
+class FromTaggedObject' arity f where
+    parseFromTaggedObject' :: Options -> Proxy arity -> String
+                           -> (Value -> Parser a) -> (Value -> Parser [a])
+                           -> Object -> Parser (f a)
 
-class FromTaggedObject'' f isRecord where
-    parseFromTaggedObject'' :: Options -> String -> Object
-                            -> Tagged isRecord (Parser (f a))
+class FromTaggedObject'' arity f isRecord where
+    parseFromTaggedObject'' :: Options -> Proxy arity -> String
+                            -> (Value -> Parser a) -> (Value -> Parser [a])
+                            -> Object -> Tagged isRecord (Parser (f a))
 
-instance ( IsRecord             f isRecord
-         , FromTaggedObject''   f isRecord
-         ) => FromTaggedObject' f where
-    parseFromTaggedObject' opts contentsFieldName =
+instance ( IsRecord                   f isRecord
+         , FromTaggedObject''   arity f isRecord
+         ) => FromTaggedObject' arity f where
+    parseFromTaggedObject' opts pa contentsFieldName pj pjl =
         (unTagged :: Tagged isRecord (Parser (f a)) -> Parser (f a)) .
-        parseFromTaggedObject'' opts contentsFieldName
+        parseFromTaggedObject'' opts pa contentsFieldName pj pjl
 
-instance (FromRecord f) => FromTaggedObject'' f True where
-    parseFromTaggedObject'' opts _ = Tagged . parseRecord opts Nothing
+instance (FromRecord arity f) => FromTaggedObject'' arity f True where
+    parseFromTaggedObject'' opts pa _ pj pjl =
+      Tagged . parseRecord opts pa Nothing pj pjl
 
-instance (GFromJSON f) => FromTaggedObject'' f False where
-    parseFromTaggedObject'' opts contentsFieldName = Tagged .
-      (gParseJSON opts <=< (.: pack contentsFieldName))
+instance (GFromJSON arity f) => FromTaggedObject'' arity f False where
+    parseFromTaggedObject'' opts pa contentsFieldName pj pjl = Tagged .
+      (gParseJSON opts pa pj pjl <=< (.: pack contentsFieldName))
 
-instance OVERLAPPING_ FromTaggedObject'' U1 False where
-    parseFromTaggedObject'' _ _ _ = Tagged (pure U1)
+instance OVERLAPPING_ FromTaggedObject'' arity U1 False where
+    parseFromTaggedObject'' _ _ _ _ _ _ = Tagged (pure U1)
 
 --------------------------------------------------------------------------------
 
-class ConsFromJSON f where
-    consParseJSON  :: Options -> Value -> Parser (f a)
+class ConsFromJSON arity f where
+    consParseJSON  :: Options -> Proxy arity
+                   -> (Value -> Parser a) -> (Value -> Parser [a])
+                   -> Value -> Parser (f a)
 
-class ConsFromJSON' f isRecord where
-    consParseJSON' :: Options -> (Maybe Text) -- ^ A dummy label
-                                           --   (Nothing to use proper label)
+class ConsFromJSON' arity f isRecord where
+    consParseJSON' :: Options -> Proxy arity
+                   -> (Maybe Text) -- ^ A dummy label
+                                   --   (Nothing to use proper label)
+                   -> (Value -> Parser a) -> (Value -> Parser [a])
                    -> Value -> Tagged isRecord (Parser (f a))
 
-instance ( IsRecord        f isRecord
-         , ConsFromJSON'   f isRecord
-         ) => ConsFromJSON f where
-    consParseJSON opts v = let
+instance ( IsRecord            f isRecord
+         , ConsFromJSON' arity f isRecord
+         ) => ConsFromJSON arity f where
+    consParseJSON opts pa pj pjl v = let
       (v2,lab) = case (unwrapUnaryRecords opts,isUnary (undefined :: f a)) of
                        -- use a dummy object with a dummy label
         (True,True) -> ((object [(pack "dummy",v)]),Just $ pack "dummy")
         _ ->(v,Nothing)
       in (unTagged :: Tagged isRecord (Parser (f a)) -> Parser (f a))
-                       $ consParseJSON' opts lab v2
+                       $ consParseJSON' opts pa lab pj pjl v2
 
 
-instance (FromRecord f) => ConsFromJSON' f True where
-    consParseJSON' opts mlab = Tagged . (withObject "record (:*:)"
-                                $ parseRecord opts mlab)
+instance (FromRecord arity f) => ConsFromJSON' arity f True where
+    consParseJSON' opts pa mlab pj pjl = Tagged . (withObject "record (:*:)"
+                                          $ parseRecord opts pa mlab pj pjl)
 
-instance (GFromJSON f) => ConsFromJSON' f False where
-    consParseJSON' opts _ = Tagged . gParseJSON opts
+instance (GFromJSON arity f) => ConsFromJSON' arity f False where
+    consParseJSON' opts pa _ pj pjl = Tagged . gParseJSON opts pa pj pjl
 
 --------------------------------------------------------------------------------
 
-class FromRecord f where
-    parseRecord :: Options -> (Maybe Text) -- ^ A dummy label
-                                           --   (Nothing to use proper label)
-                 -> Object -> Parser (f a)
+class FromRecord arity f where
+    parseRecord :: Options -> Proxy arity
+                -> (Maybe Text) -- ^ A dummy label
+                                --   (Nothing to use proper label)
+                -> (Value -> Parser a) -> (Value -> Parser [a])
+                -> Object -> Parser (f a)
 
-instance (FromRecord a, FromRecord b) => FromRecord (a :*: b) where
-    parseRecord opts _ obj = (:*:) <$> parseRecord opts Nothing obj
-                                   <*> parseRecord opts Nothing obj
+instance ( FromRecord arity a
+         , FromRecord arity b
+         ) => FromRecord arity (a :*: b) where
+    parseRecord opts pa _ pj pjl obj =
+      (:*:) <$> parseRecord opts pa Nothing pj pjl obj
+            <*> parseRecord opts pa Nothing pj pjl obj
 
-instance (Selector s, GFromJSON a) => FromRecord (S1 s a) where
-    parseRecord opts lab = (<?> Key label) . gParseJSON opts <=< (.: label)
+instance ( Selector s
+         , GFromJSON arity a
+         ) => FromRecord arity (S1 s a) where
+    parseRecord opts pa lab pj pjl =
+      (<?> Key label) . gParseJSON opts pa pj pjl <=< (.: label)
         where
           label = fromMaybe defLabel lab
           defLabel = pack . fieldLabelModifier opts $
                        selName (undefined :: t s a p)
 
 instance OVERLAPPING_ (Selector s, FromJSON a) =>
-  FromRecord (S1 s (K1 i (Maybe a))) where
-    parseRecord _ (Just lab) obj = (M1 . K1) <$> obj .:? lab
-    parseRecord opts Nothing obj = (M1 . K1) <$> obj .:? pack label
+  FromRecord arity (S1 s (K1 i (Maybe a))) where
+    parseRecord _ _ (Just lab) _ _ obj = (M1 . K1) <$> obj .:? lab
+    parseRecord opts _ Nothing _ _ obj = (M1 . K1) <$> obj .:? pack label
         where
           label = fieldLabelModifier opts $
                     selName (undefined :: t s (K1 i (Maybe a)) p)
@@ -713,33 +890,46 @@ instance ProductSize (S1 s a) where
 
 --------------------------------------------------------------------------------
 
-class FromProduct f where
-    parseProduct :: Options -> Array -> Int -> Int -> Parser (f a)
+class FromProduct arity f where
+    parseProduct :: Options -> Proxy arity
+                 -> Array -> Int -> Int
+                 -> (Value -> Parser a) -> (Value -> Parser [a])
+                 -> Parser (f a)
 
-instance (FromProduct a, FromProduct b) => FromProduct (a :*: b) where
-    parseProduct opts arr ix len =
-        (:*:) <$> parseProduct opts arr ix  lenL
-              <*> parseProduct opts arr ixR lenR
+instance ( FromProduct    arity a
+         , FromProduct    arity b
+         ) => FromProduct arity (a :*: b) where
+    parseProduct opts pa arr ix len pj pjl =
+        (:*:) <$> parseProduct opts pa arr ix  lenL pj pjl
+              <*> parseProduct opts pa arr ixR lenR pj pjl
         where
           lenL = len `unsafeShiftR` 1
           ixR  = ix + lenL
           lenR = len - lenL
 
-instance (GFromJSON a) => FromProduct (S1 s a) where
-    parseProduct opts arr ix _ = gParseJSON opts $ V.unsafeIndex arr ix
+instance (GFromJSON arity a) => FromProduct arity (S1 s a) where
+    parseProduct opts pa arr ix _ pj pjl =
+      gParseJSON opts pa pj pjl $ V.unsafeIndex arr ix
 
 --------------------------------------------------------------------------------
 
-class FromPair f where
-    parsePair :: Options -> Pair -> Maybe (Parser (f a))
+class FromPair arity f where
+    parsePair :: Options -> Proxy arity
+              -> (Value -> Parser a) -> (Value -> Parser [a])
+              -> Pair -> Maybe (Parser (f a))
 
-instance (FromPair a, FromPair b) => FromPair (a :+: b) where
-    parsePair opts pair = (fmap L1 <$> parsePair opts pair) <|>
-                          (fmap R1 <$> parsePair opts pair)
+instance ( FromPair arity a
+         , FromPair arity b
+         ) => FromPair arity (a :+: b) where
+    parsePair opts pa pj pjl pair = (fmap L1 <$> parsePair opts pa pj pjl pair) <|>
+                                    (fmap R1 <$> parsePair opts pa pj pjl pair)
 
-instance (Constructor c, GFromJSON a, ConsFromJSON a) => FromPair (C1 c a) where
-    parsePair opts (tag, value)
-        | tag == tag' = Just $ gParseJSON opts value
+instance ( Constructor c
+         , GFromJSON    arity a
+         , ConsFromJSON arity a
+         ) => FromPair arity (C1 c a) where
+    parsePair opts pa pj pjl (tag, value)
+        | tag == tag' = Just $ gParseJSON opts pa pj pjl value
         | otherwise   = Nothing
         where
           tag' = pack $ constructorTagModifier opts $
@@ -761,6 +951,8 @@ instance OVERLAPPING_ IsRecord (M1 S NoSelector f) False
 #endif
 instance (IsRecord f isRecord) => IsRecord (M1 S c f) isRecord
 instance IsRecord (K1 i c) True
+instance IsRecord Par1 True
+instance IsRecord (f :.: g) True
 instance IsRecord U1 False
   where isUnary = const False
 
@@ -774,7 +966,9 @@ instance ( AllNullary a allNullaryL
          ) => AllNullary (a :+: b) allNullary
 instance AllNullary a allNullary => AllNullary (M1 i c a) allNullary
 instance AllNullary (a :*: b) False
+instance AllNullary (a :.: b) False
 instance AllNullary (K1 i c) False
+instance AllNullary Par1 False
 instance AllNullary U1 True
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Because boilerplate makes me sad.

This adds the capability to automatically derive:

* `ToJSON1`, `ToJSON2`, `FromJSON1`, and `FromJSON2` with Template Haskell
* `ToJSON1` and `FromJSON1` via GHC generics (sadly, generics isn't expressive enough to cover `ToJSON2` and `FromJSON2`)

This code is somewhat old and had to rebased several times recently, so @andrewthad, @phadej, please make sure I didn't accidentally trample something you wrote.