### PR TITLE
Fix incorrect GitHub repository language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/JSONTestSuite/* linguist-vendored


### PR DESCRIPTION
Fixes incorrect repository language detection by ignoring vendored `tests/JSONTestSuite` folder.
See: https://github.com/github/linguist#overrides