### PR TITLE
Refactor Generic ToJSON

### DIFF
--- a/Data/Aeson.hs
+++ b/Data/Aeson.hs
@@ -76,8 +76,8 @@ module Data.Aeson
     -- ** Generic JSON classes and options
     , GFromJSON(..)
     , FromArgs(..)
-    , GToJSON(..)
-    , GToEncoding(..)
+    , GToJSON
+    , GToEncoding
     , ToArgs(..)
     , Zero
     , One

--- a/Data/Aeson/Encoding.hs
+++ b/Data/Aeson/Encoding.hs
@@ -14,6 +14,7 @@ module Data.Aeson.Encoding
     , Series
     , pairs
     , pair
+    , pairStr
     , pair'
     -- * Predicates
     , nullEncoding

--- a/Data/Aeson/Encoding/Internal.hs
+++ b/Data/Aeson/Encoding/Internal.hs
@@ -13,6 +13,7 @@ module Data.Aeson.Encoding.Internal
     , Series (..)
     , pairs
     , pair
+    , pairStr
     , pair'
     -- * Predicates
     , nullEncoding
@@ -124,6 +125,11 @@ data Series = Empty
 
 pair :: Text -> Encoding -> Series
 pair name val = pair' (text name) val
+{-# INLINE pair #-}
+
+pairStr :: String -> Encoding -> Series
+pairStr name val = pair' (string name) val
+{-# INLINE pairStr #-}
 
 pair' :: Encoding' Text -> Encoding -> Series
 pair' name val = Value $ retagEncoding $ retagEncoding name >< colon >< val

--- a/Data/Aeson/Types.hs
+++ b/Data/Aeson/Types.hs
@@ -63,8 +63,8 @@ module Data.Aeson.Types
     -- ** Generic JSON classes
     , GFromJSON(..)
     , FromArgs(..)
-    , GToJSON(..)
-    , GToEncoding(..)
+    , GToJSON
+    , GToEncoding
     , ToArgs(..)
     , Zero
     , One

--- a/Data/Aeson/Types/Class.hs
+++ b/Data/Aeson/Types/Class.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
@@ -36,8 +37,8 @@ module Data.Aeson.Types.Class
     -- * Generic JSON classes
     , GFromJSON(..)
     , FromArgs(..)
-    , GToJSON(..)
-    , GToEncoding(..)
+    , GToJSON
+    , GToEncoding
     , ToArgs(..)
     , Zero
     , One
@@ -94,4 +95,10 @@ import Prelude ()
 
 import Data.Aeson.Types.FromJSON
 import Data.Aeson.Types.Generic (One, Zero)
-import Data.Aeson.Types.ToJSON
+import Data.Aeson.Types.ToJSON hiding (GToJSON)
+import qualified Data.Aeson.Types.ToJSON as ToJSON
+import Data.Aeson.Types.Internal (Value)
+import Data.Aeson.Encoding (Encoding)
+
+type GToJSON = ToJSON.GToJSON Value
+type GToEncoding = ToJSON.GToJSON Encoding

--- a/benchmarks/AesonCompareAutoInstances.hs
+++ b/benchmarks/AesonCompareAutoInstances.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Main (main) where
@@ -7,16 +7,24 @@ module Main (main) where
 import Prelude ()
 import Prelude.Compat
 
+import Control.Monad
 import Control.DeepSeq (NFData, rnf, deepseq)
 import Criterion.Main hiding (defaultOptions)
-import Data.Aeson.Encode
+import Data.Aeson
+import Data.Aeson.Encoding
 import Data.Aeson.TH
 import Data.Aeson.Types
+import Data.ByteString.Lazy (ByteString)
 import Data.Data (Data)
 import Data.Typeable (Typeable)
-import GHC.Generics (Generic)
+import GHC.Generics (Generic, Rep)
 import Options
-import qualified Data.Aeson.Generic as G (fromJSON, toJSON)
+
+toBS :: Encoding -> ByteString
+toBS = encodingToLazyByteString
+
+gEncode :: (Generic a, GToEncoding Zero (Rep a)) => a -> ByteString
+gEncode = toBS . genericToEncoding opts
 
 --------------------------------------------------------------------------------
 
@@ -27,7 +35,7 @@ data D a = Nullary
                   , testTwo   :: Bool
                   , testThree :: D a
                   }
-           deriving (Show, Eq, Data, Typeable)
+           deriving (Show, Eq)
 
 deriveJSON opts ''D
 
@@ -60,7 +68,7 @@ data D' a = Nullary'
                     , testTwo'   :: Bool
                     , testThree' :: D' a
                     }
-            deriving (Show, Eq, Generic, Data, Typeable)
+            deriving (Show, Eq, Generic)
 
 instance ToJSON a => ToJSON (D' a) where
     toJSON = genericToJSON opts
@@ -96,7 +104,7 @@ data BigRecord = BigRecord
     , field11 :: !Int, field12 :: !Int, field13 :: !Int, field14 :: !Int, field15 :: !Int
     , field16 :: !Int, field17 :: !Int, field18 :: !Int, field19 :: !Int, field20 :: !Int
     , field21 :: !Int, field22 :: !Int, field23 :: !Int, field24 :: !Int, field25 :: !Int
-    } deriving (Show, Eq, Generic, Data, Typeable)
+    } deriving (Show, Eq, Generic)
 
 instance NFData BigRecord
 
@@ -106,14 +114,22 @@ bigRecord = BigRecord 1   2  3  4  5
                       16 17 18 19 20
                       21 22 23 24 25
 
+return []
+
 gBigRecordToJSON :: BigRecord -> Value
 gBigRecordToJSON = genericToJSON opts
+
+gBigRecordEncode :: BigRecord -> ByteString
+gBigRecordEncode = gEncode
 
 gBigRecordFromJSON :: Value -> Result BigRecord
 gBigRecordFromJSON = parse $ genericParseJSON opts
 
 thBigRecordToJSON :: BigRecord -> Value
 thBigRecordToJSON = $(mkToJSON opts ''BigRecord)
+
+thBigRecordEncode :: BigRecord -> ByteString
+thBigRecordEncode = toBS . $(mkToEncoding opts ''BigRecord)
 
 thBigRecordFromJSON :: Value -> Result BigRecord
 thBigRecordFromJSON = parse $(mkParseJSON opts ''BigRecord)
@@ -126,7 +142,7 @@ data BigProduct = BigProduct
     !Int !Int !Int !Int !Int
     !Int !Int !Int !Int !Int
     !Int !Int !Int !Int !Int
-    deriving (Show, Eq, Generic, Data, Typeable)
+    deriving (Show, Eq, Generic)
 
 instance NFData BigProduct
 
@@ -136,14 +152,22 @@ bigProduct = BigProduct 1   2  3  4  5
                         16 17 18 19 20
                         21 22 23 24 25
 
+return []
+
 gBigProductToJSON :: BigProduct -> Value
 gBigProductToJSON = genericToJSON opts
+
+gBigProductEncode :: BigProduct -> ByteString
+gBigProductEncode = gEncode
 
 gBigProductFromJSON :: Value -> Result BigProduct
 gBigProductFromJSON = parse $ genericParseJSON opts
 
 thBigProductToJSON :: BigProduct -> Value
 thBigProductToJSON = $(mkToJSON opts ''BigProduct)
+
+thBigProductEncode :: BigProduct -> ByteString
+thBigProductEncode = toBS . $(mkToEncoding opts ''BigProduct)
 
 thBigProductFromJSON :: Value -> Result BigProduct
 thBigProductFromJSON = parse $(mkParseJSON opts ''BigProduct)
@@ -155,20 +179,28 @@ data BigSum = F01 | F02 | F03 | F04 | F05
             | F11 | F12 | F13 | F14 | F15
             | F16 | F17 | F18 | F19 | F20
             | F21 | F22 | F23 | F24 | F25
-    deriving (Show, Eq, Generic, Data, Typeable)
+    deriving (Show, Eq, Generic)
 
 instance NFData BigSum
 
 bigSum = F25
 
+return []
+
 gBigSumToJSON :: BigSum -> Value
 gBigSumToJSON = genericToJSON opts
+
+gBigSumEncode :: BigSum -> ByteString
+gBigSumEncode = gEncode
 
 gBigSumFromJSON :: Value -> Result BigSum
 gBigSumFromJSON = parse $ genericParseJSON opts
 
 thBigSumToJSON :: BigSum -> Value
 thBigSumToJSON = $(mkToJSON opts ''BigSum)
+
+thBigSumEncode :: BigSum -> ByteString
+thBigSumEncode = toBS . $(mkToEncoding opts ''BigSum)
 
 thBigSumFromJSON :: Value -> Result BigSum
 thBigSumFromJSON = parse $(mkParseJSON opts ''BigSum)
@@ -177,53 +209,74 @@ thBigSumFromJSON = parse $(mkParseJSON opts ''BigSum)
 
 type FJ a = Value -> Result a
 
-main :: IO ()
-main = defaultMain
+runBench :: IO ()
+runBench = defaultMain
   [ let v = toJSON d
     in (d, d', v) `deepseq`
        bgroup "D"
        [ group "toJSON"   (nf   toJSON d)
-                          (nf G.toJSON d)
                           (nf   toJSON d')
+       , group "encode"   (nf encode d)
+                          (nf encode d')
        , group "fromJSON" (nf (  fromJSON :: FJ T ) v)
-                          (nf (G.fromJSON :: FJ T ) v)
                           (nf (  fromJSON :: FJ T') v)
        ]
   , let v = thBigRecordToJSON bigRecord
     in bigRecord `deepseq` v `deepseq`
        bgroup "BigRecord"
        [ group "toJSON"   (nf thBigRecordToJSON bigRecord)
-                          (nf G.toJSON          bigRecord)
-                          (nf gBigRecordToJSON  bigRecord)
+                          (nf  gBigRecordToJSON bigRecord)
+       , group "encode"   (nf thBigRecordEncode bigRecord)
+                          (nf  gBigRecordEncode bigRecord)
        , group "fromJSON" (nf (thBigRecordFromJSON :: FJ BigRecord) v)
-                          (nf (G.fromJSON          :: FJ BigRecord) v)
-                          (nf (gBigRecordFromJSON  :: FJ BigRecord) v)
+                          (nf ( gBigRecordFromJSON :: FJ BigRecord) v)
        ]
   , let v = thBigProductToJSON bigProduct
     in bigProduct `deepseq` v `deepseq`
        bgroup "BigProduct"
        [ group "toJSON"   (nf thBigProductToJSON bigProduct)
-                          (nf G.toJSON           bigProduct)
                           (nf gBigProductToJSON  bigProduct)
+       , group "encode"   (nf thBigProductEncode bigProduct)
+                          (nf  gBigProductEncode bigProduct)
        , group "fromJSON" (nf (thBigProductFromJSON :: FJ BigProduct) v)
-                          (nf (G.fromJSON           :: FJ BigProduct) v)
                           (nf (gBigProductFromJSON  :: FJ BigProduct) v)
        ]
   , let v = thBigSumToJSON bigSum
     in bigSum `deepseq` v `deepseq`
        bgroup "BigSum"
        [ group "toJSON"   (nf thBigSumToJSON bigSum)
-                          (nf G.toJSON       bigSum)
                           (nf gBigSumToJSON  bigSum)
+       , group "encode"   (nf thBigSumEncode bigSum)
+                          (nf  gBigSumEncode bigSum)
        , group "fromJSON" (nf (thBigSumFromJSON :: FJ BigSum) v)
-                          (nf (G.fromJSON       :: FJ BigSum) v)
                           (nf (gBigSumFromJSON  :: FJ BigSum) v)
        ]
   ]
 
-group n th syb gen = bcompare
-                     [ bgroup n [ bench "th"      th
-                                , bench "syb"     syb
-                                , bench "generic" gen
-                                ]
-                     ]
+group n th gen = bgroup n [ bench "th"      th
+                          , bench "generic" gen
+                          ]
+
+sanityCheck = do
+  check d toJSON fromJSON encode
+  check d' toJSON fromJSON encode
+  check bigRecord thBigRecordToJSON thBigRecordFromJSON thBigRecordEncode
+  check bigRecord gBigRecordToJSON gBigRecordFromJSON gBigRecordEncode
+  check bigProduct thBigProductToJSON thBigProductFromJSON thBigProductEncode
+  check bigProduct gBigProductToJSON gBigProductFromJSON gBigProductEncode
+  check bigSum thBigSumToJSON thBigSumFromJSON thBigSumEncode
+  check bigSum gBigSumToJSON gBigSumFromJSON gBigSumEncode
+
+check :: (Show a, Eq a)
+      => a -> (a -> Value) -> (Value -> Result a) -> (a -> ByteString) -> IO ()
+check x toJSON fromJSON encode = do
+  unless (Success x == (fromJSON . toJSON) x) $ fail $ "toJSON: " ++ show x
+  unless (Success x == (decode' . encode) x) $ fail $ "encode: " ++ show x
+  where
+    decode' s = case decode s of
+      Just v -> fromJSON v
+      Nothing -> fail ""
+
+main = do
+  sanityCheck
+  runBench

--- a/benchmarks/Options.hs
+++ b/benchmarks/Options.hs
@@ -1,4 +1,4 @@
-module Options () where
+module Options where
 
 import Prelude ()
 import Prelude.Compat


### PR DESCRIPTION
This merges the code for `GToEncoding` and `GToJSON` which look awfully similar.

I decided to keep exposing `GToEncoding` and `GToJSON` with the original kind as constraint synonyms for backwards compatibility, as they seem to be used in some places for type annotations. I don't think their methods are in use externally however.

This will conflict with #522. I guess I'll resolve it depending on whichever gets merged first.