### PR TITLE
Backport BCE day encoding fix to 0.11.x

### DIFF
--- a/Data/Aeson/Encode/Builder.hs
+++ b/Data/Aeson/Encode/Builder.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE BangPatterns, OverloadedStrings #-}
+{-# LANGUAGE BangPatterns      #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 -- |
 -- Module:      Data.Aeson.Encode.Builder
@@ -35,22 +36,23 @@ module Data.Aeson.Encode.Builder
     , ascii5
     ) where
 
-import Data.Aeson.Internal.Time
-import Data.Aeson.Types.Internal (Encoding(..), Value(..))
-import Data.ByteString.Builder as B
-import Data.ByteString.Builder.Prim as BP
-import Data.ByteString.Builder.Scientific (scientificBuilder)
-import Data.Char (chr, ord)
-import Data.Monoid ((<>))
-import Data.Scientific (Scientific, base10Exponent, coefficient)
-import Data.Time (UTCTime(..))
-import Data.Time.Calendar (Day(..), toGregorian)
-import Data.Time.LocalTime
-import Data.Word (Word8)
-import qualified Data.HashMap.Strict as HMS
-import qualified Data.Text as T
-import qualified Data.Text.Encoding as TE
-import qualified Data.Vector as V
+import           Data.Aeson.Internal.Time
+import           Data.Aeson.Types.Internal          (Encoding (..), Value (..))
+import           Data.ByteString.Builder            as B
+import           Data.ByteString.Builder.Prim       as BP
+import           Data.ByteString.Builder.Scientific (scientificBuilder)
+import           Data.Char                          (chr, ord)
+import qualified Data.HashMap.Strict                as HMS
+import           Data.Monoid                        ((<>))
+import           Data.Scientific                    (Scientific, base10Exponent,
+                                                     coefficient)
+import qualified Data.Text                          as T
+import qualified Data.Text.Encoding                 as TE
+import           Data.Time                          (UTCTime (..))
+import           Data.Time.Calendar                 (Day (..), toGregorian)
+import           Data.Time.LocalTime
+import qualified Data.Vector                        as V
+import           Data.Word                          (Word8)
 
 -- | Encode a JSON value to a "Data.ByteString" 'B.Builder'.
 --
@@ -181,12 +183,13 @@ day dd = encodeYear yr <>
         !(T dh dl)  = twoDigits d
         encodeYear y
             | y >= 1000 = B.integerDec y
-            | y > 0 =
-                let (ab,c) = fromIntegral y `quotRem` 10
-                    (a,b)  = ab `quotRem` 10
-                in BP.primBounded (ascii4 ('0',(digit a,(digit b,digit c)))) ()
-            | otherwise =
-                error "Data.Aeson.Encode.Builder.day:  years BCE not supported"
+            | y >= 0    = BP.primBounded (ascii4 (padYear y)) ()
+            | y >= -999 = BP.primBounded (ascii5 ('-',padYear (- y))) ()
+            | otherwise = B.integerDec y
+        padYear y =
+            let (ab,c) = fromIntegral y `quotRem` 10
+                (a,b)  = ab `quotRem` 10
+            in ('0',(digit a,(digit b,digit c)))
 {-# INLINE day #-}
 
 timeOfDay :: TimeOfDay -> Builder

--- a/Data/Aeson/Encode/Builder.hs
+++ b/Data/Aeson/Encode/Builder.hs
@@ -1,5 +1,4 @@
-{-# LANGUAGE BangPatterns      #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE BangPatterns, OverloadedStrings #-}
 
 -- |
 -- Module:      Data.Aeson.Encode.Builder
@@ -36,23 +35,22 @@ module Data.Aeson.Encode.Builder
     , ascii5
     ) where
 
-import           Data.Aeson.Internal.Time
-import           Data.Aeson.Types.Internal          (Encoding (..), Value (..))
-import           Data.ByteString.Builder            as B
-import           Data.ByteString.Builder.Prim       as BP
-import           Data.ByteString.Builder.Scientific (scientificBuilder)
-import           Data.Char                          (chr, ord)
-import qualified Data.HashMap.Strict                as HMS
-import           Data.Monoid                        ((<>))
-import           Data.Scientific                    (Scientific, base10Exponent,
-                                                     coefficient)
-import qualified Data.Text                          as T
-import qualified Data.Text.Encoding                 as TE
-import           Data.Time                          (UTCTime (..))
-import           Data.Time.Calendar                 (Day (..), toGregorian)
-import           Data.Time.LocalTime
-import qualified Data.Vector                        as V
-import           Data.Word                          (Word8)
+import Data.Aeson.Internal.Time
+import Data.Aeson.Types.Internal (Encoding(..), Value(..))
+import Data.ByteString.Builder as B
+import Data.ByteString.Builder.Prim as BP
+import Data.ByteString.Builder.Scientific (scientificBuilder)
+import Data.Char (chr, ord)
+import Data.Monoid ((<>))
+import Data.Scientific (Scientific, base10Exponent, coefficient)
+import Data.Time (UTCTime(..))
+import Data.Time.Calendar (Day(..), toGregorian)
+import Data.Time.LocalTime
+import Data.Word (Word8)
+import qualified Data.HashMap.Strict as HMS
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import qualified Data.Vector as V
 
 -- | Encode a JSON value to a "Data.ByteString" 'B.Builder'.
 --


### PR DESCRIPTION
This PR backports the BCE day encoding fix #486 to 0.11.x branch.

This is tested in production, and would permit it to be included in stackage lts-6. 

I can backport the tests etc. if desired.