### PR TITLE
Make aeson-benchmark-typed compare to old aeson

### DIFF
--- a/benchmarks/AesonParse.hs
+++ b/benchmarks/AesonParse.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE BangPatterns, OverloadedStrings #-}
+{-# LANGUAGE PackageImports #-}
 
 import Control.Exception
 import Control.Monad
-import Data.Aeson
+import "aeson-benchmarks" Data.Aeson
 import Data.Attoparsec.ByteString (IResult(..), parseWith)
 import Data.Time.Clock
 import System.Environment (getArgs)

--- a/benchmarks/Compare.hs
+++ b/benchmarks/Compare.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE PackageImports #-}
 
 module Main (main) where
 
@@ -11,7 +12,7 @@ import Twitter
 import Twitter.Manual ()
 import Typed.Common
 import qualified Compare.JsonBench as JsonBench
-import qualified Data.Aeson as Aeson
+import qualified "aeson-benchmarks" Data.Aeson as Aeson
 
 main :: IO ()
 main =

--- a/benchmarks/Typed/Common.hs
+++ b/benchmarks/Typed/Common.hs
@@ -1,6 +1,13 @@
+{-# LANGUAGE CPP, PackageImports #-}
 module Typed.Common (load) where
 
+#ifndef HAS_BOTH_AESON_AND_BENCHMARKS
 import Data.Aeson hiding (Result)
+#else
+import "aeson" Data.Aeson hiding (Result)
+import qualified "aeson-benchmarks" Data.Aeson as B
+#endif
+
 import Data.ByteString.Lazy as L
 import Control.Applicative
 import System.IO

--- a/benchmarks/Typed/Generic.hs
+++ b/benchmarks/Typed/Generic.hs
@@ -1,29 +1,41 @@
+{-# LANGUAGE PackageImports #-}
 module Typed.Generic (benchmarks) where
+
+import "aeson" Data.Aeson hiding (Result)
+import qualified "aeson-benchmarks" Data.Aeson as B
 
 import Control.Applicative
 import Criterion
-import Data.Aeson hiding (Result)
-import Data.ByteString.Builder as B
 import Data.ByteString.Lazy as L
 import Twitter.TH
 import Typed.Common
 
-encodeDirect :: Result -> L.ByteString
-encodeDirect = encode
+encodeDirectA :: Result -> L.ByteString
+encodeDirectA = encode
 
-encodeViaValue :: Result -> L.ByteString
-encodeViaValue = encode . toJSON
+encodeViaValueA :: Result -> L.ByteString
+encodeViaValueA = encode . toJSON
+
+encodeDirectB :: Result -> L.ByteString
+encodeDirectB = B.encode
+
+encodeViaValueB :: Result -> L.ByteString
+encodeViaValueB = B.encode . B.toJSON
 
 benchmarks :: Benchmark
 benchmarks =
   env ((,) <$> load "json-data/twitter100.json" <*> load "json-data/jp100.json") $ \ ~(twitter100, jp100) ->
   bgroup "generic" [
       bgroup "direct" [
-        bench "twitter100" $ nf encodeDirect twitter100
-      , bench "jp100" $ nf encodeDirect jp100
+        bench "twitter100"          $ nf encodeDirectB twitter100
+      , bench "jp100"               $ nf encodeDirectB jp100
+      , bench "twitter100 baseline" $ nf encodeDirectA twitter100
+      , bench "jp100 baseline"      $ nf encodeDirectA jp100
       ]
     , bgroup "viaValue" [
-        bench "twitter100" $ nf encodeViaValue twitter100
-      , bench "jp100" $ nf encodeViaValue jp100
+        bench "twitter100"          $ nf encodeViaValueB twitter100
+      , bench "jp100"               $ nf encodeViaValueB jp100
+      , bench "twitter100 baseline" $ nf encodeViaValueA twitter100
+      , bench "jp100 baseline"      $ nf encodeViaValueA jp100
       ]
     ]

--- a/benchmarks/Typed/Manual.hs
+++ b/benchmarks/Typed/Manual.hs
@@ -1,29 +1,41 @@
+{-# LANGUAGE PackageImports #-}
 module Typed.Manual (benchmarks) where
+
+import "aeson" Data.Aeson hiding (Result)
+import qualified "aeson-benchmarks" Data.Aeson as B
 
 import Control.Applicative
 import Criterion
-import Data.Aeson hiding (Result)
-import Data.ByteString.Builder as B
 import Data.ByteString.Lazy as L
 import Twitter.Manual
 import Typed.Common
 
-encodeDirect :: Result -> L.ByteString
-encodeDirect = encode
+encodeDirectA :: Result -> L.ByteString
+encodeDirectA = encode
 
-encodeViaValue :: Result -> L.ByteString
-encodeViaValue = encode . toJSON
+encodeViaValueA :: Result -> L.ByteString
+encodeViaValueA = encode . toJSON
+
+encodeDirectB :: Result -> L.ByteString
+encodeDirectB = B.encode
+
+encodeViaValueB :: Result -> L.ByteString
+encodeViaValueB = B.encode . B.toJSON
 
 benchmarks :: Benchmark
 benchmarks =
   env ((,) <$> load "json-data/twitter100.json" <*> load "json-data/jp100.json") $ \ ~(twitter100, jp100) ->
   bgroup "manual" [
       bgroup "direct" [
-        bench "twitter100" $ nf encodeDirect twitter100
-      , bench "jp100" $ nf encodeDirect jp100
+        bench "twitter100"          $ nf encodeDirectB twitter100
+      , bench "jp100"               $ nf encodeDirectB jp100
+      , bench "twitter100 baseline" $ nf encodeDirectA twitter100
+      , bench "jp100 baseline"      $ nf encodeDirectA jp100
       ]
     , bgroup "viaValue" [
-        bench "twitter100" $ nf encodeViaValue twitter100
-      , bench "jp100" $ nf encodeViaValue jp100
+        bench "twitter100"          $ nf encodeViaValueB twitter100
+      , bench "jp100"               $ nf encodeViaValueB jp100
+      , bench "twitter100 baseline" $ nf encodeViaValueA twitter100
+      , bench "jp100 baseline"      $ nf encodeViaValueA jp100
       ]
     ]

--- a/benchmarks/Typed/TH.hs
+++ b/benchmarks/Typed/TH.hs
@@ -1,29 +1,42 @@
+{-# LANGUAGE PackageImports #-}
 module Typed.TH (benchmarks) where
+
+import "aeson" Data.Aeson hiding (Result)
+import qualified "aeson-benchmarks" Data.Aeson as B
 
 import Control.Applicative
 import Criterion
-import Data.Aeson hiding (Result)
 import Data.ByteString.Builder as B
 import Data.ByteString.Lazy as L
 import Twitter.TH
 import Typed.Common
 
-encodeDirect :: Result -> L.ByteString
-encodeDirect = encode
+encodeDirectA :: Result -> L.ByteString
+encodeDirectA = encode
 
-encodeViaValue :: Result -> L.ByteString
-encodeViaValue = encode . toJSON
+encodeViaValueA :: Result -> L.ByteString
+encodeViaValueA = encode . toJSON
+
+encodeDirectB :: Result -> L.ByteString
+encodeDirectB = B.encode
+
+encodeViaValueB :: Result -> L.ByteString
+encodeViaValueB = B.encode . B.toJSON
 
 benchmarks :: Benchmark
 benchmarks =
   env ((,) <$> load "json-data/twitter100.json" <*> load "json-data/jp100.json") $ \ ~(twitter100, jp100) ->
   bgroup "th" [
       bgroup "direct" [
-        bench "twitter100" $ nf encodeDirect twitter100
-      , bench "jp100" $ nf encodeDirect jp100
+        bench "twitter100"          $ nf encodeDirectB twitter100
+      , bench "jp100"               $ nf encodeDirectB jp100
+      , bench "twitter100 baseline" $ nf encodeDirectA twitter100
+      , bench "jp100 baseline"      $ nf encodeDirectA jp100
       ]
     , bgroup "viaValue" [
-        bench "twitter100" $ nf encodeViaValue twitter100
-      , bench "jp100" $ nf encodeViaValue jp100
+        bench "twitter100"          $ nf encodeViaValueA twitter100
+      , bench "jp100"               $ nf encodeViaValueA jp100
+      , bench "twitter100 baseline" $ nf encodeViaValueB twitter100
+      , bench "jp100 baseline"      $ nf encodeViaValueB jp100
       ]
     ]

--- a/benchmarks/aeson-benchmarks.cabal
+++ b/benchmarks/aeson-benchmarks.cabal
@@ -106,7 +106,11 @@ executable aeson-benchmark-typed
   main-is: Typed.hs
   hs-source-dirs: ../examples .
   ghc-options: -Wall -O2 -rtsopts
+  -- We must help ourself in situations when there is both
+  -- aeson and aeson-benchmakrs
+  cpp-options: -DHAS_BOTH_AESON_AND_BENCHMARKS
   build-depends:
+    aeson,
     aeson-benchmarks,
     base,
     criterion >= 1.0,

--- a/examples/Twitter/Generic.hs
+++ b/examples/Twitter/Generic.hs
@@ -1,5 +1,6 @@
 -- Use GHC generics to automatically generate good instances.
 
+{-# LANGUAGE CPP, PackageImports #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Twitter.Generic
@@ -10,8 +11,14 @@ module Twitter.Generic
     , Result(..)
     ) where
 
-import Data.Aeson (ToJSON, FromJSON)
 import Twitter
+
+#ifndef HAS_BOTH_AESON_AND_BENCHMARKS
+import Data.Aeson (ToJSON, FromJSON)
+#else
+import "aeson" Data.Aeson (ToJSON, FromJSON)
+import qualified "aeson-benchmarks" Data.Aeson as B
+#endif
 
 instance ToJSON Metadata
 instance FromJSON Metadata
@@ -24,3 +31,17 @@ instance FromJSON Story
 
 instance ToJSON Result
 instance FromJSON Result
+
+#ifdef HAS_BOTH_AESON_AND_BENCHMARKS
+instance B.ToJSON Metadata
+instance B.FromJSON Metadata
+
+instance B.ToJSON Geo
+instance B.FromJSON Geo
+
+instance B.ToJSON Story
+instance B.FromJSON Story
+
+instance B.ToJSON Result
+instance B.FromJSON Result
+#endif

--- a/examples/Twitter/Manual.hs
+++ b/examples/Twitter/Manual.hs
@@ -1,5 +1,6 @@
 -- Manually write instances.
 
+{-# LANGUAGE CPP, PackageImports #-}
 {-# LANGUAGE OverloadedStrings, RecordWildCards #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -12,12 +13,19 @@ module Twitter.Manual
     ) where
 
 import Control.Applicative
-import Data.Aeson hiding (Result)
 import Data.Monoid ((<>))
 import Prelude hiding (id)
 import Twitter
 
+#ifndef HAS_BOTH_AESON_AND_BENCHMARKS
+import Data.Aeson hiding (Result)
+#else
+import "aeson" Data.Aeson hiding (Result)
+import qualified "aeson-benchmarks" Data.Aeson as B
+#endif
+
 instance ToJSON Metadata where
+
   toJSON Metadata{..} = object [
       "result_type" .= result_type
     ]
@@ -139,3 +147,128 @@ instance FromJSON Result where
     <*> v .: "max_id_str"
     <*> v .: "query"
   parseJSON _ = empty
+
+#ifdef HAS_BOTH_AESON_AND_BENCHMARKS
+instance B.ToJSON Metadata where
+  toJSON Metadata{..} = B.object [
+      "result_type" B..= result_type
+    ]
+
+  toEncoding Metadata{..} = B.pairs $
+    "result_type" B..= result_type
+
+instance B.FromJSON Metadata where
+  parseJSON (B.Object v) = Metadata <$> v B..: "result_type"
+  parseJSON _          = empty
+
+instance B.ToJSON Geo where
+  toJSON Geo{..} = B.object [
+      "type_"       B..= type_
+    , "coordinates" B..= coordinates
+    ]
+
+  toEncoding Geo{..} = B.pairs $
+       "type_"       B..= type_
+    <> "coordinates" B..= coordinates
+
+instance B.FromJSON Geo where
+  parseJSON (B.Object v) = Geo <$>
+        v B..: "type_"
+    <*> v B..: "coordinates"
+  parseJSON _          = empty
+
+instance B.ToJSON Story where
+  toJSON Story{..} = B.object [
+      "from_user_id_str"  B..= from_user_id_str
+    , "profile_image_url" B..= profile_image_url
+    , "created_at"        B..= created_at
+    , "from_user"         B..= from_user
+    , "id_str"            B..= id_str
+    , "metadata"          B..= metadata
+    , "to_user_id"        B..= to_user_id
+    , "text"              B..= text
+    , "id"                B..= id
+    , "from_user_id"      B..= from_user_id
+    , "geo"               B..= geo
+    , "iso_language_code" B..= iso_language_code
+    , "to_user_id_str"    B..= to_user_id_str
+    , "source"            B..= source
+    ]
+
+  toEncoding Story{..} = B.pairs $
+       "from_user_id_str"  B..= from_user_id_str
+    <> "profile_image_url" B..= profile_image_url
+    <> "created_at"        B..= created_at
+    <> "from_user"         B..= from_user
+    <> "id_str"            B..= id_str
+    <> "metadata"          B..= metadata
+    <> "to_user_id"        B..= to_user_id
+    <> "text"              B..= text
+    <> "id"                B..= id
+    <> "from_user_id"      B..= from_user_id
+    <> "geo"               B..= geo
+    <> "iso_language_code" B..= iso_language_code
+    <> "to_user_id_str"    B..= to_user_id_str
+    <> "source"            B..= source
+
+instance B.FromJSON Story where
+  parseJSON (B.Object v) = Story <$>
+        v B..: "from_user_id_str"
+    <*> v B..: "profile_image_url"
+    <*> v B..: "created_at"
+    <*> v B..: "from_user"
+    <*> v B..: "id_str"
+    <*> v B..: "metadata"
+    <*> v B..: "to_user_id"
+    <*> v B..: "text"
+    <*> v B..: "id"
+    <*> v B..: "from_user_id"
+    <*> v B..: "geo"
+    <*> v B..: "iso_language_code"
+    <*> v B..: "to_user_id_str"
+    <*> v B..: "source"
+  parseJSON _ = empty
+
+instance B.ToJSON Result where
+  toJSON Result{..} = B.object [
+      "results"          B..= results
+    , "max_id"           B..= max_id
+    , "since_id"         B..= since_id
+    , "refresh_url"      B..= refresh_url
+    , "next_page"        B..= next_page
+    , "results_per_page" B..= results_per_page
+    , "page"             B..= page
+    , "completed_in"     B..= completed_in
+    , "since_id_str"     B..= since_id_str
+    , "max_id_str"       B..= max_id_str
+    , "query"            B..= query
+    ]
+
+  toEncoding Result{..} = B.pairs $
+       "results"          B..= results
+    <> "max_id"           B..= max_id
+    <> "since_id"         B..= since_id
+    <> "refresh_url"      B..= refresh_url
+    <> "next_page"        B..= next_page
+    <> "results_per_page" B..= results_per_page
+    <> "page"             B..= page
+    <> "completed_in"     B..= completed_in
+    <> "since_id_str"     B..= since_id_str
+    <> "max_id_str"       B..= max_id_str
+    <> "query"            B..= query
+
+instance B.FromJSON Result where
+  parseJSON (B.Object v) = Result <$>
+        v B..: "results"
+    <*> v B..: "max_id"
+    <*> v B..: "since_id"
+    <*> v B..: "refresh_url"
+    <*> v B..: "next_page"
+    <*> v B..: "results_per_page"
+    <*> v B..: "page"
+    <*> v B..: "completed_in"
+    <*> v B..: "since_id_str"
+    <*> v B..: "max_id_str"
+    <*> v B..: "query"
+  parseJSON _ = empty
+#endif

--- a/examples/Twitter/TH.hs
+++ b/examples/Twitter/TH.hs
@@ -1,5 +1,6 @@
 -- Use Template Haskell to generate good instances.
 
+{-# LANGUAGE CPP, PackageImports #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -10,11 +11,23 @@ module Twitter.TH
     , Story(..)
     , Result(..)
     ) where
-
-import Data.Aeson.TH
 import Twitter
+
+#ifndef HAS_BOTH_AESON_AND_BENCHMARKS
+import Data.Aeson.TH
+#else
+import "aeson" Data.Aeson.TH
+import qualified "aeson-benchmarks" Data.Aeson.TH as B
+#endif
 
 $(deriveJSON defaultOptions ''Metadata)
 $(deriveJSON defaultOptions ''Geo)
 $(deriveJSON defaultOptions ''Story)
 $(deriveJSON defaultOptions ''Result)
+
+#ifdef HAS_BOTH_AESON_AND_BENCHMARKS
+$(B.deriveJSON B.defaultOptions ''Metadata)
+$(B.deriveJSON B.defaultOptions ''Geo)
+$(B.deriveJSON B.defaultOptions ''Story)
+$(B.deriveJSON B.defaultOptions ''Result)
+#endif


### PR DESCRIPTION
<img width="936" alt="screen shot 2016-07-15 at 20 10 15" src="https://cloud.githubusercontent.com/assets/51087/16882625/b6e58a60-4ac8-11e6-8e49-6902aa42cf86.png">

Slight slowdown since 0.11.0.2, but my machine is quite noisy atm.

ping @winterland1989, you can rebase on that and try

```
STACK_YAML=stack-bench.yaml stack build
cd benchmark
STACK_YAML=../stack-bench.yaml stack exec aeson-benchmark-typed -- -o bench.htm
```