### PR TITLE
Better invalid json message (issue #558)

### DIFF
--- a/Data/Aeson/Parser/Internal.hs
+++ b/Data/Aeson/Parser/Internal.hs
@@ -206,7 +206,7 @@ value' = parser <?> "valid json"
 
 -- | Parse a quoted JSON string.
 jstring :: Parser Text
-jstring = (A.word8 DOUBLE_QUOTE <?> "double qoutes") *> jstring_
+jstring = A.word8 DOUBLE_QUOTE *> jstring_
 
 -- | Parse a string without a leading quote.
 jstring_ :: Parser Text


### PR DESCRIPTION
See #558.

First pass. Since these shows _all_ errors for parses named with `<?>` it leads to some other jankiness:

    > eitherDecode "{ 3" :: Either String Value
    Left "Error in $: Failed reading: satisfy, valid json, 34"

The "34" comes from https://hackage.haskell.org/package/attoparsec-0.13.1.0/docs/src/Data-Attoparsec-ByteString-Internal.html#word8

Suggestions welcome. I feel like this is _slightly_ better this could potentially be even more confusing.