### PR TITLE
Make the comment on `.:!` more accurate.

### DIFF
--- a/Data/Aeson/Types/FromJSON.hs
+++ b/Data/Aeson/Types/FromJSON.hs
@@ -655,9 +655,9 @@ obj .: key = case H.lookup key obj of
                Just v  -> parseJSON v <?> Key key
 {-# INLINE (.:) #-}
 
--- | Retrieve the value associated with the given key of an 'Object'.  The
--- result is 'Nothing' if the key is not present or value is 'Null', or 'empty'
--- if the value cannot be converted to the desired type.
+-- | Retrieve the value associated with the given key of an 'Object'. The
+-- result is 'Nothing' if the key is not present or if its value is 'Null',
+-- or 'empty' if the value cannot be converted to the desired type.
 --
 -- This accessor is most useful if the key and value can be absent
 -- from an object without affecting its validity.  If the key and
@@ -668,8 +668,12 @@ obj .:? key = case H.lookup key obj of
                Just v  -> parseJSON v <?> Key key
 {-# INLINE (.:?) #-}
 
--- | Like '.:?', but the resulting parser will fail,
--- if the key is present but is 'Null'.
+-- | Retrieve the value associated with the given key of an 'Object'.
+-- The result is 'Nothing' if the key is not present or 'empty' if the
+-- value cannot be converted to the desired type.
+--
+-- This differs from '.:?' by attempting to parse 'Null' the same as any
+-- other JSON value, instead of interpreting it as 'Nothing'.
 (.:!) :: (FromJSON a) => Object -> Text -> Parser (Maybe a)
 obj .:! key = case H.lookup key obj of
                Nothing -> pure Nothing


### PR DESCRIPTION
`.:!` won't necessarily fail of the value its given is `Null`,
rather it will attempt to parse it like any other value.

Also: touch up the comment on `.:?` slightly.