### PR TITLE
Add parserThrowError and parserCatchError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 dist
 dist-newstyle
+.ghc.environment.*
 .cabal-sandbox/
 cabal.sandbox.config
 .stack-work/

--- a/Data/Aeson/Types.hs
+++ b/Data/Aeson/Types.hs
@@ -36,6 +36,8 @@ module Data.Aeson.Types
     , ToJSON(..)
     , KeyValue(..)
     , modifyFailure
+    , parserThrowError
+    , parserCatchError
 
     -- ** Keys for maps
     , ToJSONKey(..)

--- a/aeson.cabal
+++ b/aeson.cabal
@@ -225,7 +225,7 @@ test-suite tests
     unordered-containers,
     uuid-types,
     vector,
-    quickcheck-instances >=0.3.12
+    quickcheck-instances >=0.3.14
 
   if flag(bytestring-builder)
     build-depends: bytestring >= 0.9 && < 0.10.4,

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 For the latest version of this document, please see [https://github.com/bos/aeson/blob/master/changelog.md](https://github.com/bos/aeson/blob/master/changelog.md).
 
+## 1.2.1.0
+
+* Add `parserThrowError` and `parserCatchError` combinators.
+
 ## 1.2.0.0
 
 * `tagSingleConstructors`, an option to encode single-constructor types as tagged sums was added to `Options`. It is disabled by default for backward compatibility.

--- a/stack-bench.yaml
+++ b/stack-bench.yaml
@@ -2,3 +2,5 @@ resolver: lts-8.5
 packages:
 - '.'
 - benchmarks
+extra-deps:
+- quickcheck-instances-0.3.14

--- a/stack-lts6.yaml
+++ b/stack-lts6.yaml
@@ -3,8 +3,13 @@ packages:
 - '.'
 - attoparsec-iso8601
 extra-deps:
-- semigroups-0.18.2
 - integer-logarithms-1
+- QuickCheck-2.9.2
+- quickcheck-instances-0.3.14
+- semigroups-0.18.2
+- tagged-0.8.5
+- transformers-compat-0.5.1.4
+flags:
 flags:
   aeson:
     fast: true

--- a/stack-lts7.yaml
+++ b/stack-lts7.yaml
@@ -4,6 +4,7 @@ packages:
 - attoparsec-iso8601
 extra-deps:
 - integer-logarithms-1
+- quickcheck-instances-0.3.14
 flags:
   aeson:
     fast: true

--- a/stack-lts8.yaml
+++ b/stack-lts8.yaml
@@ -2,6 +2,8 @@ resolver: lts-8.1
 packages:
 - '.'
 - attoparsec-iso8601
+extra-deps:
+- quickcheck-instances-0.3.14
 flags:
   aeson:
     fast: true

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -2,6 +2,8 @@ resolver: nightly-2017-03-25
 packages:
 - '.'
 - attoparsec-iso8601
+extra-deps:
+- quickcheck-instances-0.3.14
 flags:
   aeson:
     fast: true

--- a/stack-pure-unescape.yaml
+++ b/stack-pure-unescape.yaml
@@ -1,6 +1,8 @@
 resolver: lts-8.1
 packages:
 - '.'
+extra-deps:
+- quickcheck-instances-0.3.14
 flags:
   aeson:
     fast: true

--- a/tests/Instances.hs
+++ b/tests/Instances.hs
@@ -16,7 +16,6 @@ import Data.Aeson.Types
 import Data.Function (on)
 import Data.Functor.Compose (Compose (..))
 import Data.Proxy (Proxy(..))
-import Data.Tagged (Tagged(..))
 import Data.Time (ZonedTime(..), TimeZone(..))
 import Data.Time.Clock (UTCTime(..))
 import Functions
@@ -24,7 +23,6 @@ import Test.QuickCheck (Arbitrary(..), elements,  oneof)
 import Types
 import qualified Data.DList as DList
 import qualified Data.HashMap.Strict as HM
-import qualified Data.UUID.Types as UUID
 
 #if !MIN_VERSION_QuickCheck(2,9,0)
 import Control.Applicative (Const(..))
@@ -193,9 +191,6 @@ instance Arbitrary Natural where
 instance Arbitrary (Proxy a) where
     arbitrary = pure Proxy
 
-instance Arbitrary b => Arbitrary (Tagged a b) where
-    arbitrary = Tagged <$> arbitrary
-
 instance Arbitrary a => Arbitrary (DList.DList a) where
     arbitrary = DList.fromList <$> arbitrary
 
@@ -220,10 +215,3 @@ makeVersion b = Version b []
 instance Arbitrary a => Arbitrary (Identity a) where
     arbitrary = Identity <$> arbitrary
 #endif
-
-instance Arbitrary UUID.UUID where
-    arbitrary = UUID.fromWords
-        <$> arbitrary
-        <*> arbitrary
-        <*> arbitrary
-        <*> arbitrary

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -127,7 +127,7 @@ parserCatchErrorProp :: [String] -> String -> Property
 parserCatchErrorProp path msg =
     result === Success ([I.Key "outer", I.Key "inner"] ++ jsonPath, msg)
   where
-    parser = parserCatchError outer (\p err -> pure (p, err))
+    parser = parserCatchError outer (curry pure)
 
     outer = inner I.<?> I.Key "outer"
     inner = parserThrowError jsonPath msg I.<?> I.Key "inner"

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -113,6 +113,23 @@ modifyFailureProp orig added =
     result :: Result ()
     result = parse parser ()
 
+parserThrowErrorProp :: String -> Property
+parserThrowErrorProp msg =
+    result === Error msg
+  where
+    parser = const $ parserThrowError [] msg
+    result :: Result ()
+    result = parse parser ()
+
+parserCatchErrorProp :: String -> Property
+parserCatchErrorProp msg =
+    result === Success msg
+  where
+    -- Fail, catch, use error message as a successful parse
+    parser = const $ parserCatchError (fail msg) (\_ err -> pure err)
+    result :: Result String
+    result = parse parser ()
+
 -- | Perform a structural comparison of the results of two encoding
 -- methods. Compares decoded values to account for HashMap-driven
 -- variation in JSON object key ordering.
@@ -306,6 +323,8 @@ tests = testGroup "properties" [
     ]
   , testGroup "failure messages" [
       testProperty "modify failure" modifyFailureProp
+    , testProperty "parserThrowError" parserThrowErrorProp
+    , testProperty "parserCatchError" parserCatchErrorProp
     ]
   , testGroup "generic" [
       testGroup "toJSON" [


### PR DESCRIPTION
I ran into need for `parserCatchError` and cannot workaround it anymore :/ (`<|>` doesn't give me an error message, but is virtually the same)