### PR TITLE
Remove INLINE pragma on timeOfDay64

### DIFF
--- a/Data/Aeson/Encoding/Builder.hs
+++ b/Data/Aeson/Encoding/Builder.hs
@@ -234,7 +234,6 @@ timeOfDay64 (TOD h m s)
     pico       = 1000000000000 -- number of picoseconds  in 1 second
     micro      =       1000000 -- number of microseconds in 1 second
     milli      =          1000 -- number of milliseconds in 1 second
-{-# INLINE timeOfDay64 #-}
 
 timeZone :: TimeZone -> Builder
 timeZone (TimeZone off _ _)

--- a/benchmarks/aeson-benchmarks.cabal
+++ b/benchmarks/aeson-benchmarks.cabal
@@ -179,7 +179,7 @@ executable aeson-benchmark-json-parse
 
 executable aeson-benchmark-dates
   main-is: Dates.hs
-  ghc-options: -Wall -O2 -rtsopts -fsimpl-tick-factor=200
+  ghc-options: -Wall -O2 -rtsopts
   build-depends:
     base,
     base-compat,


### PR DESCRIPTION
`timeOfDay64` is an enormous function, and marking it as `INLINE` causes a simple `aeson` benchmark to exhaust its simplifier ticks.

Thanks to @mpickering for spotting this in https://ghc.haskell.org/trac/ghc/ticket/12967#comment:4.

Fixes #502.