### PR TITLE
Add encode/foldable benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 dist
 .cabal-sandbox/
 cabal.sandbox.config
+.stack-work/
 
 *.o
 *.hi

--- a/benchmarks/AesonFoldable.hs
+++ b/benchmarks/AesonFoldable.hs
@@ -1,0 +1,80 @@
+{-# LANGUAGE OverloadedStrings #-}
+import Criterion.Main
+import Data.Aeson
+import Data.Foldable (toList)
+
+import qualified Data.Sequence as S
+import qualified Data.Vector as V
+import qualified Data.Vector.Unboxed as U
+
+-------------------------------------------------------------------------------
+-- List
+-------------------------------------------------------------------------------
+
+newtype L f = L { getL :: f Int }
+
+instance Foldable f => ToJSON (L f) where
+    toJSON = error "do not use this"
+    toEncoding = toEncoding . toList . getL
+
+-------------------------------------------------------------------------------
+-- Foldable
+-------------------------------------------------------------------------------
+
+newtype F f = F { getF :: f Int }
+
+instance Foldable f => ToJSON (F f) where
+    toJSON = error "do not use this"
+    toEncoding = foldable . getF
+
+-------------------------------------------------------------------------------
+-- Values
+-------------------------------------------------------------------------------
+
+valueList :: [Int]
+valueList = [1..1000]
+
+valueSeq :: S.Seq Int
+valueSeq = S.fromList valueList
+
+valueVector :: V.Vector Int
+valueVector = V.fromList valueList
+
+valueUVector :: U.Vector Int
+valueUVector = U.fromList valueList
+
+-------------------------------------------------------------------------------
+-- Main
+-------------------------------------------------------------------------------
+
+benchEncode
+    :: ToJSON a
+    => String
+    -> a
+    -> Benchmark
+benchEncode name val
+    = bench name $ nf encode val
+
+main :: IO ()
+main =  defaultMain
+    [ bgroup "encode"
+        [ bgroup "List"
+            [ benchEncode "-"     valueList
+            , benchEncode "L" $ L valueList
+            , benchEncode "F" $ F valueList
+            ]
+        , bgroup "Seq"
+            [ benchEncode "-"     valueSeq
+            , benchEncode "L" $ L valueSeq
+            , benchEncode "F" $ F valueSeq
+            ]
+        , bgroup "Vector"
+            [ benchEncode "-"     valueVector
+            , benchEncode "L" $ L valueVector
+            , benchEncode "F" $ F valueVector
+            ]
+        , bgroup "Vector.Unboxed"
+            [ benchEncode "-"     valueUVector
+            ]
+        ]
+    ]

--- a/benchmarks/aeson-benchmarks.cabal
+++ b/benchmarks/aeson-benchmarks.cabal
@@ -174,6 +174,20 @@ executable aeson-benchmark-map
     hashable,
     tagged,
     text,
-    transformers,
-    transformers-compat,
     unordered-containers
+
+executable aeson-benchmark-foldable
+  main-is: AesonFoldable.hs
+  ghc-options: -Wall -O2 -rtsopts
+  build-depends:
+    aeson-benchmarks,
+    base,
+    criterion >= 1.0,
+    bytestring,
+    containers,
+    deepseq,
+    hashable,
+    tagged,
+    text,
+    unordered-containers,
+    vector


### PR DESCRIPTION
With current state:

<img width="926" alt="screen shot 2016-06-14 at 10 34 35" src="https://cloud.githubusercontent.com/assets/51087/16034684/c22f8634-321b-11e6-8069-4bf24582f531.png">

The results in benchmark are about the same as in #411, yet atm my machine is quite noisy.

Resolves: https://github.com/bos/aeson/issues/411 and https://github.com/bos/aeson/issues/402

*EDIT* maybe it's possible to push out more speed out of `Seq`, but at least we have ~optimal solution from the simple ones (it uses `Foldable` `toList` tm, my machine was indeed noisy)