### PR TITLE
Re-export some TH type names in Data.Aeson.TH

### DIFF
--- a/Data/Aeson/TH.hs
+++ b/Data/Aeson/TH.hs
@@ -115,6 +115,10 @@ module Data.Aeson.TH
     , mkParseJSON
     , mkLiftParseJSON
     , mkLiftParseJSON2
+
+    , Dec
+    , Name
+    , Q
     ) where
 
 import Prelude ()


### PR DESCRIPTION
When writing functions that call `deriveJSON` with different options, type names such as `Name` or `Q` are required for the function's type signature. As they are not exported by this package, the user must separately import `Language.Haskell.TH` and add `template-haskell` to the project `build-depends` section. Creating wrappers of `deriveJSON` is inconvenient because of this.

This Pull Request attempts to relieve the pain in a minimally invasive way.

As far as I know, this is a backwards-compatible change.