### PR TITLE
Add BCE day support

### DIFF
--- a/Data/Aeson/Encoding/Builder.hs
+++ b/Data/Aeson/Encoding/Builder.hs
@@ -194,7 +194,7 @@ day dd = encodeYear yr <>
         encodeYear y
             | y >= 1000 = B.integerDec y
             | y >= 0    = BP.primBounded (ascii4 (padYear y)) ()
-            | y >= -999 = BP.primBounded (ascii5 ('-',padYear y)) ()
+            | y >= -999 = BP.primBounded (ascii5 ('-',padYear (- y))) ()
             | otherwise = B.integerDec y
         padYear y =
             let (ab,c) = fromIntegral y `quotRem` 10

--- a/Data/Aeson/Encoding/Builder.hs
+++ b/Data/Aeson/Encoding/Builder.hs
@@ -193,12 +193,13 @@ day dd = encodeYear yr <>
         !(T dh dl)  = twoDigits d
         encodeYear y
             | y >= 1000 = B.integerDec y
-            | y > 0 =
-                let (ab,c) = fromIntegral y `quotRem` 10
-                    (a,b)  = ab `quotRem` 10
-                in BP.primBounded (ascii4 ('0',(digit a,(digit b,digit c)))) ()
-            | otherwise =
-                error "Data.Aeson.Encode.Builder.day:  years BCE not supported"
+            | y >= 0    = BP.primBounded (ascii4 (padYear y)) ()
+            | y >= -999 = BP.primBounded (ascii5 ('-',padYear y)) ()
+            | otherwise = B.integerDec y
+        padYear y =
+            let (ab,c) = fromIntegral y `quotRem` 10
+                (a,b)  = ab `quotRem` 10
+            in ('0',(digit a,(digit b,digit c)))
 {-# INLINE day #-}
 
 timeOfDay :: TimeOfDay -> Builder

--- a/Data/Aeson/Parser/Time.hs
+++ b/Data/Aeson/Parser/Time.hs
@@ -25,6 +25,7 @@ module Data.Aeson.Parser.Time
 import Prelude ()
 import Prelude.Compat
 
+import Control.Applicative ((<|>))
 import Control.Monad (void, when)
 import Data.Aeson.Internal.Time (toPico)
 import Data.Attoparsec.Text as A
@@ -49,11 +50,7 @@ run p t = case A.parseOnly (p <* endOfInput) t of
 -- | Parse a date of the form @[+,-]YYYY-MM-DD@.
 day :: Parser Day
 day = do
-  absOrNeg <- choice
-    [ char '-' *> pure negate
-    , char '+' *> pure id
-    , pure id
-    ]
+  absOrNeg <- negate <$ char '-' <|> id <$ char '+' <|> pure id
   y <- decimal <* char '-'
   m <- twoDigits <* char '-'
   d <- twoDigits

--- a/Data/Aeson/Parser/Time.hs
+++ b/Data/Aeson/Parser/Time.hs
@@ -46,13 +46,18 @@ run p t = case A.parseOnly (p <* endOfInput) t of
             Left err -> fail $ "could not parse date: " ++ err
             Right r  -> return r
 
--- | Parse a date of the form @YYYY-MM-DD@.
+-- | Parse a date of the form @[+,-]YYYY-MM-DD@.
 day :: Parser Day
 day = do
+  absOrNeg <- choice
+    [ char '-' *> pure negate
+    , char '+' *> pure id
+    , pure id
+    ]
   y <- decimal <* char '-'
   m <- twoDigits <* char '-'
   d <- twoDigits
-  maybe (fail "invalid date") return (fromGregorianValid y m d)
+  maybe (fail "invalid date") return (fromGregorianValid (absOrNeg y) m d)
 
 -- | Parse a two-digit integer (e.g. day of month, hour).
 twoDigits :: Parser Int

--- a/changelog.md
+++ b/changelog.md
@@ -27,6 +27,7 @@ categorised as follows:
   states that control characters must be escaped. (This may change at
   some point, but doesn't seem important.)
 
+- Days BCE are properly encoded.
 
 #### 1.0.2.1
 

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -202,6 +202,7 @@ tests = testGroup "properties" [
     , testProperty "Lazy Text" $ roundTripEq LT.empty
     , testProperty "Foo" $ roundTripEq (undefined :: Foo)
     , testProperty "Day" $ roundTripEq (undefined :: Day)
+    , testProperty "BCE Day" $ roundTripEq (undefined :: BCEDay)
     , testProperty "DotNetTime" $ roundTripEq (undefined :: Approx DotNetTime)
     , testProperty "LocalTime" $ roundTripEq (undefined :: LocalTime)
     , testProperty "TimeOfDay" $ roundTripEq (undefined :: TimeOfDay)

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -330,7 +330,7 @@ jsonDecodingExamples = [
   , MaybeExample "Word8 3.14" "3.14" (Nothing :: Maybe Word8)
   , MaybeExample "Word8 -1"   "-1"   (Nothing :: Maybe Word8)
   , MaybeExample "Word8 300"  "300"  (Nothing :: Maybe Word8)
-
+  -- Negative zero year, encoding never produces such:
   , MaybeExample "Day -0000-02-03" "\"-0000-02-03\"" (Just (fromGregorian 0 2 3))
   ]
 

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -99,10 +99,6 @@ tests = testGroup "unit" [
       testCase "good" $ utcTimeGood
     , testCase "bad"  $ utcTimeBad
     ]
-  , testGroup "day" [
-      testCase "encode normal" $ dayEncodeCE
-    , testCase "encode BCE" $ dayEncodeBCE
-    ]
   , testGroup "formatError" [
       testCase "example 1" $ formatErrorExample
     ]
@@ -245,20 +241,6 @@ utcTimeBad = do
     verifyFailParse (s :: LT.Text) =
       let (dec :: Maybe UTCTime) = decode . LT.encodeUtf8 $ (LT.concat ["\"", s, "\""]) in
       assertEqual "verify failure" Nothing dec
-
-dayEncodeCE :: Assertion
-dayEncodeCE = do
-    let ceDay = fromGregorian 1234 12 5
-    assertEqual "Encode a CE day works appropriately" (encode ceDay) "\"1234-12-05\""
-
-dayEncodeBCE :: Assertion
-dayEncodeBCE = do
-    let zeroDay  = fromGregorian 0 6 11
-        bceDay   = fromGregorian (-100) 5 13
-        wayEarly = fromGregorian (-10000) 3 3
-    assertEqual "Encode a zero year day works appropriately" (encode zeroDay) "\"0000-06-11\""
-    assertEqual "Encode a BCE day works appropriately" (encode bceDay) "\"-0100-05-13\""
-    assertEqual "Encode a really early day works appropriately" (encode wayEarly) "\"-10000-03-03\""
 
 -- Non identifier keys should be escaped & enclosed in brackets
 formatErrorExample :: Assertion
@@ -409,6 +391,12 @@ jsonExamples =
   , Example "Maybe Char" "\"x\""              (pure 'x' :: Maybe Char)
   , Example "Maybe String" "\"foo\""          (pure "foo" :: Maybe String)
   , Example "Maybe [Identity Char]" "\"xy\""  (pure [pure 'x', pure 'y'] :: Maybe [Identity Char])
+
+  , Example "Day; year >= 1000" "\"1999-10-12\""        (fromGregorian 1999    10 12)
+  , Example "Day; year > 0 && < 1000" "\"0500-03-04\""  (fromGregorian 500     3  4)
+  , Example "Day; year == 0" "\"0000-02-20\""           (fromGregorian 0       2  20)
+  , Example "Day; year < 0" "\"-0234-01-01\""           (fromGregorian (-234)  1  1)
+  , Example "Day; year < -1000" "\"-1234-01-01\""       (fromGregorian (-1234) 1  1)
 
   , Example "Product I Maybe Int" "[1,2]"         (Pair (pure 1) (pure 2) :: Product I Maybe Int)
   , Example "Product I Maybe Int" "[1,null]"      (Pair (pure 1) Nothing :: Product I Maybe Int)

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -43,7 +43,7 @@ import Data.Scientific (Scientific)
 import Data.Sequence (Seq)
 import Data.Tagged (Tagged(..))
 import Data.Text (Text)
-import Data.Time (UTCTime)
+import Data.Time (UTCTime, Day, fromGregorian)
 import Data.Time.Format (parseTime)
 import Data.Time.Locale.Compat (defaultTimeLocale)
 import Data.Word (Word8)
@@ -98,6 +98,10 @@ tests = testGroup "unit" [
   , testGroup "utctime" [
       testCase "good" $ utcTimeGood
     , testCase "bad"  $ utcTimeBad
+    ]
+  , testGroup "day" [
+      testCase "encode normal" $ dayEncodeCE
+    , testCase "encode BCE" $ dayEncodeBCE
     ]
   , testGroup "formatError" [
       testCase "example 1" $ formatErrorExample
@@ -241,6 +245,20 @@ utcTimeBad = do
     verifyFailParse (s :: LT.Text) =
       let (dec :: Maybe UTCTime) = decode . LT.encodeUtf8 $ (LT.concat ["\"", s, "\""]) in
       assertEqual "verify failure" Nothing dec
+
+dayEncodeCE :: Assertion
+dayEncodeCE = do
+    let ceDay = fromGregorian 1234 12 5
+    assertEqual "Encode a CE day works appropriately" (encode ceDay) "\"1234-12-05\""
+
+dayEncodeBCE :: Assertion
+dayEncodeBCE = do
+    let zeroDay  = fromGregorian 0 6 11
+        bceDay   = fromGregorian (-100) 5 13
+        wayEarly = fromGregorian (-10000) 3 3
+    assertEqual "Encode a zero year day works appropriately" (encode zeroDay) "\"0000-06-11\""
+    assertEqual "Encode a BCE day works appropriately" (encode bceDay) "\"-0100-05-13\""
+    assertEqual "Encode a really early day works appropriately" (encode wayEarly) "\"-10000-03-03\""
 
 -- Non identifier keys should be escaped & enclosed in brackets
 formatErrorExample :: Assertion

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -43,7 +43,7 @@ import Data.Scientific (Scientific)
 import Data.Sequence (Seq)
 import Data.Tagged (Tagged(..))
 import Data.Text (Text)
-import Data.Time (UTCTime, Day, fromGregorian)
+import Data.Time (UTCTime, fromGregorian)
 import Data.Time.Format (parseTime)
 import Data.Time.Locale.Compat (defaultTimeLocale)
 import Data.Word (Word8)
@@ -330,6 +330,8 @@ jsonDecodingExamples = [
   , MaybeExample "Word8 3.14" "3.14" (Nothing :: Maybe Word8)
   , MaybeExample "Word8 -1"   "-1"   (Nothing :: Maybe Word8)
   , MaybeExample "Word8 300"  "300"  (Nothing :: Maybe Word8)
+
+  , MaybeExample "Day -0000-02-03" "\"-0000-02-03\"" (Just (fromGregorian 0 2 3))
   ]
 
 jsonExamples :: [Example]


### PR DESCRIPTION
This PR adds support for the encoding of BCE `Day`s, fixing #484.