### PR TITLE
Fix TH bug when deriving ToJSON1/2 or FromJSON1/2 for types that don't mention the parameter

### DIFF
--- a/Data/Aeson/TH.hs
+++ b/Data/Aeson/TH.hs
@@ -1408,10 +1408,12 @@ dispatchFunByType jc jf conName tvMap list ty = do
     if any (`mentionsName` tyVarNames) lhsArgs
           || itf && any (`mentionsName` tyVarNames) tyArgs
        then outOfPlaceTyVarError jc conName
-       else appsE $ varE (jsonFunValOrListName list jf $ toEnum numLastArgs)
-                    : zipWith (dispatchFunByType jc jf conName tvMap)
-                              (cycle [False,True])
-                              (interleave rhsArgs rhsArgs)
+       else if any (`mentionsName` tyVarNames) rhsArgs
+            then appsE $ varE (jsonFunValOrListName list jf $ toEnum numLastArgs)
+                         : zipWith (dispatchFunByType jc jf conName tvMap)
+                                   (cycle [False,True])
+                                   (interleave rhsArgs rhsArgs)
+            else varE $ jsonFunValOrListName list jf Arity0
 
 dispatchToJSON, dispatchToEncoding, dispatchParseJSON
   :: JSONClass -> Name -> TyVarMap -> Type -> Q Exp

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -15,10 +15,10 @@ import Instances ()
 
 import Control.Applicative (Const(..))
 import Control.Monad (forM)
-import Data.Aeson (FromJSONKeyFunction(..), FromJSONKey(..), decode, eitherDecode, encode, genericParseJSON, genericToJSON, genericToEncoding, object, FromJSON(..), withObject, (.=), (.:), (.:?), (.:!))
+import Data.Aeson (FromJSONKeyFunction(..), FromJSONKey(..), decode, eitherDecode, encode, genericParseJSON, genericToJSON, genericToEncoding, object, FromJSON(..), withObject, ToJSON1(..), (.=), (.:), (.:?), (.:!))
 import Data.Aeson.Text (encodeToTextBuilder)
 import Data.Aeson.Internal (JSONPathElement(..), formatError)
-import Data.Aeson.TH (deriveJSON)
+import Data.Aeson.TH (deriveJSON, deriveToJSON, deriveToJSON1)
 import Data.Aeson.Types (ToJSON(..), Value, camelTo, camelTo2, defaultOptions, omitNothingFields, Options(..), SumEncoding(..))
 import Data.Char (toUpper)
 import Data.Hashable (hash)
@@ -93,6 +93,9 @@ tests = testGroup "unit" [
   , testGroup "Issue #351" $ fmap (testCase "-") issue351
   , testGroup "Nullary constructors" $ fmap (testCase "-") nullaryConstructors
   , testGroup "FromJSONKey" $ fmap (testCase "-") fromJSONKeyAssertions
+  , testGroup "PR #455" [
+      testCase "-" pr455
+    ]
   ]
 
 roundTripCamel :: String -> Assertion
@@ -544,10 +547,24 @@ encoderComparisonTests = do
 
 -- A regression test for: https://github.com/bos/aeson/issues/293
 data MyRecord = MyRecord {_field1 :: Maybe Int, _field2 :: Maybe Bool}
-deriveJSON defaultOptions{omitNothingFields=True} ''MyRecord
 
 data MyRecord2 = MyRecord2 {_field3 :: Maybe Int, _field4 :: Maybe Bool}
   deriving Generic
 
 instance ToJSON   MyRecord2
 instance FromJSON MyRecord2
+
+-- A regression test for: https://github.com/bos/aeson/pull/455
+data Foo a = FooNil | FooCons (Foo Int)
+
+pr455 :: Assertion
+pr455 = assertEqual "FooCons FooNil"
+          (toJSON foo) (liftToJSON undefined undefined foo)
+  where
+    foo :: Foo Int
+    foo = FooCons FooNil
+
+deriveJSON defaultOptions{omitNothingFields=True} ''MyRecord
+
+deriveToJSON  defaultOptions ''Foo
+deriveToJSON1 defaultOptions ''Foo

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -93,9 +93,7 @@ tests = testGroup "unit" [
   , testGroup "Issue #351" $ fmap (testCase "-") issue351
   , testGroup "Nullary constructors" $ fmap (testCase "-") nullaryConstructors
   , testGroup "FromJSONKey" $ fmap (testCase "-") fromJSONKeyAssertions
-  , testGroup "PR #455" [
-      testCase "-" pr455
-    ]
+  , testCase "PR #455" pr455
   ]
 
 roundTripCamel :: String -> Assertion


### PR DESCRIPTION
Before, this code:

```haskell
newtype Foo a = Foo (Foo Int)

$(deriveToJSON  defaultOptions ''Foo)
$(deriveToJSON1 defaultOptions ''Foo)
```

Would generate the following `ToJSON1` instance:

```haskell
    deriveToJSON1 defaultOptions ''Foo
  ======>
    instance ToJSON1 Foo where
      liftToJSON
        = \ _tj1_aFns _tjl1_aFnt value_aFnr
            -> case value_aFnr of {
                 Foo arg1_aFnu -> liftToJSON toJSON toJSONList arg1_aFnu }
      liftToEncoding
        = \ _te1_aFnw _tel1_aFnx value_aFnv
            -> case value_aFnv of {
                 Foo arg1_aFny
                   -> liftToEncoding toEncoding toEncodingList arg1_aFny }
```

Although this typechecks, actually contradicts the strategy that GHC adapts when deriving `* -> *`-kinded classes (e.g., `Functor`). Namely, when an argument type doesn't mention the last type parameter at all, GHC doesn't attempt to "tunnel into" the type expression like the above code is doing with the expression `liftToJSON toJSON toJSONList`.

With the changes in this PR, the generated code would instead be:

```haskell
    deriveToJSON1 defaultOptions ''Foo
  ======>
    instance ToJSON1 Foo where
      liftToJSON
        = \ _tj1_aFo0 _tjl1_aFo1 value_aFnZ
            -> case value_aFnZ of { Foo arg1_aFo2 -> toJSON arg1_aFo2 }
      liftToEncoding
        = \ _te1_aFo4 _tel1_aFo5 value_aFo3
            -> case value_aFo3 of { Foo arg1_aFo6 -> toEncoding arg1_aFo6 }
```