### PR TITLE
don't unescape text in clear cases

### DIFF
--- a/Data/Aeson/Parser/Internal.hs
+++ b/Data/Aeson/Parser/Internal.hs
@@ -235,8 +235,6 @@ jstring_ = {-# SCC "jstring_" #-} do
             `orI#` (w `andI#` 0x1f# ==# w)     -- c < 0x20
 
 data S = S Int# Int#
--- This hint will no longer trigger once hlint > 1.9.41 is released.
-{-# ANN S ("HLint: ignore Use newtype instead of data" :: String) #-}
 #else
   s <- A.scan startState go <* A.anyWord8
   case unescapeText s of

--- a/Data/Aeson/Parser/Internal.hs
+++ b/Data/Aeson/Parser/Internal.hs
@@ -53,8 +53,9 @@ import qualified Data.Scientific as Sci
 import Data.Aeson.Parser.Unescape (unescapeText)
 
 #if MIN_VERSION_ghc_prim(0,3,1)
-import GHC.Base (Int#, (==#), isTrue#, word2Int#)
+import GHC.Base (Int#, (==#), isTrue#, word2Int#, orI#, andI#)
 import GHC.Word (Word8(W8#))
+import qualified Data.Text.Encoding as TE
 #endif
 
 #define BACKSLASH 92
@@ -207,23 +208,41 @@ jstring = A.word8 DOUBLE_QUOTE *> jstring_
 jstring_ :: Parser Text
 {-# INLINE jstring_ #-}
 jstring_ = {-# SCC "jstring_" #-} do
+#if MIN_VERSION_ghc_prim(0,3,1)
+  (s, S _ escaped) <- A.runScanner startState go <* A.anyWord8
+  -- We escape only if there are
+  -- non-ascii (over 7bit) characters or backslash present.
+  --
+  -- Note: if/when text will have fast ascii -> text conversion
+  -- (e.g. uses utf8 encoding) we can have further speedup.
+  if isTrue# escaped
+    then case unescapeText s of
+      Right r  -> return r
+      Left err -> fail $ show err
+    else return (TE.decodeUtf8 s)
+ where
+    startState              = S 0# 0#
+    go (S skip escaped) (W8# c)
+      | isTrue# skip        = Just (S 0# escaped')
+      | isTrue# (w ==# 34#) = Nothing   -- double quote
+      | otherwise           = Just (S skip' escaped')
+      where
+        w = word2Int# c
+        skip' = w ==# 92# -- backslash
+        escaped' = escaped
+            `orI#` (w `andI#` 0x80# ==# 0x80#) -- c >= 0x80
+            `orI#` skip'
+            `orI#` (w `andI#` 0x1f# ==# w)     -- c < 0x20
+
+data S = S Int# Int#
+-- This hint will no longer trigger once hlint > 1.9.41 is released.
+{-# ANN S ("HLint: ignore Use newtype instead of data" :: String) #-}
+#else
   s <- A.scan startState go <* A.anyWord8
   case unescapeText s of
     Right r  -> return r
     Left err -> fail $ show err
  where
-#if MIN_VERSION_ghc_prim(0,3,1)
-    startState              = S 0#
-    go (S a) (W8# c)
-      | isTrue# a                     = Just (S 0#)
-      | isTrue# (word2Int# c ==# 34#) = Nothing   -- double quote
-      | otherwise = let a' = word2Int# c ==# 92#  -- backslash
-                    in Just (S a')
-
-data S = S Int#
--- This hint will no longer trigger once hlint > 1.9.41 is released.
-{-# ANN S ("HLint: ignore Use newtype instead of data" :: String) #-}
-#else
     startState              = False
     go a c
       | a                  = Just False

--- a/stack-lts8.yaml
+++ b/stack-lts8.yaml
@@ -1,4 +1,4 @@
-resolver: lts-8.1
+resolver: lts-8.5
 packages:
 - '.'
 - attoparsec-iso8601


### PR DESCRIPTION
After:

```
benchmarking decode/en/aeson/lazy
time                 1.630 ms   (1.606 ms .. 1.655 ms)
                     0.998 R²   (0.996 R² .. 0.999 R²)
mean                 1.638 ms   (1.626 ms .. 1.664 ms)
std dev              59.77 μs   (35.45 μs .. 104.0 μs)
variance introduced by outliers: 23% (moderately inflated)

benchmarking decode/jp/aeson
time                 2.382 ms   (2.359 ms .. 2.406 ms)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 2.404 ms   (2.392 ms .. 2.431 ms)
std dev              60.54 μs   (36.76 μs .. 112.9 μs)
variance introduced by outliers: 12% (moderately inflated)
```

before

```
benchmarking decode/en/aeson/lazy
time                 2.053 ms   (2.027 ms .. 2.077 ms)
                     0.998 R²   (0.996 R² .. 0.999 R²)
mean                 2.069 ms   (2.056 ms .. 2.098 ms)
std dev              62.97 μs   (34.19 μs .. 105.8 μs)
variance introduced by outliers: 17% (moderately inflated)

benchmarking decode/jp/aeson
time                 2.666 ms   (2.636 ms .. 2.699 ms)
                     0.998 R²   (0.997 R² .. 0.999 R²)
mean                 2.695 ms   (2.672 ms .. 2.735 ms)
std dev              103.1 μs   (64.72 μs .. 159.6 μs)
variance introduced by outliers: 22% (moderately inflated)
```

Even for japanese there seems to be small speedup, because record keys are ASCII