### PR TITLE
Allow building with GHC 7.4/7.6's bundled bytestring using bytestring-builder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,12 @@ before_cache:
 
 matrix:
   include:
-    - env: BUILD=cabal CABALVER=1.16 GHCVER=7.4.2
+    - env: BUILD=cabal CABALVER=1.18 GHCVER=7.4.2
       compiler: ": #GHC 7.4.2"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.4.2], sources: [hvr-ghc]}}
-    - env: BUILD=cabal CABALVER=1.16 GHCVER=7.6.3
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2], sources: [hvr-ghc]}}
+    - env: BUILD=cabal CABALVER=1.18 GHCVER=7.6.3
       compiler: ": #GHC 7.6.3"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3], sources: [hvr-ghc]}}
     - env: BUILD=cabal CABALVER=1.18 GHCVER=7.8.4
       compiler: ": #GHC 7.8.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}

--- a/Data/Aeson/Encoding/Builder.hs
+++ b/Data/Aeson/Encoding/Builder.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE BangPatterns, OverloadedStrings #-}
+{-# LANGUAGE BangPatterns, CPP, OverloadedStrings #-}
 
 -- |
 -- Module:      Data.Aeson.Encoding.Builder
@@ -52,8 +52,21 @@ import Data.Time.LocalTime
 import Data.Word (Word8)
 import qualified Data.HashMap.Strict as HMS
 import qualified Data.Text as T
-import qualified Data.Text.Encoding as TE
 import qualified Data.Vector as V
+
+#if MIN_VERSION_bytestring(0,10,4)
+import Data.Text.Encoding (encodeUtf8BuilderEscaped)
+#else
+import Data.Bits ((.&.))
+import Data.Text.Internal (Text(..))
+import Data.Text.Internal.Unsafe.Shift (shiftR)
+import Foreign.Ptr (minusPtr, plusPtr)
+import Foreign.Storable (poke)
+import qualified Data.ByteString.Builder.Internal as B
+import qualified Data.ByteString.Builder.Prim.Internal as BP
+import qualified Data.Text.Array as A
+import qualified Data.Text.Internal.Encoding.Utf16 as U16
+#endif
 
 -- | Encode a JSON value to a "Data.ByteString" 'B.Builder'.
 --
@@ -101,7 +114,7 @@ text t = B.char8 '"' <> unquoted t <> B.char8 '"'
 
 -- | Encode a JSON string, without enclosing quotes.
 unquoted :: T.Text -> Builder
-unquoted = TE.encodeUtf8BuilderEscaped escapeAscii
+unquoted = encodeUtf8BuilderEscaped escapeAscii
 
 -- | Add quotes surrounding a builder
 quote :: Builder -> Builder
@@ -254,3 +267,62 @@ twoDigits a     = T (digit hi) (digit lo)
 
 digit :: Int -> Char
 digit x = chr (x + 48)
+
+#if !(MIN_VERSION_bytestring(0,10,4))
+-- | Encode text using UTF-8 encoding and escape the ASCII characters using
+-- a 'BP.BoundedPrim'.
+--
+-- Use this function is to implement efficient encoders for text-based formats
+-- like JSON or HTML.
+{-# INLINE encodeUtf8BuilderEscaped #-}
+-- TODO: Extend documentation with references to source code in @blaze-html@
+-- or @aeson@ that uses this function.
+encodeUtf8BuilderEscaped :: BP.BoundedPrim Word8 -> Text -> B.Builder
+encodeUtf8BuilderEscaped be =
+    -- manual eta-expansion to ensure inlining works as expected
+    \txt -> B.builder (mkBuildstep txt)
+  where
+    bound = max 4 $ BP.sizeBound be
+
+    mkBuildstep (Text arr off len) !k =
+        outerLoop off
+      where
+        iend = off + len
+
+        outerLoop !i0 !br@(B.BufferRange op0 ope)
+          | i0 >= iend       = k br
+          | outRemaining > 0 = goPartial (i0 + min outRemaining inpRemaining)
+          -- TODO: Use a loop with an integrated bound's check if outRemaining
+          -- is smaller than 8, as this will save on divisions.
+          | otherwise        = return $ B.bufferFull bound op0 (outerLoop i0)
+          where
+            outRemaining = (ope `minusPtr` op0) `div` bound
+            inpRemaining = iend - i0
+
+            goPartial !iendTmp = go i0 op0
+              where
+                go !i !op
+                  | i < iendTmp = case A.unsafeIndex arr i of
+                      w | w <= 0x7F -> do
+                            BP.runB be (fromIntegral w) op >>= go (i + 1)
+                        | w <= 0x7FF -> do
+                            poke8 0 $ (w `shiftR` 6) + 0xC0
+                            poke8 1 $ (w .&. 0x3f) + 0x80
+                            go (i + 1) (op `plusPtr` 2)
+                        | 0xD800 <= w && w <= 0xDBFF -> do
+                            let c = ord $ U16.chr2 w (A.unsafeIndex arr (i+1))
+                            poke8 0 $ (c `shiftR` 18) + 0xF0
+                            poke8 1 $ ((c `shiftR` 12) .&. 0x3F) + 0x80
+                            poke8 2 $ ((c `shiftR` 6) .&. 0x3F) + 0x80
+                            poke8 3 $ (c .&. 0x3F) + 0x80
+                            go (i + 2) (op `plusPtr` 4)
+                        | otherwise -> do
+                            poke8 0 $ (w `shiftR` 12) + 0xE0
+                            poke8 1 $ ((w `shiftR` 6) .&. 0x3F) + 0x80
+                            poke8 2 $ (w .&. 0x3F) + 0x80
+                            go (i + 1) (op `plusPtr` 3)
+                  | otherwise =
+                      outerLoop i (B.BufferRange op ope)
+                  where
+                    poke8 j v = poke (op `plusPtr` j) (fromIntegral v :: Word8)
+#endif

--- a/Data/Aeson/Parser/Internal.hs
+++ b/Data/Aeson/Parser/Internal.hs
@@ -48,6 +48,7 @@ import Data.Text.Internal.Unsafe.Char (ord)
 import Data.Vector as Vector (Vector, empty, fromList, reverse)
 import Data.Word (Word8)
 import Foreign.ForeignPtr (withForeignPtr)
+import Foreign.Marshal.Utils (copyBytes)
 import Foreign.Ptr (Ptr, minusPtr, plusPtr)
 import Foreign.Storable (poke)
 import System.IO.Unsafe (unsafePerformIO)
@@ -261,7 +262,7 @@ unescape s = unsafePerformIO $ do
         let newlen = p `minusPtr` ptr
             slop = len - newlen
         Right <$> if slop >= 128 && slop >= len `quot` 4
-                  then B.create newlen $ \np -> B.memcpy np ptr newlen
+                  then B.create newlen $ \np -> copyBytes np ptr newlen
                   else return (PS fp 0 newlen)
  where
   go ptr = do
@@ -380,7 +381,7 @@ word8 w ptr = do
 copy :: ByteString -> Ptr Word8 -> Z.ZeptoT IO (Ptr Word8)
 copy (PS fp off len) ptr =
   liftIO . withForeignPtr fp $ \src -> do
-    B.memcpy ptr (src `plusPtr` off) len
+    copyBytes ptr (src `plusPtr` off) len
     return $! ptr `plusPtr` len
 
 charUtf8 :: Char -> Ptr Word8 -> Z.ZeptoT IO (Ptr Word8)

--- a/Data/Aeson/Types/ToJSON.hs
+++ b/Data/Aeson/Types/ToJSON.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns          #-}
 {-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE DefaultSignatures     #-}
@@ -96,6 +97,7 @@ import Foreign.Storable        (Storable)
 import GHC.Generics
 import Numeric.Natural         (Natural)
 
+import qualified Data.ByteString       as S
 import qualified Data.ByteString.Lazy  as L
 import qualified Data.DList            as DList
 import qualified Data.HashMap.Strict   as H
@@ -117,6 +119,15 @@ import qualified Data.Vector.Mutable   as VM
 import qualified Data.Vector.Primitive as VP
 import qualified Data.Vector.Storable  as VS
 import qualified Data.Vector.Unboxed   as VU
+
+#if !(MIN_VERSION_bytestring(0,10,0))
+import Foreign.ForeignPtr    (withForeignPtr)
+import Foreign.Marshal.Utils (copyBytes)
+import Foreign.Ptr           (plusPtr)
+
+import qualified Data.ByteString.Internal      as S
+import qualified Data.ByteString.Lazy.Internal as L
+#endif
 
 toJSONPair :: (a -> Value) -> (b -> Value) -> (a, b) -> Value
 toJSONPair a b = liftToJSON2 a (listValue a) b (listValue b)
@@ -448,7 +459,11 @@ toJSONKeyTextEnc :: (a -> Encoding' Text) -> ToJSONKeyFunction a
 toJSONKeyTextEnc e = ToJSONKeyText tot e
  where
     -- TODO: dropAround is also used in stringEncoding, which is unfortunate atm
-    tot = T.dropAround (== '"') . T.decodeLatin1 . L.toStrict . E.encodingToLazyByteString . e
+    tot = T.dropAround (== '"')
+        . T.decodeLatin1
+        . lazyToStrictByteString
+        . E.encodingToLazyByteString
+        . e
 
 -- | Contravariant map, as 'ToJSONKeyFunction' is a contravariant functor.
 contramapToJSONKeyFunction :: (b -> a) -> ToJSONKeyFunction a -> ToJSONKeyFunction b
@@ -1943,7 +1958,7 @@ stringEncoding :: Encoding' Text -> Value
 stringEncoding = String
     . T.dropAround (== '"')
     . T.decodeLatin1
-    . L.toStrict
+    . lazyToStrictByteString
     . E.encodingToLazyByteString
 {-# INLINE stringEncoding #-}
 
@@ -2583,3 +2598,28 @@ instance (ToJSON a, ToJSON b, ToJSON c, ToJSON d, ToJSON e, ToJSON f, ToJSON g, 
     {-# INLINE toJSON #-}
     toEncoding = toEncoding2
     {-# INLINE toEncoding #-}
+
+-------------------------------------------------------------------------------
+-- pre-bytestring-0.10 compatibility
+-------------------------------------------------------------------------------
+
+{-# INLINE lazyToStrictByteString #-}
+lazyToStrictByteString :: L.ByteString -> S.ByteString
+#if MIN_VERSION_bytestring(0,10,0)
+lazyToStrictByteString = L.toStrict
+#else
+lazyToStrictByteString = packChunks
+
+-- packChunks is taken from the blaze-builder package.
+
+-- | Pack the chunks of a lazy bytestring into a single strict bytestring.
+packChunks :: L.ByteString -> S.ByteString
+packChunks lbs = do
+    S.unsafeCreate (fromIntegral $ L.length lbs) (copyChunks lbs)
+  where
+    copyChunks !L.Empty                         !_pf = return ()
+    copyChunks !(L.Chunk (S.PS fpbuf o l) lbs') !pf  = do
+        withForeignPtr fpbuf $ \pbuf ->
+            copyBytes pf (pbuf `plusPtr` o) l
+        copyChunks lbs' (pf `plusPtr` l)
+#endif

--- a/aeson.cabal
+++ b/aeson.cabal
@@ -58,6 +58,11 @@ flag developer
   default: False
   manual: True
 
+flag bytestring-builder
+  description: Depend on the bytestring-builder package for backwards compatibility.
+  default: False
+  manual: False
+
 library
   default-language: Haskell2010
 
@@ -92,13 +97,12 @@ library
     attoparsec >= 0.13.0.1,
     base >= 4.5 && < 5,
     base-compat >= 0.9.1 && < 0.10,
-    bytestring >= 0.10.4.0,
     containers >= 0.2.4.1,
     deepseq >= 1.3,
     dlist >= 0.2,
     ghc-prim >= 0.2,
     hashable >= 1.1.2.0,
-    scientific >= 0.3.1 && < 0.4,
+    scientific >= 0.3.4.7 && < 0.4,
     tagged >=0.8.3 && <0.9,
     template-haskell >= 2.7,
     text >= 1.1.1.0,
@@ -107,10 +111,16 @@ library
     unordered-containers >= 0.2.5.0,
     vector >= 0.8
 
+  if flag(bytestring-builder)
+    build-depends: bytestring >= 0.9 && < 0.10.4,
+                   bytestring-builder >= 0.10.4 && < 1
+  else
+    build-depends: bytestring >= 0.10.4
+
   if !impl(ghc >= 8.0)
     -- `Data.Semigroup` and `Control.Monad.Fail` and `Control.Monad.IO.Class` are available in base only since GHC 8.0 / base 4.9
     build-depends:
-      semigroups >= 0.16.1 && < 0.19,
+      semigroups >= 0.18.2 && < 0.19,
       transformers >= 0.2.2.0,
       transformers-compat >= 0.3,
       fail == 4.9.*
@@ -156,7 +166,6 @@ test-suite tests
     base,
     base-compat,
     base-orphans >= 0.5.3 && <0.6,
-    bytestring,
     containers,
     dlist,
     generic-deriving >= 1.10 && < 1.11,
@@ -175,9 +184,15 @@ test-suite tests
     vector,
     quickcheck-instances >=0.3.12
 
+  if flag(bytestring-builder)
+    build-depends: bytestring >= 0.9 && < 0.10.4,
+                   bytestring-builder >= 0.10.4 && < 1
+  else
+    build-depends: bytestring >= 0.10.4
+
   if !impl(ghc >= 8.0)
     build-depends:
-      semigroups >= 0.16.1 && < 0.19,
+      semigroups >= 0.18.2 && < 0.19,
       transformers >= 0.2.2.0,
       transformers-compat >= 0.3
 

--- a/benchmarks/aeson-benchmarks.cabal
+++ b/benchmarks/aeson-benchmarks.cabal
@@ -4,6 +4,11 @@ build-type:          Simple
 
 cabal-version:       >=1.8
 
+flag bytestring-builder
+  description: Depend on the bytestring-builder package for backwards compatibility.
+  default: False
+  manual: False
+
 library
   hs-source-dirs: .. .
 
@@ -34,7 +39,6 @@ library
     base == 4.*,
     base-compat >= 0.9.1 && <0.10,
     time-locale-compat >=0.1.1 && <0.2,
-    bytestring >= 0.10.4.0,
     containers,
     deepseq,
     dlist >= 0.2,
@@ -42,7 +46,7 @@ library
     ghc-prim >= 0.2,
     hashable >= 1.1.2.0,
     mtl,
-    scientific >= 0.3.1 && < 0.4,
+    scientific >= 0.3.4.7 && < 0.4,
     syb,
     tagged >=0.8.3 && <0.9,
     template-haskell >= 2.4,
@@ -52,12 +56,18 @@ library
     unordered-containers >= 0.2.3.0,
     vector >= 0.7.1
 
+  if flag(bytestring-builder)
+    build-depends: bytestring >= 0.9 && < 0.10.4,
+                   bytestring-builder >= 0.10.4 && < 1
+  else
+    build-depends: bytestring >= 0.10.4
+
   if impl(ghc >=7.8)
     cpp-options: -DHAS_COERCIBLE
 
   if !impl(ghc >= 8.0)
     -- `Data.Semigroup` is available in base only since GHC 8.0 / base 4.9
-    build-depends: semigroups >= 0.16.1 && < 0.19
+    build-depends: semigroups >= 0.18.2 && < 0.19
 
   include-dirs: ../include
 
@@ -99,12 +109,17 @@ executable aeson-benchmark-typed
   build-depends:
     aeson-benchmarks,
     base,
-    bytestring,
     criterion >= 1.0,
     deepseq,
     ghc-prim,
     text,
     time
+
+  if flag(bytestring-builder)
+    build-depends: bytestring >= 0.9 && < 0.10.4,
+                   bytestring-builder >= 0.10.4 && < 1
+  else
+    build-depends: bytestring >= 0.10.4
 
 executable aeson-benchmark-compare-with-json
   main-is: CompareWithJSON.hs


### PR DESCRIPTION
Currently, `aeson` requires `bytestring >= 0.10.4` due to its use of `Data.ByteString.Builder`. This poses a problem for GHC 7.4 and 7.6, which are shipped with older versions of `bytestring`, and as a result must manually install more recent `bytestring`s to work with `aeson`.

Doing so can cause other problems, though. For instance, it can force the `unix` package to be reinstalled (since the `unix` that's shipped with GHC 7.4/7.6 isn't compatible with newer `bytestring`, but if a `Cabal` script uses the version of `Cabal` that's bundled with GHC and tries to link against the reinstalled `unix`, it'll produce linker errors due to `Cabal` itself being linked against the older `unix`. This isn't a hypothetical scenario: this has been observed [here](https://travis-ci.org/lambda-llama/bitset/jobs/136297705#L312).

Anyway, the fix is simple. We allow `aeson` to build with older `bytestring`s by conditionally depending on the `bytestring-builder` package, which backports `Data.ByteString.Builder` when necessary. This has the result of making `aeson`-related build plans much saner with GHC 7.4 and 7.6.