### PR TITLE
Use the th-abstraction library to factor out some TH boilerplate

### DIFF
--- a/Data/Aeson/TH.hs
+++ b/Data/Aeson/TH.hs
@@ -130,7 +130,7 @@ import Data.Foldable (foldr')
 #if MIN_VERSION_template_haskell(2,8,0) && !MIN_VERSION_template_haskell(2,10,0)
 import Data.List (nub)
 #endif
-import Data.List (find, foldl', genericLength , intercalate , intersperse, partition, union)
+import Data.List (foldl', genericLength , intercalate , intersperse, partition, union)
 import Data.List.NonEmpty ((<|), NonEmpty((:|)))
 import Data.Map (Map)
 import Data.Maybe (catMaybes, fromMaybe, mapMaybe)
@@ -140,7 +140,7 @@ import Language.Haskell.TH hiding (Arity)
 #else
 import Language.Haskell.TH
 #endif
-import Language.Haskell.TH.Syntax (VarStrictType)
+import Language.Haskell.TH.Datatype
 #if MIN_VERSION_template_haskell(2,7,0) && !(MIN_VERSION_template_haskell(2,8,0))
 import Language.Haskell.TH.Lib (starK)
 #endif
@@ -152,8 +152,8 @@ import qualified Data.Aeson as A
 import qualified Data.Aeson.Encoding.Internal as E
 import qualified Data.Foldable as F (all)
 import qualified Data.HashMap.Strict as H (lookup, toList)
-import qualified Data.List.NonEmpty as NE (drop, length, reverse, splitAt)
-import qualified Data.Map as M (fromList, findWithDefault, keys, lookup , singleton, size)
+import qualified Data.List.NonEmpty as NE (length, reverse)
+import qualified Data.Map as M (fromList, keys, lookup , singleton, size)
 import qualified Data.Set as Set (empty, insert, member)
 import qualified Data.Text as T (Text, pack, unpack)
 import qualified Data.Vector as V (unsafeIndex, null, length, create, fromList)
@@ -322,32 +322,36 @@ consToValue :: JSONClass
             -- ^ The ToJSON variant being derived.
             -> Options
             -- ^ Encoding options.
-            -> [Con]
+            -> [Type]
+            -- ^ The types from the data type/data family instance declaration
+            -> [ConstructorInfo]
             -- ^ Constructors for which to generate JSON generating code.
             -> Q Exp
 
-consToValue _ _ [] = error $ "Data.Aeson.TH.consToValue: "
-                            ++ "Not a single constructor given!"
+consToValue _ _ _ [] = error $ "Data.Aeson.TH.consToValue: "
+                             ++ "Not a single constructor given!"
 
-consToValue jc opts cons = do
+consToValue jc opts vars cons = do
     value <- newName "value"
     tjs   <- newNameList "_tj"  $ arityInt jc
     tjls  <- newNameList "_tjl" $ arityInt jc
     let zippedTJs      = zip tjs tjls
         interleavedTJs = interleave tjs tjls
+        lastTyVars     = map varTToName $ drop (length vars - arityInt jc) vars
+        tvMap          = M.fromList $ zip lastTyVars zippedTJs
     lamE (map varP $ interleavedTJs ++ [value]) $
-        caseE (varE value) (matches zippedTJs)
+        caseE (varE value) (matches tvMap)
   where
-    matches tjs = case cons of
+    matches tvMap = case cons of
       -- A single constructor is directly encoded. The constructor itself may be
       -- forgotten.
-      [con] | not (tagSingleConstructors opts) -> [argsToValue jc tjs opts False con]
+      [con] | not (tagSingleConstructors opts) -> [argsToValue jc tvMap opts False con]
       _ | allNullaryToStringTag opts && all isNullary cons ->
               [ match (conP conName []) (normalB $ conStr opts conName) []
               | con <- cons
-              , let conName = getConName con
+              , let conName = constructorName con
               ]
-        | otherwise -> [argsToValue jc tjs opts True con | con <- cons]
+        | otherwise -> [argsToValue jc tvMap opts True con | con <- cons]
 
 conStr :: Options -> Name -> Q Exp
 conStr opts = appE [|String|] . conTxt opts
@@ -365,42 +369,47 @@ consToEncoding :: JSONClass
                -- ^ The ToJSON variant being derived.
                -> Options
                -- ^ Encoding options.
-               -> [Con]
+               -> [Type]
+               -- ^ The types from the data type/data family instance declaration
+               -> [ConstructorInfo]
                -- ^ Constructors for which to generate JSON generating code.
                -> Q Exp
 
-consToEncoding _ _ [] = error $ "Data.Aeson.TH.consToEncoding: "
-                        ++ "Not a single constructor given!"
+consToEncoding _ _ _ [] = error $ "Data.Aeson.TH.consToEncoding: "
+                          ++ "Not a single constructor given!"
 
-consToEncoding jc opts cons = do
+consToEncoding jc opts vars cons = do
     value <- newName "value"
     tes   <- newNameList "_te"  $ arityInt jc
     tels  <- newNameList "_tel" $ arityInt jc
     let zippedTEs      = zip tes tels
         interleavedTEs = interleave tes tels
+        lastTyVars     = map varTToName $ drop (length vars - arityInt jc) vars
+        tvMap          = M.fromList $ zip lastTyVars zippedTEs
     lamE (map varP $ interleavedTEs ++ [value]) $
-        caseE (varE value) (matches zippedTEs)
+        caseE (varE value) (matches tvMap)
   where
-    matches tes = case cons of
+    matches tvMap = case cons of
       -- A single constructor is directly encoded. The constructor itself may be
       -- forgotten.
-      [con] | not (tagSingleConstructors opts) -> [argsToEncoding jc tes opts False con]
+      [con] | not (tagSingleConstructors opts) -> [argsToEncoding jc tvMap opts False con]
       -- Encode just the name of the constructor of a sum type iff all the
       -- constructors are nullary.
       _ | allNullaryToStringTag opts && all isNullary cons ->
               [ match (conP conName [])
                 (normalB $ encStr opts conName) []
               | con <- cons
-              , let conName = getConName con
+              , let conName = constructorName con
               ]
-        | otherwise -> [argsToEncoding jc tes opts True con | con <- cons]
+        | otherwise -> [argsToEncoding jc tvMap opts True con | con <- cons]
 
 encStr :: Options -> Name -> Q Exp
 encStr opts = appE [|E.text|] . conTxt opts
 
 -- | If constructor is nullary.
-isNullary :: Con -> Bool
-isNullary (NormalC _ []) = True
+isNullary :: ConstructorInfo -> Bool
+isNullary (ConstructorInfo { constructorVariant = NormalConstructor
+                           , constructorFields  = tys }) = null tys
 isNullary _ = False
 
 sumToValue :: Options -> Bool -> Bool -> Name -> Q Exp -> Q Exp
@@ -423,16 +432,19 @@ sumToValue opts multiCons nullary conName exp
     | otherwise = exp
 
 -- | Generates code to generate the JSON encoding of a single constructor.
-argsToValue :: JSONClass -> [(Name, Name)] -> Options -> Bool -> Con -> Q Match
+argsToValue :: JSONClass -> TyVarMap -> Options -> Bool -> ConstructorInfo -> Q Match
 
 -- Polyadic constructors with special case for unary constructors.
-argsToValue jc tjs opts multiCons (NormalC conName ts) = do
-    (argTys, tvMap) <- reifyConTys jc tjs conName
-    let len = length ts
+argsToValue jc tvMap opts multiCons
+  (ConstructorInfo { constructorName    = conName
+                   , constructorVariant = NormalConstructor
+                   , constructorFields  = argTys }) = do
+    argTys' <- mapM resolveTypeSynonyms argTys
+    let len = length argTys'
     args <- newNameList "arg" len
     js <- case [ dispatchToJSON jc conName tvMap argTy
                    `appE` varE arg
-               | (arg, argTy) <- zip args argTys
+               | (arg, argTy) <- zip args argTys'
                ] of
             -- Single argument is directly converted.
             [e] -> return e
@@ -454,69 +466,77 @@ argsToValue jc tjs opts multiCons (NormalC conName ts) = do
                          (varE 'V.create `appE`
                            doE (newMV:stmts++[ret]))
     match (conP conName $ map varP args)
-          (normalB $ sumToValue opts multiCons (null ts) conName js)
+          (normalB $ sumToValue opts multiCons (null argTys') conName js)
           []
 
 -- Records.
-argsToValue jc tjs opts multiCons (RecC conName ts) = case (unwrapUnaryRecords opts, not multiCons, ts) of
-  (True,True,[(_,st,ty)]) -> argsToValue jc tjs opts multiCons (NormalC conName [(st,ty)])
-  _ -> do
-    (argTys, tvMap) <- reifyConTys jc tjs conName
-    args <- newNameList "arg" $ length ts
-    let exp = [|A.object|] `appE` pairs
+argsToValue jc tvMap opts multiCons
+  info@(ConstructorInfo { constructorName    = conName
+                        , constructorVariant = RecordConstructor fields
+                        , constructorFields  = argTys }) =
+    case (unwrapUnaryRecords opts, not multiCons, argTys) of
+      (True,True,[_]) -> argsToValue jc tvMap opts multiCons
+                                     (info{constructorVariant = NormalConstructor})
+      _ -> do
+        argTys' <- mapM resolveTypeSynonyms argTys
+        args <- newNameList "arg" $ length argTys'
+        let exp = [|A.object|] `appE` pairs
 
-        pairs | omitNothingFields opts = infixApp maybeFields
-                                                  [|(++)|]
-                                                  restFields
-              | otherwise = listE $ map toPair argCons
+            pairs | omitNothingFields opts = infixApp maybeFields
+                                                      [|(++)|]
+                                                      restFields
+                  | otherwise = listE $ map toPair argCons
 
-        argCons = zip3 args argTys ts
+            argCons = zip3 args argTys' fields
 
-        maybeFields = [|catMaybes|] `appE` listE (map maybeToPair maybes)
+            maybeFields = [|catMaybes|] `appE` listE (map maybeToPair maybes)
 
-        restFields = listE $ map toPair rest
+            restFields = listE $ map toPair rest
 
-        (maybes, rest) = partition isMaybe argCons
+            (maybes, rest) = partition isMaybe argCons
 
-        maybeToPair (arg, argTy, (field, _, _)) =
-            infixApp ([|keyValuePairWith|]
-                        `appE` dispatchToJSON jc conName tvMap argTy
-                        `appE` toFieldName field)
-                     [|(<$>)|]
-                     (varE arg)
+            maybeToPair (arg, argTy, field) =
+                infixApp ([|keyValuePairWith|]
+                            `appE` dispatchToJSON jc conName tvMap argTy
+                            `appE` toFieldName field)
+                         [|(<$>)|]
+                         (varE arg)
 
-        toPair (arg, argTy, (field, _, _)) =
-            [|keyValuePairWith|]
-              `appE` dispatchToJSON jc conName tvMap argTy
-              `appE` toFieldName field
-              `appE` varE arg
+            toPair (arg, argTy, field) =
+                [|keyValuePairWith|]
+                  `appE` dispatchToJSON jc conName tvMap argTy
+                  `appE` toFieldName field
+                  `appE` varE arg
 
-        toFieldName field = [|T.pack|] `appE` fieldLabelExp opts field
+            toFieldName field = [|T.pack|] `appE` fieldLabelExp opts field
 
-    match (conP conName $ map varP args)
-          ( normalB
-          $ if multiCons
-            then case sumEncoding opts of
-                   TwoElemArray -> [|toJSON|] `appE` tupE [conStr opts conName, exp]
-                   TaggedObject{tagFieldName} ->
-                       [|A.object|] `appE`
-                         -- TODO: Maybe throw an error in case
-                         -- tagFieldName overwrites a field in pairs.
-                         infixApp (infixApp [|T.pack tagFieldName|]
-                                            [|(.=)|]
-                                            (conStr opts conName))
-                                  [|(:)|]
-                                  pairs
-                   ObjectWithSingleField ->
-                       [|A.object|] `appE` listE
-                         [ infixApp (conTxt opts conName) [|(.=)|] exp ]
-                   UntaggedValue -> exp
-            else exp
-          ) []
+        match (conP conName $ map varP args)
+              ( normalB
+              $ if multiCons
+                then case sumEncoding opts of
+                       TwoElemArray -> [|toJSON|] `appE` tupE [conStr opts conName, exp]
+                       TaggedObject{tagFieldName} ->
+                           [|A.object|] `appE`
+                             -- TODO: Maybe throw an error in case
+                             -- tagFieldName overwrites a field in pairs.
+                             infixApp (infixApp [|T.pack tagFieldName|]
+                                                [|(.=)|]
+                                                (conStr opts conName))
+                                      [|(:)|]
+                                      pairs
+                       ObjectWithSingleField ->
+                           [|A.object|] `appE` listE
+                             [ infixApp (conTxt opts conName) [|(.=)|] exp ]
+                       UntaggedValue -> exp
+                else exp
+              ) []
 
 -- Infix constructors.
-argsToValue jc tjs opts multiCons (InfixC _ conName _) = do
-    ([alTy, arTy], tvMap) <- reifyConTys jc tjs conName
+argsToValue jc tvMap opts multiCons
+  (ConstructorInfo { constructorName    = conName
+                   , constructorVariant = InfixConstructor
+                   , constructorFields  = argTys }) = do
+    [alTy, arTy] <- mapM resolveTypeSynonyms argTys
     al <- newName "argL"
     ar <- newName "argR"
     match (infixP (varP al) conName (varP ar))
@@ -528,22 +548,10 @@ argsToValue jc tjs opts multiCons (InfixC _ conName _) = do
                                     ]
           )
           []
--- Existentially quantified constructors.
-argsToValue jc tjs opts multiCons (ForallC _ _ con) =
-    argsToValue jc tjs opts multiCons con
 
-#if MIN_VERSION_template_haskell(2,11,0)
--- GADTs.
-argsToValue jc tjs opts multiCons (GadtC conNames ts _) =
-    argsToValue jc tjs opts multiCons $ NormalC (head conNames) ts
-
-argsToValue jc tjs opts multiCons (RecGadtC conNames ts _) =
-    argsToValue jc tjs opts multiCons $ RecC (head conNames) ts
-#endif
-
-isMaybe :: (a, b, (c, d, Type)) -> Bool
-isMaybe (_, _, (_, _, AppT (ConT t) _)) = t == ''Maybe
-isMaybe _                               = False
+isMaybe :: (a, Type, b) -> Bool
+isMaybe (_, AppT (ConT t) _, _) = t == ''Maybe
+isMaybe _                       = False
 
 (<^>) :: ExpQ -> ExpQ -> ExpQ
 (<^>) a b = infixApp a [|(E.><)|] b
@@ -583,14 +591,17 @@ sumToEncoding opts multiCons nullary conName exp
     | otherwise = exp
 
 -- | Generates code to generate the JSON encoding of a single constructor.
-argsToEncoding :: JSONClass -> [(Name, Name)] -> Options -> Bool -> Con -> Q Match
+argsToEncoding :: JSONClass -> TyVarMap -> Options -> Bool -> ConstructorInfo -> Q Match
 
 -- Polyadic constructors with special case for unary constructors.
-argsToEncoding jc tes opts multiCons (NormalC conName ts) = do
-    (argTys, tvMap) <- reifyConTys jc tes conName
-    let len = length ts
+argsToEncoding jc tvMap opts multiCons
+  (ConstructorInfo { constructorName    = conName
+                   , constructorVariant = NormalConstructor
+                   , constructorFields  = argTys }) = do
+    argTys' <- mapM resolveTypeSynonyms argTys
+    let len = length argTys'
     args <- newNameList "arg" len
-    js <- case zip args argTys of
+    js <- case zip args argTys' of
             -- Nullary constructors are converted to an empty array.
             [] -> return [| E.emptyArray_ |]
 
@@ -604,73 +615,81 @@ argsToEncoding jc tes opts multiCons (NormalC conName ts) = do
                                           | (x,xTy) <- es
                                           ]))
     match (conP conName $ map varP args)
-          (normalB $ sumToEncoding opts multiCons (null ts) conName js)
+          (normalB $ sumToEncoding opts multiCons (null argTys') conName js)
           []
 
 -- Records.
-argsToEncoding jc tes opts multiCons (RecC conName ts) = case (unwrapUnaryRecords opts, not multiCons, ts) of
-  (True,True,[(_,st,ty)]) -> argsToEncoding jc tes opts multiCons (NormalC conName [(st,ty)])
-  _ -> do
-    args <- newNameList "arg" $ length ts
-    (argTys, tvMap) <- reifyConTys jc tes conName
-    let exp = object objBody
+argsToEncoding jc tvMap opts multiCons
+  info@(ConstructorInfo { constructorName    = conName
+                        , constructorVariant = RecordConstructor fields
+                        , constructorFields  = argTys }) = do
+    case (unwrapUnaryRecords opts, not multiCons, argTys) of
+      (True,True,[_]) -> argsToEncoding jc tvMap opts multiCons
+                                        (info{constructorVariant = NormalConstructor})
+      _ -> do
+        argTys' <- mapM resolveTypeSynonyms argTys
+        args <- newNameList "arg" $ length argTys'
+        let exp = object objBody
 
-        objBody = [|E.econcat|] `appE`
-                  ([|intersperse E.comma|] `appE` pairs)
-        pairs | omitNothingFields opts = infixApp maybeFields
-                                                  [|(++)|]
-                                                  restFields
-              | otherwise = listE (map toPair argCons)
+            objBody = [|E.econcat|] `appE`
+                      ([|intersperse E.comma|] `appE` pairs)
+            pairs | omitNothingFields opts = infixApp maybeFields
+                                                      [|(++)|]
+                                                      restFields
+                  | otherwise = listE (map toPair argCons)
 
-        argCons = zip3 args argTys ts
+            argCons = zip3 args argTys' fields
 
-        maybeFields = [|catMaybes|] `appE` listE (map maybeToPair maybes)
+            maybeFields = [|catMaybes|] `appE` listE (map maybeToPair maybes)
 
-        restFields = listE (map toPair rest)
+            restFields = listE (map toPair rest)
 
-        (maybes, rest) = partition isMaybe argCons
+            (maybes, rest) = partition isMaybe argCons
 
-        maybeToPair (arg, argTy, (field, _, _)) =
-            infixApp
-              (infixApp
-                (infixE
-                  (Just $ toFieldName field <^> [|E.colon|])
-                  [|(E.><)|]
-                  Nothing)
-                [|(.)|]
-                (dispatchToEncoding jc conName tvMap argTy))
-              [|(<$>)|]
-              (varE arg)
+            maybeToPair (arg, argTy, field) =
+                infixApp
+                  (infixApp
+                    (infixE
+                      (Just $ toFieldName field <^> [|E.colon|])
+                      [|(E.><)|]
+                      Nothing)
+                    [|(.)|]
+                    (dispatchToEncoding jc conName tvMap argTy))
+                  [|(<$>)|]
+                  (varE arg)
 
-        toPair (arg, argTy, (field, _, _)) =
-          toFieldName field
-            <:> dispatchToEncoding jc conName tvMap argTy
-                  `appE` varE arg
+            toPair (arg, argTy, field) =
+              toFieldName field
+                <:> dispatchToEncoding jc conName tvMap argTy
+                      `appE` varE arg
 
-        toFieldName field = [|E.text|] `appE`
-                            ([|T.pack|] `appE` fieldLabelExp opts field)
+            toFieldName field = [|E.text|] `appE`
+                                ([|T.pack|] `appE` fieldLabelExp opts field)
 
-    match (conP conName $ map varP args)
-          ( normalB
-          $ if multiCons
-            then case sumEncoding opts of
-                   TwoElemArray -> array $
-                     encStr opts conName <%>  exp
-                   TaggedObject{tagFieldName} -> object $
-                     ([|E.text (T.pack tagFieldName)|] <:>
-                      encStr opts conName) <%>
-                     objBody
-                   ObjectWithSingleField -> object $
-                     encStr opts conName <:> exp
-                   UntaggedValue -> exp
-            else exp
-          ) []
+        match (conP conName $ map varP args)
+              ( normalB
+              $ if multiCons
+                then case sumEncoding opts of
+                       TwoElemArray -> array $
+                         encStr opts conName <%>  exp
+                       TaggedObject{tagFieldName} -> object $
+                         ([|E.text (T.pack tagFieldName)|] <:>
+                          encStr opts conName) <%>
+                         objBody
+                       ObjectWithSingleField -> object $
+                         encStr opts conName <:> exp
+                       UntaggedValue -> exp
+                else exp
+              ) []
 
 -- Infix constructors.
-argsToEncoding jc tes opts multiCons (InfixC _ conName _) = do
+argsToEncoding jc tvMap opts multiCons
+  (ConstructorInfo { constructorName    = conName
+                   , constructorVariant = InfixConstructor
+                   , constructorFields  = argTys }) = do
     al <- newName "argL"
     ar <- newName "argR"
-    ([alTy,arTy], tvMap) <- reifyConTys jc tes conName
+    [alTy,arTy] <- mapM resolveTypeSynonyms argTys
     match (infixP (varP al) conName (varP ar))
           ( normalB
           $ sumToEncoding opts multiCons False conName
@@ -680,18 +699,6 @@ argsToEncoding jc tes opts multiCons (InfixC _ conName _) = do
                                 ])
           )
           []
--- Existentially quantified constructors.
-argsToEncoding jc tes opts multiCons (ForallC _ _ con) =
-    argsToEncoding jc tes opts multiCons con
-
-#if MIN_VERSION_template_haskell(2,11,0)
--- GADTs.
-argsToEncoding jc tes opts multiCons (GadtC conNames ts _) =
-    argsToEncoding jc tes opts multiCons $ NormalC (head conNames) ts
-
-argsToEncoding jc tes opts multiCons (RecGadtC conNames ts _) =
-    argsToEncoding jc tes opts multiCons $ RecC (head conNames) ts
-#endif
 
 --------------------------------------------------------------------------------
 -- FromJSON
@@ -775,33 +782,41 @@ consFromJSON :: JSONClass
              -- ^ Name of the type to which the constructors belong.
              -> Options
              -- ^ Encoding options
-             -> [Con]
+             -> [Type]
+             -- ^ The types from the data type/data family instance declaration
+             -> [ConstructorInfo]
              -- ^ Constructors for which to generate JSON parsing code.
              -> Q Exp
 
-consFromJSON _ _ _ [] = error $ "Data.Aeson.TH.consFromJSON: "
-                              ++ "Not a single constructor given!"
+consFromJSON _ _ _ _ [] = error $ "Data.Aeson.TH.consFromJSON: "
+                                ++ "Not a single constructor given!"
 
-consFromJSON jc tName opts cons = do
+consFromJSON jc tName opts vars cons = do
   value <- newName "value"
   pjs   <- newNameList "_pj"  $ arityInt jc
   pjls  <- newNameList "_pjl" $ arityInt jc
   let zippedPJs      = zip pjs pjls
       interleavedPJs = interleave pjs pjls
-  lamE (map varP $ interleavedPJs ++ [value]) $ lamExpr value zippedPJs
+      lastTyVars     = map varTToName $ drop (length vars - arityInt jc) vars
+      tvMap          = M.fromList $ zip lastTyVars zippedPJs
+  lamE (map varP $ interleavedPJs ++ [value]) $ lamExpr value tvMap
 
   where
-    lamExpr value pjs = case cons of
+    checkExi tvMap con = checkExistentialContext jc tvMap
+                                                 (constructorContext con)
+                                                 (constructorName con)
+
+    lamExpr value tvMap = case cons of
       [con]
         | not (tagSingleConstructors opts)
-            -> parseArgs jc pjs tName opts con (Right value)
+            -> checkExi tvMap con $ parseArgs jc tvMap tName opts con (Right value)
       _ | sumEncoding opts == UntaggedValue
-            -> parseUntaggedValue pjs cons value
+            -> parseUntaggedValue tvMap cons value
         | otherwise
             -> caseE (varE value) $
                    if allNullaryToStringTag opts && all isNullary cons
                    then allNullaryMatches
-                   else mixedMatches pjs
+                   else mixedMatches tvMap
 
     allNullaryMatches =
       [ do txt <- newName "txt"
@@ -815,7 +830,7 @@ consFromJSON jc tName opts cons = do
                                )
                                ([|pure|] `appE` conE conName)
                   | con <- cons
-                  , let conName = getConName con
+                  , let conName = constructorName con
                   ]
                   ++
                   [ liftM2 (,)
@@ -836,13 +851,13 @@ consFromJSON jc tName opts cons = do
                  []
       ]
 
-    mixedMatches pjs =
+    mixedMatches tvMap =
         case sumEncoding opts of
           TaggedObject {tagFieldName, contentsFieldName} ->
-            parseObject $ parseTaggedObject pjs tagFieldName contentsFieldName
+            parseObject $ parseTaggedObject tvMap tagFieldName contentsFieldName
           UntaggedValue -> error "UntaggedValue: Should be handled already"
           ObjectWithSingleField ->
-            parseObject $ parseObjectWithSingleField pjs
+            parseObject $ parseObjectWithSingleField tvMap
           TwoElemArray ->
             [ do arr <- newName "array"
                  match (conP 'Array [varP arr])
@@ -850,7 +865,7 @@ consFromJSON jc tName opts cons = do
                         [ liftM2 (,) (normalG $ infixApp ([|V.length|] `appE` varE arr)
                                                          [|(==)|]
                                                          (litE $ integerL 2))
-                                     (parse2ElemArray pjs arr)
+                                     (parse2ElemArray tvMap arr)
                         , liftM2 (,) (normalG [|otherwise|])
                                      ([|not2ElemArray|]
                                        `appE` litE (stringL $ show tName)
@@ -881,20 +896,24 @@ consFromJSON jc tName opts cons = do
                    []
         ]
 
-    parseTaggedObject pjs typFieldName valFieldName obj = do
+    parseTaggedObject tvMap typFieldName valFieldName obj = do
       conKey <- newName "conKey"
       doE [ bindS (varP conKey)
                   (infixApp (varE obj)
                             [|(.:)|]
                             ([|T.pack|] `appE` stringE typFieldName))
-          , noBindS $ parseContents pjs conKey (Left (valFieldName, obj)) 'conNotFoundFailTaggedObject
+          , noBindS $ parseContents tvMap conKey (Left (valFieldName, obj)) 'conNotFoundFailTaggedObject
           ]
 
-    parseUntaggedValue pjs cons' conVal =
+    parseUntaggedValue tvMap cons' conVal =
         foldr1 (\e e' -> infixApp e [|(<|>)|] e')
-               (map (\x -> parseValue pjs x conVal) cons')
+               (map (\x -> parseValue tvMap x conVal) cons')
 
-    parseValue _pjs (NormalC conName []) conVal = do
+    parseValue _tvMap
+        (ConstructorInfo { constructorName    = conName
+                         , constructorVariant = NormalConstructor
+                         , constructorFields  = [] })
+        conVal = do
       str <- newName "str"
       caseE (varE conVal)
         [ match (conP 'String [varP str])
@@ -907,11 +926,11 @@ consFromJSON jc tName opts cons = do
                 []
         , matchFailed tName conName "String"
         ]
-    parseValue pjs con conVal =
-      parseArgs jc pjs tName opts con (Right conVal)
+    parseValue tvMap con conVal =
+      checkExi tvMap con $ parseArgs jc tvMap tName opts con (Right conVal)
 
 
-    parse2ElemArray pjs arr = do
+    parse2ElemArray tvMap arr = do
       conKey <- newName "conKey"
       conVal <- newName "conVal"
       let letIx n ix =
@@ -926,7 +945,7 @@ consFromJSON jc tName opts cons = do
            (caseE (varE conKey)
                   [ do txt <- newName "txt"
                        match (conP 'String [varP txt])
-                             (normalB $ parseContents pjs
+                             (normalB $ parseContents tvMap
                                                       txt
                                                       (Right conVal)
                                                       'conNotFoundFail2ElemArray
@@ -943,12 +962,12 @@ consFromJSON jc tName opts cons = do
                   ]
            )
 
-    parseObjectWithSingleField pjs obj = do
+    parseObjectWithSingleField tvMap obj = do
       conKey <- newName "conKey"
       conVal <- newName "conVal"
       caseE ([e|H.toList|] `appE` varE obj)
             [ match (listP [tupP [varP conKey, varP conVal]])
-                    (normalB $ parseContents pjs conKey (Right conVal) 'conNotFoundFailObjectSingleField)
+                    (normalB $ parseContents tvMap conKey (Right conVal) 'conNotFoundFailObjectSingleField)
                     []
             , do other <- newName "other"
                  match (varP other)
@@ -959,7 +978,7 @@ consFromJSON jc tName opts cons = do
                        []
             ]
 
-    parseContents pjs conKey contents errorFun =
+    parseContents tvMap conKey contents errorFun =
         caseE (varE conKey)
               [ match wildP
                       ( guardedB $
@@ -967,7 +986,8 @@ consFromJSON jc tName opts cons = do
                                                      [|(==)|]
                                                      ([|T.pack|] `appE`
                                                         conNameExp opts con)
-                             e <- parseArgs jc pjs tName opts con contents
+                             e <- checkExi tvMap con $
+                                  parseArgs jc tvMap tName opts con contents
                              return (g, e)
                         | con <- cons
                         ]
@@ -980,7 +1000,7 @@ consFromJSON jc tName opts cons = do
                                                      . stringL
                                                      . constructorTagModifier opts
                                                      . nameBase
-                                                     . getConName
+                                                     . constructorName
                                                      ) cons
                                                 )
                                    `appE` ([|T.unpack|] `appE` varE conKey)
@@ -1029,10 +1049,10 @@ parseRecord :: JSONClass
             -> Options
             -> Name
             -> Name
-            -> [VarStrictType]
+            -> [Name]
             -> Name
             -> ExpQ
-parseRecord jc tvMap argTys opts tName conName ts obj =
+parseRecord jc tvMap argTys opts tName conName fields obj =
     foldl' (\a b -> infixApp a [|(<*>)|] b)
            (infixApp (conE conName) [|(<$>)|] x)
            xs
@@ -1044,7 +1064,7 @@ parseRecord jc tvMap argTys opts tName conName ts obj =
                `appE` varE obj
                `appE` ( [|T.pack|] `appE` fieldLabelExp opts field
                       )
-             | ((field, _, _), argTy) <- zip ts argTys
+             | (field, argTy) <- zip fields argTys
              ]
 
 getValField :: Name -> String -> [MatchQ] -> Q Exp
@@ -1063,67 +1083,82 @@ matchCases (Right valName)            = caseE (varE valName)
 
 -- | Generates code to parse the JSON encoding of a single constructor.
 parseArgs :: JSONClass -- ^ The FromJSON variant being derived.
-          -> [(Name, Name)] -- ^ The names of the encoding/decoding function arguments.
+          -> TyVarMap -- ^ Maps the last type variables to their decoding
+                      --   function arguments.
           -> Name -- ^ Name of the type to which the constructor belongs.
           -> Options -- ^ Encoding options.
-          -> Con -- ^ Constructor for which to generate JSON parsing code.
+          -> ConstructorInfo -- ^ Constructor for which to generate JSON parsing code.
           -> Either (String, Name) Name -- ^ Left (valFieldName, objName) or
                                         --   Right valName
           -> Q Exp
 -- Nullary constructors.
-parseArgs jc pjs _ _ (NormalC conName []) (Left _) = do
-  ([], _) <- reifyConTys jc pjs conName
-  [|pure|] `appE` conE conName
-parseArgs jc pjs tName _ (NormalC conName []) (Right valName) = do
-  ([], _) <- reifyConTys jc pjs conName
-  caseE (varE valName) $ parseNullaryMatches tName conName
+parseArgs _ _ _ _
+  (ConstructorInfo { constructorName    = conName
+                   , constructorVariant = NormalConstructor
+                   , constructorFields  = [] })
+  (Left _) =
+    [|pure|] `appE` conE conName
+parseArgs _ _ tName _
+  (ConstructorInfo { constructorName    = conName
+                   , constructorVariant = NormalConstructor
+                   , constructorFields  = [] })
+  (Right valName) =
+    caseE (varE valName) $ parseNullaryMatches tName conName
 
 -- Unary constructors.
-parseArgs jc pjs _ _ (NormalC conName [_]) contents = do
-  ([argTy], tvMap) <- reifyConTys jc pjs conName
-  matchCases contents $ parseUnaryMatches jc tvMap argTy conName
+parseArgs jc tvMap _ _
+  (ConstructorInfo { constructorName    = conName
+                   , constructorVariant = NormalConstructor
+                   , constructorFields  = [argTy] })
+  contents = do
+    argTy' <- resolveTypeSynonyms argTy
+    matchCases contents $ parseUnaryMatches jc tvMap argTy' conName
 
 -- Polyadic constructors.
-parseArgs jc pjs tName _ (NormalC conName ts) contents = do
-    (argTys, tvMap) <- reifyConTys jc pjs conName
-    let len = genericLength ts
-    matchCases contents $ parseProduct jc tvMap argTys tName conName len
+parseArgs jc tvMap tName _
+  (ConstructorInfo { constructorName    = conName
+                   , constructorVariant = NormalConstructor
+                   , constructorFields  = argTys })
+  contents = do
+    argTys' <- mapM resolveTypeSynonyms argTys
+    let len = genericLength argTys'
+    matchCases contents $ parseProduct jc tvMap argTys' tName conName len
 
 -- Records.
-parseArgs jc pjs tName opts (RecC conName ts) (Left (_, obj)) = do
-    (argTys, tvMap) <- reifyConTys jc pjs conName
-    parseRecord jc tvMap argTys opts tName conName ts obj
-parseArgs jc pjs tName opts (RecC conName ts) (Right valName) = case (unwrapUnaryRecords opts,ts) of
-  (True,[(_,st,ty)])-> parseArgs jc pjs tName opts (NormalC conName [(st,ty)]) (Right valName)
-  _ -> do
-    obj <- newName "recObj"
-    (argTys, tvMap) <- reifyConTys jc pjs conName
-    caseE (varE valName)
-      [ match (conP 'Object [varP obj]) (normalB $
-          parseRecord jc tvMap argTys opts tName conName ts obj) []
-      , matchFailed tName conName "Object"
-      ]
+parseArgs jc tvMap tName opts
+  (ConstructorInfo { constructorName    = conName
+                   , constructorVariant = RecordConstructor fields
+                   , constructorFields  = argTys })
+  (Left (_, obj)) = do
+    argTys' <- mapM resolveTypeSynonyms argTys
+    parseRecord jc tvMap argTys' opts tName conName fields obj
+parseArgs jc tvMap tName opts
+  info@(ConstructorInfo { constructorName    = conName
+                        , constructorVariant = RecordConstructor fields
+                        , constructorFields  = argTys })
+  (Right valName) =
+    case (unwrapUnaryRecords opts,argTys) of
+      (True,[_])-> parseArgs jc tvMap tName opts
+                             (info{constructorVariant = NormalConstructor})
+                             (Right valName)
+      _ -> do
+        obj <- newName "recObj"
+        argTys' <- mapM resolveTypeSynonyms argTys
+        caseE (varE valName)
+          [ match (conP 'Object [varP obj]) (normalB $
+              parseRecord jc tvMap argTys' opts tName conName fields obj) []
+          , matchFailed tName conName "Object"
+          ]
 
 -- Infix constructors. Apart from syntax these are the same as
 -- polyadic constructors.
-parseArgs jc pjs tName _ (InfixC _ conName _) contents = do
-    (argTys, tvMap) <- reifyConTys jc pjs conName
-    matchCases contents $ parseProduct jc tvMap argTys tName conName 2
-
--- Existentially quantified constructors. We ignore the quantifiers
--- and proceed with the contained constructor.
-parseArgs jc pjs tName opts (ForallC _ _ con) contents =
-    parseArgs jc pjs tName opts con contents
-
-#if MIN_VERSION_template_haskell(2,11,0)
--- GADTs. We ignore the refined return type and proceed as if it were a
--- NormalC or RecC.
-parseArgs jc pjs tName opts (GadtC conNames ts _) contents =
-    parseArgs jc pjs tName opts (NormalC (head conNames) ts) contents
-
-parseArgs jc pjs tName opts (RecGadtC conNames ts _) contents =
-    parseArgs jc pjs tName opts (RecC (head conNames) ts) contents
-#endif
+parseArgs jc tvMap tName _
+  (ConstructorInfo { constructorName    = conName
+                   , constructorVariant = InfixConstructor
+                   , constructorFields  = argTys })
+  contents = do
+    argTys' <- mapM resolveTypeSynonyms argTys
+    matchCases contents $ parseProduct jc tvMap argTys' tName conName 2
 
 -- | Generates code to parse the JSON encoding of an n-ary
 -- constructor.
@@ -1278,7 +1313,8 @@ deriveJSONBoth dtj dfj opts name =
     liftM2 (++) (dtj opts name) (dfj opts name)
 
 -- | Functionality common to @deriveToJSON(1)(2)@ and @deriveFromJSON(1)(2)@.
-deriveJSONClass :: [(JSONFun, JSONClass -> Name -> Options -> [Con] -> Q Exp)]
+deriveJSONClass :: [(JSONFun, JSONClass -> Name -> Options -> [Type]
+                                        -> [ConstructorInfo] -> Q Exp)]
                 -- ^ The class methods and the functions which derive them.
                 -> JSONClass
                 -- ^ The class for which to generate an instance.
@@ -1288,27 +1324,30 @@ deriveJSONClass :: [(JSONFun, JSONClass -> Name -> Options -> [Con] -> Q Exp)]
                 -- ^ Name of the type for which to generate a class instance
                 -- declaration.
                 -> Q [Dec]
-deriveJSONClass consFuns jc opts name =
-    withType name $ \name' ctxt tvbs cons mbTys ->
-        (:[]) <$> fromCons name' ctxt tvbs cons mbTys
-  where
-    fromCons :: Name -> Cxt -> [TyVarBndr] -> [Con] -> Maybe [Type] -> Q Dec
-    fromCons name' ctxt tvbs cons mbTys = do
+deriveJSONClass consFuns jc opts name = do
+  info <- reifyDatatype name
+  case info of
+    DatatypeInfo { datatypeContext = ctxt
+                 , datatypeName    = parentName
+                 , datatypeVars    = vars
+                 , datatypeVariant = variant
+                 , datatypeCons    = cons
+                 } -> do
       (instanceCxt, instanceType)
-        <- buildTypeInstance name' jc ctxt tvbs mbTys
-      instanceD (return instanceCxt)
-                (return instanceType)
-                (methodDecs name' cons)
-
-    methodDecs :: Name -> [Con] -> [Q Dec]
-    methodDecs name' cons = flip map consFuns $ \(jf, jfMaker) ->
+        <- buildTypeInstance parentName jc ctxt vars variant
+      (:[]) <$> instanceD (return instanceCxt)
+                          (return instanceType)
+                          (methodDecs parentName vars cons)
+  where
+    methodDecs :: Name -> [Type] -> [ConstructorInfo] -> [Q Dec]
+    methodDecs parentName vars cons = flip map consFuns $ \(jf, jfMaker) ->
       funD (jsonFunValName jf (arity jc))
            [ clause []
-                    (normalB $ jfMaker jc name' opts cons)
+                    (normalB $ jfMaker jc parentName opts vars cons)
                     []
            ]
 
-mkFunCommon :: (JSONClass -> Name -> Options -> [Con] -> Q Exp)
+mkFunCommon :: (JSONClass -> Name -> Options -> [Type] -> [ConstructorInfo] -> Q Exp)
             -- ^ The function which derives the expression.
             -> JSONClass
             -- ^ Which class's method is being derived.
@@ -1317,15 +1356,20 @@ mkFunCommon :: (JSONClass -> Name -> Options -> [Con] -> Q Exp)
             -> Name
             -- ^ Name of the encoded type.
             -> Q Exp
-mkFunCommon consFun jc opts name = withType name fromCons
-  where
-    fromCons :: Name -> Cxt -> [TyVarBndr] -> [Con] -> Maybe [Type] -> Q Exp
-    fromCons name' ctxt tvbs cons mbTys = do
-        -- We force buildTypeInstance here since it performs some checks for whether
-        -- or not the provided datatype's kind matches the derived method's
-        -- typeclass, and produces errors if it can't.
-        !_ <- buildTypeInstance name' jc ctxt tvbs mbTys
-        consFun jc name' opts cons
+mkFunCommon consFun jc opts name = do
+  info <- reifyDatatype name
+  case info of
+    DatatypeInfo { datatypeContext = ctxt
+                 , datatypeName    = parentName
+                 , datatypeVars    = vars
+                 , datatypeVariant = variant
+                 , datatypeCons    = cons
+                 } -> do
+      -- We force buildTypeInstance here since it performs some checks for whether
+      -- or not the provided datatype's kind matches the derived method's
+      -- typeclass, and produces errors if it can't.
+      !_ <- buildTypeInstance parentName jc ctxt vars variant
+      consFun jc parentName opts vars cons
 
 dispatchFunByType :: JSONClass
                   -> JSONFun
@@ -1380,190 +1424,24 @@ dispatchParseJSON  jc n tvMap = dispatchFunByType jc ParseJSON  n tvMap False
 -- Utility functions
 --------------------------------------------------------------------------------
 
--- | Boilerplate for top level splices.
---
--- The given 'Name' must meet one of two criteria:
---
--- 1. It must be the name of a type constructor of a plain data type or newtype.
--- 2. It must be the name of a data family instance or newtype instance constructor.
-
--- Any other value will result in an exception.
-withType :: Name
-         -> (Name -> Cxt -> [TyVarBndr] -> [Con] -> Maybe [Type] -> Q a)
-         -- ^ Function that generates the actual code. Will be applied
-         -- to the datatype/data family 'Name', datatype context, type
-         -- variable binders and constructors extracted from the given
-         -- 'Name'. If the 'Name' is from a data family instance
-         -- constructor, it will also have its instantiated types;
-         -- otherwise, it will be 'Nothing'.
-         -> Q a
-         -- ^ Resulting value in the 'Q'uasi monad.
-withType name f = do
-    info <- reify name
-    case info of
-      TyConI dec ->
-        case dec of
-#if MIN_VERSION_template_haskell(2,11,0)
-          DataD    ctxt _ tvbs _ cons _ -> f name ctxt tvbs cons Nothing
-          NewtypeD ctxt _ tvbs _ con  _ -> f name ctxt tvbs [con] Nothing
-#else
-          DataD    ctxt _ tvbs   cons _ -> f name ctxt tvbs cons Nothing
-          NewtypeD ctxt _ tvbs   con  _ -> f name ctxt tvbs [con] Nothing
-#endif
-          other -> fail $ ns ++ "Unsupported type: " ++ show other
-#if MIN_VERSION_template_haskell(2,11,0)
-      DataConI _ _ parentName   -> do
-#else
-      DataConI _ _ parentName _ -> do
-#endif
-        parentInfo <- reify parentName
-        case parentInfo of
-#if MIN_VERSION_template_haskell(2,11,0)
-          FamilyI (DataFamilyD _ tvbs _) decs ->
-#else
-          FamilyI (FamilyD DataFam _ tvbs _) decs ->
-#endif
-            let instDec = flip find decs $ \dec -> case dec of
-#if MIN_VERSION_template_haskell(2,11,0)
-                  DataInstD    _ _ _ _ cons _ -> any ((name ==) . getConName) cons
-                  NewtypeInstD _ _ _ _ con  _ -> name == getConName con
-#else
-                  DataInstD    _ _ _   cons _ -> any ((name ==) . getConName) cons
-                  NewtypeInstD _ _ _   con  _ -> name == getConName con
-#endif
-                  _ -> error $ ns ++ "Must be a data or newtype instance."
-             in case instDec of
-#if MIN_VERSION_template_haskell(2,11,0)
-                  Just (DataInstD    ctxt _ instTys _ cons _) -> f parentName ctxt tvbs cons $ Just instTys
-                  Just (NewtypeInstD ctxt _ instTys _ con  _) -> f parentName ctxt tvbs [con] $ Just instTys
-#else
-                  Just (DataInstD    ctxt _ instTys   cons _) -> f parentName ctxt tvbs cons $ Just instTys
-                  Just (NewtypeInstD ctxt _ instTys   con  _) -> f parentName ctxt tvbs [con] $ Just instTys
-#endif
-                  _ -> fail $ ns ++
-                    "Could not find data or newtype instance constructor."
-          _ -> fail $ ns ++ "Data constructor " ++ show name ++
-            " is not from a data family instance constructor."
-#if MIN_VERSION_template_haskell(2,11,0)
-      FamilyI DataFamilyD{} _ ->
-#else
-      FamilyI (FamilyD DataFam _ _ _) _ ->
-#endif
-        fail $ ns ++
-          "Cannot use a data family name. Use a data family instance constructor instead."
-      _ -> fail $ ns ++ "I need the name of a plain data type constructor, "
-                      ++ "or a data family instance constructor."
-  where
-    ns :: String
-    ns = "Data.Aeson.TH.withType: "
-
--- | Infer the context and instance head needed for a FromJSON or ToJSON instance.
+-- For the given Types, generate an instance context and head.
 buildTypeInstance :: Name
                   -- ^ The type constructor or data family name
                   -> JSONClass
                   -- ^ The typeclass to derive
                   -> Cxt
                   -- ^ The datatype context
-                  -> [TyVarBndr]
-                  -- ^ The type variables from the data type/data family declaration
-                  -> Maybe [Type]
-                  -- ^ 'Just' the types used to instantiate a data family instance,
-                  -- or 'Nothing' if it's a plain data type
+                  -> [Type]
+                  -- ^ The types to instantiate the instance with
+                  -> DatatypeVariant
+                  -- ^ Are we dealing with a data family instance or not
                   -> Q (Cxt, Type)
-                  -- ^ The resulting 'Cxt' and 'Type' to use in a class instance
--- Plain data type/newtype case
-buildTypeInstance tyConName jc dataCxt tvbs Nothing =
-    let varTys :: [Type]
-        varTys = map tvbToType tvbs
-    in buildTypeInstanceFromTys tyConName jc dataCxt varTys False
--- Data family instance case
---
--- The CPP is present to work around a couple of annoying old GHC bugs.
--- See Note [Polykinded data families in Template Haskell]
-buildTypeInstance dataFamName jc dataCxt tvbs (Just instTysAndKinds) = do
-#if !(MIN_VERSION_template_haskell(2,8,0)) || MIN_VERSION_template_haskell(2,10,0)
-    let instTys :: [Type]
-        instTys = zipWith stealKindForType tvbs instTysAndKinds
-#else
-    let kindVarNames :: [Name]
-        kindVarNames = nub $ concatMap (tyVarNamesOfType . tvbKind) tvbs
-
-        numKindVars :: Int
-        numKindVars = length kindVarNames
-
-        givenKinds, givenKinds' :: [Kind]
-        givenTys                :: [Type]
-        (givenKinds, givenTys) = splitAt numKindVars instTysAndKinds
-        givenKinds' = map sanitizeStars givenKinds
-
-        -- A GHC 7.6-specific bug requires us to replace all occurrences of
-        -- (ConT GHC.Prim.*) with StarT, or else Template Haskell will reject it.
-        -- Luckily, (ConT GHC.Prim.*) only seems to occur in this one spot.
-        sanitizeStars :: Kind -> Kind
-        sanitizeStars = go
-          where
-            go :: Kind -> Kind
-            go (AppT t1 t2)                 = AppT (go t1) (go t2)
-            go (SigT t k)                   = SigT (go t) (go k)
-            go (ConT n) | n == starKindName = StarT
-            go t                            = t
-
-            -- It's quite awkward to import * from GHC.Prim, so we'll just
-            -- hack our way around it.
-            starKindName :: Name
-            starKindName = mkNameG_tc "ghc-prim" "GHC.Prim" "*"
-
-    -- If we run this code with GHC 7.8, we might have to generate extra type
-    -- variables to compensate for any type variables that Template Haskell
-    -- eta-reduced away.
-    -- See Note [Polykinded data families in Template Haskell]
-    xTypeNames <- newNameList "tExtra" (length tvbs - length givenTys)
-
-    let xTys   :: [Type]
-        xTys = map VarT xTypeNames
-        -- ^ Because these type variables were eta-reduced away, we can only
-        --   determine their kind by using stealKindForType. Therefore, we mark
-        --   them as VarT to ensure they will be given an explicit kind annotation
-        --   (and so the kind inference machinery has the right information).
-
-        substNamesWithKinds :: [(Name, Kind)] -> Type -> Type
-        substNamesWithKinds nks t = foldr' (uncurry substNameWithKind) t nks
-
-        -- The types from the data family instance might not have explicit kind
-        -- annotations, which the kind machinery needs to work correctly. To
-        -- compensate, we use stealKindForType to explicitly annotate any
-        -- types without kind annotations.
-        instTys :: [Type]
-        instTys = map (substNamesWithKinds (zip kindVarNames givenKinds'))
-                  -- Note that due to a GHC 7.8-specific bug
-                  -- (see Note [Polykinded data families in Template Haskell]),
-                  -- there may be more kind variable names than there are kinds
-                  -- to substitute. But this is OK! If a kind is eta-reduced, it
-                  -- means that is was not instantiated to something more specific,
-                  -- so we need not substitute it. Using stealKindForType will
-                  -- grab the correct kind.
-                $ zipWith stealKindForType tvbs (givenTys ++ xTys)
-#endif
-    buildTypeInstanceFromTys dataFamName jc dataCxt instTys True
-
--- For the given Types, generate an instance context and head.
-buildTypeInstanceFromTys :: Name
-                         -- ^ The type constructor or data family name
-                         -> JSONClass
-                         -- ^ The typeclass to derive
-                         -> Cxt
-                         -- ^ The datatype context
-                         -> [Type]
-                         -- ^ The types to instantiate the instance with
-                         -> Bool
-                         -- ^ True if it's a data family, False otherwise
-                         -> Q (Cxt, Type)
-buildTypeInstanceFromTys tyConName jc dataCxt varTysOrig isDataFamily = do
+buildTypeInstance tyConName jc dataCxt varTysOrig variant = do
     -- Make sure to expand through type/kind synonyms! Otherwise, the
     -- eta-reduction check might get tripped up over type variables in a
     -- synonym that are actually dropped.
     -- (See GHC Trac #11416 for a scenario where this actually happened.)
-    varTysExp <- mapM expandSyn varTysOrig
+    varTysExp <- mapM resolveTypeSynonyms varTysOrig
 
     let remainingLength :: Int
         remainingLength = length varTysOrig - arityInt jc
@@ -1593,7 +1471,7 @@ buildTypeInstanceFromTys tyConName jc dataCxt varTysOrig isDataFamily = do
         -- All of the type variables mentioned in the dropped types
         -- (post-synonym expansion)
         droppedTyVarNames :: [Name]
-        droppedTyVarNames = concatMap tyVarNamesOfType droppedTysExpSubst
+        droppedTyVarNames = freeVariables droppedTysExpSubst
 
     -- If any of the dropped types were polykinded, ensure that they are of kind *
     -- after substituting * for the dropped kind variables. If not, throw an error.
@@ -1633,6 +1511,13 @@ buildTypeInstanceFromTys tyConName jc dataCxt varTysOrig isDataFamily = do
         remainingTysOrigSubst =
           map (substNamesWithKindStar (droppedKindVarNames `union` kvNames'))
             $ take remainingLength varTysOrig
+
+        isDataFamily :: Bool
+        isDataFamily = case variant of
+                         Datatype        -> False
+                         Newtype         -> False
+                         DataInstance    -> True
+                         NewtypeInstance -> True
 
         remainingTysOrigSubst' :: [Type]
         -- See Note [Kind signatures in derived instances] for an explanation
@@ -1687,55 +1572,6 @@ deriveConstraint jc t
     jcConstraint = jsonClassName . JSONClass (direction jc)
 
 {-
-Note [Polykinded data families in Template Haskell]
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-In order to come up with the correct instance context and head for an instance, e.g.,
-
-  instance C a => C (Data a) where ...
-
-We need to know the exact types and kinds used to instantiate the instance. For
-plain old datatypes, this is simple: every type must be a type variable, and
-Template Haskell reliably tells us the type variables and their kinds.
-
-Doing the same for data families proves to be much harder for three reasons:
-
-1. On any version of Template Haskell, it may not tell you what an instantiated
-   type's kind is. For instance, in the following data family instance:
-
-     data family Fam (f :: * -> *) (a :: *)
-     data instance Fam f a
-
-   Then if we use TH's reify function, it would tell us the TyVarBndrs of the
-   data family declaration are:
-
-     [KindedTV f (AppT (AppT ArrowT StarT) StarT),KindedTV a StarT]
-
-   and the instantiated types of the data family instance are:
-
-     [VarT f1,VarT a1]
-
-   We can't just pass [VarT f1,VarT a1] to buildTypeInstanceFromTys, since we
-   have no way of knowing their kinds. Luckily, the TyVarBndrs tell us what the
-   kind is in case an instantiated type isn't a SigT, so we use the stealKindForType
-   function to ensure all of the instantiated types are SigTs before passing them
-   to buildTypeInstanceFromTys.
-2. On GHC 7.6 and 7.8, a bug is present in which Template Haskell lists all of
-   the specified kinds of a data family instance efore any of the instantiated
-   types. Fortunately, this is easy to deal with: you simply count the number of
-   distinct kind variables in the data family declaration, take that many elements
-   from the front of the  Types list of the data family instance, substitute the
-   kind variables with their respective instantiated kinds (which you took earlier),
-   and proceed as normal.
-3. On GHC 7.8, an even uglier bug is present (GHC Trac #9692) in which Template
-   Haskell might not even list all of the Types of a data family instance, since
-   they are eta-reduced away! And yes, kinds can be eta-reduced too.
-
-   The simplest workaround is to count how many instantiated types are missing from
-   the list and generate extra type variables to use in their place. Luckily, we
-   needn't worry much if its kind was eta-reduced away, since using stealKindForType
-   will get it back.
-
 Note [Kind signatures in derived instances]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -1813,50 +1649,14 @@ things we can do to make instance contexts that work for 80% of use cases:
          and perform kind substitution as in the other cases.
 -}
 
--- Determines the types of a constructor's arguments as well as the last type
--- parameters (mapped to their encoding/decoding functions), expanding through
--- any type synonyms.
---
--- The type parameters are determined on a constructor-by-constructor basis since
--- they may be refined to be particular types in a GADT.
-reifyConTys :: JSONClass
-            -> [(Name, Name)]
-            -> Name
-            -> Q ([Type], TyVarMap)
-reifyConTys jc tpjs conName = do
-    info  <- reify conName
-    (ctxt, uncTy) <- case info of
-        DataConI _ ty _
-#if !(MIN_VERSION_template_haskell(2,11,0))
-                _
-#endif
-                -> fmap uncurryTy (expandSyn ty)
-        _ -> error "Must be a data constructor"
-    let (argTys, [resTy]) = NE.splitAt (NE.length uncTy - 1) uncTy
-        unapResTy = unapplyTy resTy
-        -- If one of the last type variables is refined to a particular type
-        -- (i.e., not truly polymorphic), we mark it with Nothing and filter
-        -- it out later, since we only apply encoding/decoding functions to
-        -- arguments of a type that it (1) one of the last type variables,
-        -- and (2) of a truly polymorphic type.
-        jArity = arityInt jc
-        mbTvNames = map varTToNameMaybe $
-                        NE.drop (NE.length unapResTy - jArity) unapResTy
-        -- We use M.fromList to ensure that if there are any duplicate type
-        -- variables (as can happen in a GADT), the rightmost type variable gets
-        -- associated with the show function.
-        --
-        -- See Note [Matching functions with GADT type variables]
-        tvMap = M.fromList
-                    . catMaybes -- Drop refined types
-                    $ zipWith (\mbTvName tpj ->
-                                  fmap (\tvName -> (tvName, tpj)) mbTvName)
-                              mbTvNames tpjs
-    if (any (`predMentionsName` M.keys tvMap) ctxt
-         || M.size tvMap < jArity)
-         && not (allowExQuant jc)
-       then existentialContextError conName
-       else return (argTys, tvMap)
+checkExistentialContext :: JSONClass -> TyVarMap -> Cxt -> Name
+                        -> Q a -> Q a
+checkExistentialContext jc tvMap ctxt conName q =
+  if (any (`predMentionsName` M.keys tvMap) ctxt
+       || M.size tvMap < arityInt jc)
+       && not (allowExQuant jc)
+     then existentialContextError conName
+     else q
 
 {-
 Note [Matching functions with GADT type variables]
@@ -1896,24 +1696,6 @@ Both.
 -- are the function arguments of types (b -> Value) and ([b] -> Value).
 type TyVarMap = Map Name (Name, Name)
 
--- | If a VarT is missing an explicit kind signature, steal it from a TyVarBndr.
-stealKindForType :: TyVarBndr -> Type -> Type
-stealKindForType tvb t@VarT{} = SigT t (tvbKind tvb)
-stealKindForType _   t        = t
-
--- | Extracts the kind from a type variable binder.
-tvbKind :: TyVarBndr -> Kind
-#if MIN_VERSION_template_haskell(2,8,0)
-tvbKind (PlainTV  _  ) = StarT
-#else
-tvbKind (PlainTV  _  ) = StarK
-#endif
-tvbKind (KindedTV _ k) = k
-
-tvbToType :: TyVarBndr -> Type
-tvbToType (PlainTV n)    = VarT n
-tvbToType (KindedTV n k) = SigT (VarT n) k
-
 -- | Returns True if a Type has kind *.
 hasKindStar :: Type -> Bool
 hasKindStar VarT{}         = True
@@ -1938,27 +1720,6 @@ isStarOrVar _      = False
 newNameList :: String -> Int -> Q [Name]
 newNameList prefix len = mapM newName [prefix ++ show n | n <- [1..len]]
 
--- Gets all of the type/kind variable names mentioned somewhere in a Type.
-tyVarNamesOfType :: Type -> [Name]
-tyVarNamesOfType = go
-  where
-    go :: Type -> [Name]
-    go (AppT t1 t2) = go t1 ++ go t2
-    go (SigT t _k)  = go t
-#if MIN_VERSION_template_haskell(2,8,0)
-                           ++ go _k
-#endif
-    go (VarT n)     = [n]
-    go _            = []
-
--- | Gets all of the type/kind variable names mentioned somewhere in a Kind.
-tyVarNamesOfKind :: Kind -> [Name]
-#if MIN_VERSION_template_haskell(2,8,0)
-tyVarNamesOfKind = tyVarNamesOfType
-#else
-tyVarNamesOfKind _ = [] -- There are no kind variables
-#endif
-
 -- | @hasKindVarChain n kind@ Checks if @kind@ is of the form
 -- k_0 -> k_1 -> ... -> k_(n-1), where k0, k1, ..., and k_(n-1) can be * or
 -- kind variables.
@@ -1966,7 +1727,7 @@ hasKindVarChain :: Int -> Type -> Maybe [Name]
 hasKindVarChain kindArrows t =
   let uk = uncurryKind (tyKind t)
   in if (NE.length uk - 1 == kindArrows) && F.all isStarOrVar uk
-        then Just (concatMap tyVarNamesOfKind uk)
+        then Just (concatMap freeVariables uk)
         else Nothing
 
 -- | If a Type is a SigT, returns its kind signature. Otherwise, return *.
@@ -1985,17 +1746,6 @@ varTToNameMaybe _          = Nothing
 -- type variable, throw an error.
 varTToName :: Type -> Name
 varTToName = fromMaybe (error "Not a type variable!") . varTToNameMaybe
-
--- | Extracts the name from a constructor.
-getConName :: Con -> Name
-getConName (NormalC name _)  = name
-getConName (RecC name _)     = name
-getConName (InfixC _ name _) = name
-getConName (ForallC _ _ con) = getConName con
-#if MIN_VERSION_template_haskell(2,11,0)
-getConName (GadtC    names _ _) = head names
-getConName (RecGadtC names _ _) = head names
-#endif
 
 interleave :: [a] -> [a] -> [a]
 interleave (a1:a1s) (a2:a2s) = a1:a2:interleave a1s a2s
@@ -2128,12 +1878,12 @@ createKindChain = go starK
 #endif
 
 -- | Makes a string literal expression from a constructor's name.
-conNameExp :: Options -> Con -> Q Exp
+conNameExp :: Options -> ConstructorInfo -> Q Exp
 conNameExp opts = litE
                 . stringL
                 . constructorTagModifier opts
                 . nameBase
-                . getConName
+                . constructorName
 
 -- | Creates a string literal expression from a record field label.
 fieldLabelExp :: Options -- ^ Encoding options
@@ -2178,73 +1928,15 @@ canEtaReduce remaining dropped =
 -- Expanding type synonyms
 -------------------------------------------------------------------------------
 
--- | Expands all type synonyms in a type. Written by Dan Rosén in the
--- @genifunctors@ package (licensed under BSD3).
-expandSyn :: Type -> Q Type
-expandSyn (ForallT tvs ctx t) = ForallT tvs ctx <$> expandSyn t
-expandSyn t@AppT{}            = expandSynApp t []
-expandSyn t@ConT{}            = expandSynApp t []
-expandSyn (SigT t k)          = do t' <- expandSyn t
-                                   k' <- expandSynKind k
-                                   return (SigT t' k')
-expandSyn t                   = return t
-
-expandSynKind :: Kind -> Q Kind
+applySubstitutionKind :: Map Name Kind -> Type -> Type
 #if MIN_VERSION_template_haskell(2,8,0)
-expandSynKind = expandSyn
+applySubstitutionKind = applySubstitution
 #else
-expandSynKind = return -- There are no kind synonyms to deal with
-#endif
-
-expandSynApp :: Type -> [Type] -> Q Type
-expandSynApp (AppT t1 t2) ts = do
-    t2' <- expandSyn t2
-    expandSynApp t1 (t2':ts)
-expandSynApp (ConT n) ts | nameBase n == "[]" = return $ foldl' AppT ListT ts
-expandSynApp t@(ConT n) ts = do
-    info <- reify n
-    case info of
-        TyConI (TySynD _ tvs rhs) ->
-            let (ts', ts'') = splitAt (length tvs) ts
-                subs = mkSubst tvs ts'
-                rhs' = substType subs rhs
-             in expandSynApp rhs' ts''
-        _ -> return $ foldl' AppT t ts
-expandSynApp t ts = do
-    t' <- expandSyn t
-    return $ foldl' AppT t' ts
-
-type TypeSubst = Map Name Type
-type KindSubst = Map Name Kind
-
-mkSubst :: [TyVarBndr] -> [Type] -> TypeSubst
-mkSubst vs ts =
-   let vs' = map un vs
-       un (PlainTV v)    = v
-       un (KindedTV v _) = v
-   in M.fromList $ zip vs' ts
-
-substType :: TypeSubst -> Type -> Type
-substType subs (ForallT v c t) = ForallT v c $ substType subs t
-substType subs t@(VarT n)      = M.findWithDefault t n subs
-substType subs (AppT t1 t2)    = AppT (substType subs t1) (substType subs t2)
-substType subs (SigT t k)      = SigT (substType subs t)
-#if MIN_VERSION_template_haskell(2,8,0)
-                                      (substType subs k)
-#else
-                                      k
-#endif
-substType _ t                  = t
-
-substKind :: KindSubst -> Type -> Type
-#if MIN_VERSION_template_haskell(2,8,0)
-substKind = substType
-#else
-substKind _ t = t -- There are no kind variables!
+applySubstitutionKind _ t = t
 #endif
 
 substNameWithKind :: Name -> Kind -> Type -> Type
-substNameWithKind n k = substKind (M.singleton n k)
+substNameWithKind n k = applySubstitutionKind (M.singleton n k)
 
 substNamesWithKindStar :: [Name] -> Type -> Type
 substNamesWithKindStar ns t = foldr' (`substNameWithKind` starK) t ns

--- a/aeson.cabal
+++ b/aeson.cabal
@@ -125,6 +125,7 @@ library
     tagged >=0.8.3 && <0.9,
     template-haskell >= 2.7,
     text >= 1.1.1.0,
+    th-abstraction >= 0.2.2 && < 0.3,
     time >= 1.1.1.4,
     time-locale-compat >= 0.1.1 && < 0.2,
     unordered-containers >= 0.2.5.0 && < 0.3,

--- a/benchmarks/aeson-benchmarks.cabal
+++ b/benchmarks/aeson-benchmarks.cabal
@@ -54,6 +54,7 @@ library
     tagged >=0.8.3 && <0.9,
     template-haskell >= 2.4,
     text >= 1.1.1.0,
+    th-abstraction >= 0.2.2 && < 0.3,
     time,
     transformers,
     unordered-containers >= 0.2.3.0,

--- a/stack-bench.yaml
+++ b/stack-bench.yaml
@@ -4,3 +4,4 @@ packages:
 - benchmarks
 extra-deps:
 - quickcheck-instances-0.3.14
+- th-abstraction-0.2.2.0

--- a/stack-lts6.yaml
+++ b/stack-lts6.yaml
@@ -8,6 +8,7 @@ extra-deps:
 - quickcheck-instances-0.3.14
 - semigroups-0.18.2
 - tagged-0.8.5
+- th-abstraction-0.2.2.0
 - transformers-compat-0.5.1.4
 flags:
 flags:

--- a/stack-lts7.yaml
+++ b/stack-lts7.yaml
@@ -5,6 +5,7 @@ packages:
 extra-deps:
 - integer-logarithms-1
 - quickcheck-instances-0.3.14
+- th-abstraction-0.2.2.0
 flags:
   aeson:
     fast: true

--- a/stack-lts8.yaml
+++ b/stack-lts8.yaml
@@ -4,6 +4,7 @@ packages:
 - attoparsec-iso8601
 extra-deps:
 - quickcheck-instances-0.3.14
+- th-abstraction-0.2.2.0
 flags:
   aeson:
     fast: true

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -4,6 +4,7 @@ packages:
 - attoparsec-iso8601
 extra-deps:
 - quickcheck-instances-0.3.14
+- th-abstraction-0.2.2.0
 flags:
   aeson:
     fast: true

--- a/stack-pure-unescape.yaml
+++ b/stack-pure-unescape.yaml
@@ -3,6 +3,7 @@ packages:
 - '.'
 extra-deps:
 - quickcheck-instances-0.3.14
+- th-abstraction-0.2.2.0
 flags:
   aeson:
     fast: true


### PR DESCRIPTION
A lot of the messy TH internals have been factored out into the `th-abstraction` library. I advocate for using it here in `aeson`, since it saves almost 300 lines of code, most of which is ugly CPP.