### PR TITLE
Specialize ToJSON for common types

### DIFF
--- a/Data/Aeson/Types/ToJSON.hs
+++ b/Data/Aeson/Types/ToJSON.hs
@@ -615,6 +615,11 @@ instance ToJSON1 [] where
     {-# INLINE liftToEncoding #-}
 
 instance (ToJSON a) => ToJSON [a] where
+    {-# SPECIALIZE instance ToJSON String #-}
+    {-# SPECIALIZE instance ToJSON [String] #-}
+    {-# SPECIALIZE instance ToJSON [Array] #-}
+    {-# SPECIALIZE instance ToJSON [Object] #-}
+
     toJSON = toJSON1
     {-# INLINE toJSON #-}
 
@@ -1865,6 +1870,8 @@ instance ToJSON1 Vector where
     {-# INLINE liftToEncoding #-}
 
 instance (ToJSON a) => ToJSON (Vector a) where
+    {-# SPECIALIZE instance ToJSON Array #-}
+
     toJSON = toJSON1
     {-# INLINE toJSON #-}
 
@@ -1936,6 +1943,8 @@ instance ToJSONKey k => ToJSON1 (H.HashMap k) where
     {-# INLINE liftToEncoding #-}
 
 instance (ToJSON v, ToJSONKey k) => ToJSON (H.HashMap k v) where
+    {-# SPECIALIZE instance ToJSON Object #-}
+
     toJSON = toJSON1
     {-# INLINE toJSON #-}
 


### PR DESCRIPTION
Here's a motivating example:

```
mkArray :: [Value] -> Array
mkArray = Vector.fromList

mkObject :: [(Text, Value)] -> Object
mkObject = HashMap.fromList

someArray :: Array
someArray =
  mkArray
     [toJSON
        (mkObject
           ["dummy" .=
              mkObject
                ["dummy" .=
                   "dummy",
                 "dummy" .= "dummy",
                 "dummy" .= 42,
                 "dummy" .= 42],
            "dummy" .=
              mkArray
                [toJSON "dummy", toJSON "dummy"],
            "dummy" .=
              mkObject
                ["dummy" .= 42,
                 "dummy" .= 42],
            "dummy" .= mkArray [toJSON "dummy"]])]
```

If `aeson` doesn't pre-specialize, every time this
example is compiled you pay the cost of specialization.

In this case this blows up the number of terms from
181 to 2464 making compile time significantly slower than
necessary.
