### PR TITLE
Remove use of Proxy and undefined in generics code

### DIFF
--- a/Data/Aeson.hs
+++ b/Data/Aeson.hs
@@ -75,8 +75,10 @@ module Data.Aeson
     , toEncoding2
     -- ** Generic JSON classes and options
     , GFromJSON(..)
+    , FromArgs(..)
     , GToJSON(..)
     , GToEncoding(..)
+    , ToArgs(..)
     , Zero
     , One
     , genericToJSON

--- a/Data/Aeson/Types.hs
+++ b/Data/Aeson/Types.hs
@@ -62,8 +62,10 @@ module Data.Aeson.Types
 
     -- ** Generic JSON classes
     , GFromJSON(..)
+    , FromArgs(..)
     , GToJSON(..)
     , GToEncoding(..)
+    , ToArgs(..)
     , Zero
     , One
     , genericToJSON

--- a/Data/Aeson/Types/Class.hs
+++ b/Data/Aeson/Types/Class.hs
@@ -35,8 +35,10 @@ module Data.Aeson.Types.Class
     , toEncoding2
     -- * Generic JSON classes
     , GFromJSON(..)
+    , FromArgs(..)
     , GToJSON(..)
     , GToEncoding(..)
+    , ToArgs(..)
     , Zero
     , One
     , genericToJSON

--- a/Data/Aeson/Types/Generic.hs
+++ b/Data/Aeson/Types/Generic.hs
@@ -29,7 +29,6 @@ import Prelude ()
 import Prelude.Compat
 
 import GHC.Generics
-import Data.Proxy (Proxy (..))
 
 --------------------------------------------------------------------------------
 
@@ -88,12 +87,6 @@ data Zero
 
 -- | A type-level indicator that 'ToJSON1' or 'FromJSON1' is being derived generically.
 data One
-
-proxyZero :: Proxy Zero
-proxyZero = Proxy
-
-proxyOne :: Proxy One
-proxyOne  = Proxy
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
In order to facilitate the use of `FromJSON1` and `ToJSON1`, I introduced some infelicitous code in #414. Namely, `gToJSON`/`gToEncoding`/`gFromJSON` now requires passing around a `Proxy` argument and two `undefined` values everywhere. To make this a little nicer, I introduce two new data types, `ToArgs` and `FromArgs`, which subsume the need for `Proxy`s, and only contain function arguments if necessary.