### PR TITLE
Fix generic instances involving type parameters in recursive positions

### DIFF
--- a/Data/Aeson/Types/Generic.hs
+++ b/Data/Aeson/Types/Generic.hs
@@ -47,6 +47,7 @@ instance OVERLAPPING_ IsRecord (M1 S NoSelector f) False
 instance (IsRecord f isRecord) => IsRecord (M1 S c f) isRecord
 instance IsRecord (K1 i c) True
 instance IsRecord Par1 True
+instance IsRecord (Rec1 f) True
 instance IsRecord (f :.: g) True
 instance IsRecord U1 False
   where isUnary = const False
@@ -64,6 +65,7 @@ instance AllNullary (a :*: b) False
 instance AllNullary (a :.: b) False
 instance AllNullary (K1 i c) False
 instance AllNullary Par1 False
+instance AllNullary (Rec1 f) False
 instance AllNullary U1 True
 
 newtype Tagged2 (s :: * -> *) b = Tagged2 {unTagged2 :: b}

--- a/tests/DataFamilies/Instances.hs
+++ b/tests/DataFamilies/Instances.hs
@@ -24,6 +24,7 @@ instance Arbitrary a => Arbitrary (SomeType c () a) where
                       , Unary   <$> arbitrary
                       , Product <$> arbitrary <*> arbitrary <*> arbitrary
                       , Record  <$> arbitrary <*> arbitrary <*> arbitrary
+                      , List    <$> arbitrary
                       ]
 
 instance Arbitrary (GADT String) where

--- a/tests/DataFamilies/Types.hs
+++ b/tests/DataFamilies/Types.hs
@@ -24,7 +24,9 @@ data instance SomeType c () a = Nullary
                               | Record { testOne   :: Double
                                        , testTwo   :: Maybe Bool
                                        , testThree :: Maybe a
-                                       } deriving (Eq, Show)
+                                       }
+                              | List [a]
+    deriving (Eq, Show)
 
 data family Approx a
 newtype instance Approx a = Approx { fromApprox :: a }

--- a/tests/Instances.hs
+++ b/tests/Instances.hs
@@ -153,6 +153,7 @@ instance Arbitrary a => Arbitrary (SomeType a) where
                       , Unary   <$> arbitrary
                       , Product <$> arbitrary <*> arbitrary <*> arbitrary
                       , Record  <$> arbitrary <*> arbitrary <*> arbitrary
+                      , List    <$> arbitrary
                       ]
 
 instance Arbitrary (GADT String) where

--- a/tests/Types.hs
+++ b/tests/Types.hs
@@ -63,7 +63,9 @@ data SomeType a = Nullary
                 | Record { testOne   :: Double
                          , testTwo   :: Maybe Bool
                          , testThree :: Maybe a
-                         } deriving (Eq, Show)
+                         }
+                | List [a]
+  deriving (Eq, Show)
 
 data GADT a where
     GADT :: { gadt :: String } -> GADT String


### PR DESCRIPTION
This fixes an oversight I made wherein I forgot to encode some properties of type parameters within other datatypes (`Rec1`).

Fixes #440.