### PR TITLE
RFC: Object parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist-newstyle
 .cabal-sandbox/
 cabal.sandbox.config
 .stack-work/
+.stack-work-bench/
 
 *.o
 *.hi

--- a/Data/Aeson/Types/ObjectParser.hs
+++ b/Data/Aeson/Types/ObjectParser.hs
@@ -1,0 +1,86 @@
+{-# LANGUAGE GADTs, PatternGuards #-}
+module Data.Aeson.Types.ObjectParser (
+    ObjectParser,
+    withObjectParser,
+    withObjectParser',
+    runObjectParser,
+    runObjectParser',
+    liftObjectParser,
+    explicitObjectField,
+    objectField,
+    ) where
+
+import Prelude ()
+import Prelude.Compat
+
+import Data.Text (Text)
+import qualified Data.HashSet as HS
+
+import Data.Aeson.Types.Internal
+import Data.Aeson.Types.FromJSON
+
+-- | Applicative Object parser
+data ObjectParser a = OP
+    { runObjectParser :: !(Object -> Parser a)
+    , _opKeys         :: !(HS.HashSet Text)
+    -- TODO: maybe fields
+    }
+
+instance Functor ObjectParser where
+    fmap f (OP x ks) = OP (fmap f . x) ks
+    {-# INLINE fmap #-}
+
+instance Applicative ObjectParser where
+    pure x = OP (\_ -> pure x) mempty
+    OP f ks <*> OP x ks' = OP (\obj -> f obj <*> x obj) (HS.union ks ks')
+    {-# INLINE (<*>) #-}
+
+withObjectParser :: String -> ObjectParser a -> Value -> Parser a
+withObjectParser name p = withObject name (runObjectParser p)
+
+withObjectParser'
+    :: String
+    -> ObjectParser a
+    -> HS.HashSet Text  -- ^ required
+    -> HS.HashSet Text  -- ^ optional
+    -> Value -> Parser a
+withObjectParser' name p req opt = withObject name (runObjectParser' p req opt)
+
+liftObjectParser :: Text -> (Value -> Parser a) -> ObjectParser a
+liftObjectParser k p = OP (\obj -> explicitParseField p obj k) (HS.singleton k)
+{-# INLINE liftObjectParser #-}
+
+explicitObjectField :: Text -> (Value -> Parser a) -> ObjectParser a
+explicitObjectField = liftObjectParser
+
+objectField :: FromJSON a => Text -> ObjectParser a
+objectField k = explicitObjectField k parseJSON
+
+-- | Strict 'runObjectParser'.
+--
+-- First checks that there aren't extra keys in the 'Object'.
+runObjectParser'
+    :: ObjectParser a
+    -> HS.HashSet Text  -- additional required keys, these keys MUST be present
+    -> HS.HashSet Text  -- additional optional keys, these keys MAY be present
+    -> Object
+    -> Parser a
+runObjectParser' (OP p ks) ks' os' obj
+    | Just missing <- required `isSubsetOf` keys =
+        -- take only few keys to have reasonable sized errors
+        fail $ "Not all required keys present: " ++ show (take 3 $ HS.toList missing)
+    | Just extra <-  keys `isSubsetOf` optional =
+        fail $ "Extra keys present: " ++ show (take 3 $ HS.toList extra)
+    | otherwise                        = p obj
+  where
+    keys = HS.fromMap (() <$ obj)
+    required = HS.union ks ks'
+    optional = HS.union required os'
+
+-- Special case: Nothing = True, Just extraKeys = False
+isSubsetOf :: HS.HashSet Text -> HS.HashSet Text -> Maybe (HS.HashSet Text)
+isSubsetOf as bs
+    | HS.null cs = Nothing
+    | otherwise  = Just cs
+  where
+    cs = HS.difference as bs

--- a/aeson.cabal
+++ b/aeson.cabal
@@ -104,11 +104,12 @@ library
     Data.Aeson.Parser.Internal
     Data.Aeson.Parser.Unescape
     Data.Aeson.Parser.Time
+    Data.Aeson.Types.Class
     Data.Aeson.Types.FromJSON
     Data.Aeson.Types.Generic
-    Data.Aeson.Types.ToJSON
-    Data.Aeson.Types.Class
     Data.Aeson.Types.Internal
+    Data.Aeson.Types.ObjectParser
+    Data.Aeson.Types.ToJSON
     Data.Attoparsec.Time
     Data.Attoparsec.Time.Internal
 

--- a/benchmarks/AesonMap.hs
+++ b/benchmarks/AesonMap.hs
@@ -160,7 +160,7 @@ benchDecodeHM name val = bgroup name
     ,  bench "Identity"        $ nf (decodeHMB proxyT1)   val
     ,  bench "Coerce"          $ nf (decodeHMB proxyT2)   val
     ,  bench "Parser"          $ nf (decodeHMB proxyT3)   val
-    ,  bench "aeson-0.11"      $ nf (decodeHMA proxyText) val
+    ,  bench "aeson-hackage"   $ nf (decodeHMA proxyText) val
     ,  bench "Tagged Text"     $ nf (decodeHMB $ proxyTagged proxyText) val
     ,  bench "Tagged Identity" $ nf (decodeHMB $ proxyTagged proxyT1)   val
     ,  bench "Tagged Coerce"   $ nf (decodeHMB $ proxyTagged proxyT2)   val
@@ -172,11 +172,11 @@ benchDecodeMap
     -> LBS.ByteString
     -> Benchmark
 benchDecodeMap name val = bgroup name
-    [  bench "Text"        $ nf (decodeMapB proxyText) val
-    ,  bench "Identity"    $ nf (decodeMapB proxyT1)   val
-    ,  bench "Coerce"      $ nf (decodeMapB proxyT2)   val
-    ,  bench "Parser"      $ nf (decodeMapB proxyT3)   val
-    ,  bench "aeson-0.11"  $ nf (decodeMapA proxyText) val
+    [  bench "Text"           $ nf (decodeMapB proxyText) val
+    ,  bench "Identity"       $ nf (decodeMapB proxyT1)   val
+    ,  bench "Coerce"         $ nf (decodeMapB proxyT2)   val
+    ,  bench "Parser"         $ nf (decodeMapB proxyT3)   val
+    ,  bench "aeson-hackage"  $ nf (decodeMapA proxyText) val
     ]
 
 benchEncodeHM

--- a/benchmarks/Dates.hs
+++ b/benchmarks/Dates.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -fsimpl-tick-factor=0 #-}
 module Main (main) where
 
 import Prelude ()

--- a/benchmarks/Typed.hs
+++ b/benchmarks/Typed.hs
@@ -13,4 +13,7 @@ main = defaultMain [
     Generic.benchmarks
   , Manual.benchmarks
   , TH.benchmarks
+  , Generic.decodeBenchmarks
+  , Manual.decodeBenchmarks
+  , TH.decodeBenchmarks
   ]

--- a/benchmarks/Typed/Generic.hs
+++ b/benchmarks/Typed/Generic.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE PackageImports #-}
-module Typed.Generic (benchmarks) where
+module Typed.Generic (benchmarks, decodeBenchmarks) where
 
 import Prelude ()
 import Prelude.Compat
@@ -26,7 +26,7 @@ encodeViaValueB = B.encode . B.toJSON
 benchmarks :: Benchmark
 benchmarks =
   env ((,) <$> load "json-data/twitter100.json" <*> load "json-data/jp100.json") $ \ ~(twitter100, jp100) ->
-  bgroup "generic" [
+  bgroup "encodeGeneric" [
       bgroup "direct" [
         bench "twitter100"          $ nf encodeDirectB twitter100
       , bench "jp100"               $ nf encodeDirectB jp100
@@ -38,5 +38,23 @@ benchmarks =
       , bench "jp100"               $ nf encodeViaValueB jp100
       , bench "twitter100 baseline" $ nf encodeViaValueA twitter100
       , bench "jp100 baseline"      $ nf encodeViaValueA jp100
+      ]
+    ]
+
+decodeDirectA :: L.ByteString -> Maybe Result
+decodeDirectA = decode
+
+decodeDirectB :: L.ByteString -> Maybe Result
+decodeDirectB = B.decode
+
+decodeBenchmarks :: Benchmark
+decodeBenchmarks =
+  env ((,) <$> L.readFile "json-data/twitter100.json" <*> L.readFile "json-data/jp100.json") $ \ ~(twitter100, jp100) ->
+  bgroup "decodeGeneric"
+    [ bgroup "direct"
+      [ bench "twitter100"          $ nf decodeDirectB twitter100
+      , bench "jp100"               $ nf decodeDirectB jp100
+      , bench "twitter100 baseline" $ nf decodeDirectA twitter100
+      , bench "jp100 baseline"      $ nf decodeDirectA jp100
       ]
     ]

--- a/benchmarks/Typed/Generic.hs
+++ b/benchmarks/Typed/Generic.hs
@@ -7,7 +7,7 @@ import Prelude.Compat
 import "aeson" Data.Aeson hiding (Result)
 import Criterion
 import Data.ByteString.Lazy as L
-import Twitter.TH
+import Twitter.Generic
 import Typed.Common
 import qualified "aeson-benchmarks" Data.Aeson as B
 

--- a/benchmarks/Typed/Manual.hs
+++ b/benchmarks/Typed/Manual.hs
@@ -47,6 +47,12 @@ decodeDirectA = decode
 decodeDirectB :: L.ByteString -> Maybe Result
 decodeDirectB = B.decode
 
+decodeObjectB :: L.ByteString -> Maybe Result
+-- decodeObjectB = fmap R . B.decode
+decodeObjectB b = case  B.eitherDecode b of
+    Right (R r) -> Just r
+    Left err    -> error err
+
 decodeBenchmarks :: Benchmark
 decodeBenchmarks =
   env ((,) <$> L.readFile "json-data/twitter100.json" <*> L.readFile "json-data/jp100.json") $ \ ~(twitter100, jp100) ->
@@ -56,5 +62,9 @@ decodeBenchmarks =
       , bench "jp100"               $ nf decodeDirectB jp100
       , bench "twitter100 baseline"  $ nf decodeDirectA twitter100
       , bench "jp100 baseline"      $ nf decodeDirectA jp100
+      ]
+    , bgroup "object-parser"
+      [ bench "twitter100"          $ nf decodeObjectB twitter100
+      , bench "jp100"               $ nf decodeObjectB jp100
       ]
     ]

--- a/benchmarks/Typed/Manual.hs
+++ b/benchmarks/Typed/Manual.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE PackageImports #-}
-module Typed.Manual (benchmarks) where
+module Typed.Manual (benchmarks, decodeBenchmarks) where
 
 import Prelude ()
 import Prelude.Compat
@@ -26,7 +26,7 @@ encodeViaValueB = B.encode . B.toJSON
 benchmarks :: Benchmark
 benchmarks =
   env ((,) <$> load "json-data/twitter100.json" <*> load "json-data/jp100.json") $ \ ~(twitter100, jp100) ->
-  bgroup "manual" [
+  bgroup "encodeManual" [
       bgroup "direct" [
         bench "twitter100"          $ nf encodeDirectB twitter100
       , bench "jp100"               $ nf encodeDirectB jp100
@@ -38,5 +38,23 @@ benchmarks =
       , bench "jp100"               $ nf encodeViaValueB jp100
       , bench "twitter100 baseline" $ nf encodeViaValueA twitter100
       , bench "jp100 baseline"      $ nf encodeViaValueA jp100
+      ]
+    ]
+
+decodeDirectA :: L.ByteString -> Maybe Result
+decodeDirectA = decode
+
+decodeDirectB :: L.ByteString -> Maybe Result
+decodeDirectB = B.decode
+
+decodeBenchmarks :: Benchmark
+decodeBenchmarks =
+  env ((,) <$> L.readFile "json-data/twitter100.json" <*> L.readFile "json-data/jp100.json") $ \ ~(twitter100, jp100) ->
+  bgroup "decodeManual"
+    [ bgroup "direct"
+      [ bench "twitter100"          $ nf decodeDirectB twitter100
+      , bench "jp100"               $ nf decodeDirectB jp100
+      , bench "twitter100 baseline"  $ nf decodeDirectA twitter100
+      , bench "jp100 baseline"      $ nf decodeDirectA jp100
       ]
     ]

--- a/benchmarks/Typed/TH.hs
+++ b/benchmarks/Typed/TH.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE PackageImports #-}
-module Typed.TH (benchmarks) where
+module Typed.TH (benchmarks, decodeBenchmarks) where
 
 import Prelude ()
 import Prelude.Compat
@@ -26,7 +26,7 @@ encodeViaValueB = B.encode . B.toJSON
 benchmarks :: Benchmark
 benchmarks =
   env ((,) <$> load "json-data/twitter100.json" <*> load "json-data/jp100.json") $ \ ~(twitter100, jp100) ->
-  bgroup "th" [
+  bgroup "encodeTH" [
       bgroup "direct" [
         bench "twitter100"          $ nf encodeDirectB twitter100
       , bench "jp100"               $ nf encodeDirectB jp100
@@ -38,5 +38,23 @@ benchmarks =
       , bench "jp100"               $ nf encodeViaValueA jp100
       , bench "twitter100 baseline" $ nf encodeViaValueB twitter100
       , bench "jp100 baseline"      $ nf encodeViaValueB jp100
+      ]
+    ]
+
+decodeDirectA :: L.ByteString -> Maybe Result
+decodeDirectA = decode
+
+decodeDirectB :: L.ByteString -> Maybe Result
+decodeDirectB = B.decode
+
+decodeBenchmarks :: Benchmark
+decodeBenchmarks =
+  env ((,) <$> L.readFile "json-data/twitter100.json" <*> L.readFile "json-data/jp100.json") $ \ ~(twitter100, jp100) ->
+  bgroup "decodeTH"
+    [ bgroup "direct"
+      [ bench "twitter100"          $ nf decodeDirectB twitter100
+      , bench "jp100"               $ nf decodeDirectB jp100
+      , bench "twitter100 baseline"  $ nf decodeDirectA twitter100
+      , bench "jp100 baseline"      $ nf decodeDirectA jp100
       ]
     ]

--- a/benchmarks/aeson-benchmarks.cabal
+++ b/benchmarks/aeson-benchmarks.cabal
@@ -83,6 +83,13 @@ executable aeson-benchmark-compare
   main-is: Compare.hs
   hs-source-dirs: ../examples .
   ghc-options: -Wall -O2 -rtsopts
+  other-modules:
+    Compare.BufferBuilder
+    Compare.JsonBench
+    Compare.JsonBuilder
+    Twitter
+    Twitter.Manual
+    Typed.Common
   build-depends:
     aeson-benchmarks,
     base,
@@ -116,6 +123,14 @@ executable aeson-benchmark-typed
   -- We must help ourself in situations when there is both
   -- aeson and aeson-benchmakrs
   cpp-options: -DHAS_BOTH_AESON_AND_BENCHMARKS
+  other-modules:
+    Twitter
+    Twitter.Manual
+    Twitter.TH
+    Typed.Common
+    Typed.Generic
+    Typed.Manual
+    Typed.TH
   build-depends:
     aeson,
     aeson-benchmarks,
@@ -136,7 +151,9 @@ executable aeson-benchmark-typed
 executable aeson-benchmark-compare-with-json
   main-is: CompareWithJSON.hs
   ghc-options: -Wall -O2 -rtsopts
+  cpp-options: -DHAS_BOTH_AESON_AND_BENCHMARKS
   build-depends:
+    aeson,
     aeson-benchmarks,
     base,
     base-compat,

--- a/benchmarks/aeson-benchmarks.cabal
+++ b/benchmarks/aeson-benchmarks.cabal
@@ -33,6 +33,7 @@ library
     Data.Aeson.Types.FromJSON
     Data.Aeson.Types.Generic
     Data.Aeson.Types.Internal
+    Data.Aeson.Types.ObjectParser
     Data.Aeson.Types.ToJSON
     Data.Attoparsec.Time
     Data.Attoparsec.Time.Internal
@@ -142,7 +143,8 @@ executable aeson-benchmark-typed
     deepseq,
     ghc-prim,
     text,
-    time
+    time,
+    unordered-containers
 
   if flag(bytestring-builder)
     build-depends: bytestring >= 0.9 && < 0.10.4,

--- a/benchmarks/aeson-benchmarks.cabal
+++ b/benchmarks/aeson-benchmarks.cabal
@@ -125,7 +125,9 @@ executable aeson-benchmark-typed
   cpp-options: -DHAS_BOTH_AESON_AND_BENCHMARKS
   other-modules:
     Twitter
+    Twitter.Generic
     Twitter.Manual
+    Twitter.Options
     Twitter.TH
     Typed.Common
     Typed.Generic

--- a/examples/Twitter/Generic.hs
+++ b/examples/Twitter/Generic.hs
@@ -1,9 +1,11 @@
 -- Use GHC generics to automatically generate good instances.
 
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE PackageImports #-}
-
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+
+#ifdef HAS_BOTH_AESON_AND_BENCHMARKS
+{-# LANGUAGE PackageImports #-}
+#endif
 
 module Twitter.Generic
     (

--- a/examples/Twitter/Generic.hs
+++ b/examples/Twitter/Generic.hs
@@ -1,5 +1,8 @@
 -- Use GHC generics to automatically generate good instances.
+
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE PackageImports #-}
+
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Twitter.Generic
@@ -11,39 +14,64 @@ module Twitter.Generic
     ) where
 
 import Prelude ()
-import Prelude.Compat
+import Prelude.Compat ()
 
 import Twitter
+import Twitter.Options
 
 #ifndef HAS_BOTH_AESON_AND_BENCHMARKS
-import Data.Aeson (ToJSON, FromJSON)
+import Data.Aeson (ToJSON (..), FromJSON (..), genericToJSON, genericToEncoding, genericParseJSON)
 #else
-import "aeson" Data.Aeson (ToJSON, FromJSON)
+import "aeson" Data.Aeson (ToJSON (..), FromJSON (..), genericToJSON, genericToEncoding, genericParseJSON)
 import qualified "aeson-benchmarks" Data.Aeson as B
 #endif
 
-instance ToJSON Metadata
-instance FromJSON Metadata
+instance ToJSON Metadata where
+    toJSON = genericToJSON twitterOptions
+    toEncoding = genericToEncoding twitterOptions
+instance FromJSON Metadata where
+    parseJSON = genericParseJSON twitterOptions
 
-instance ToJSON Geo
-instance FromJSON Geo
+instance ToJSON Geo where
+    toJSON = genericToJSON twitterOptions
+    toEncoding = genericToEncoding twitterOptions
+instance FromJSON Geo where
+    parseJSON = genericParseJSON twitterOptions
 
-instance ToJSON Story
-instance FromJSON Story
+instance ToJSON Story where
+    toJSON = genericToJSON twitterOptions
+    toEncoding = genericToEncoding twitterOptions
+instance FromJSON Story where
+    parseJSON = genericParseJSON twitterOptions
 
-instance ToJSON Result
-instance FromJSON Result
+instance ToJSON Result where
+    toJSON = genericToJSON twitterOptions
+    toEncoding = genericToEncoding twitterOptions
+instance FromJSON Result where
+    parseJSON = genericParseJSON twitterOptions
 
 #ifdef HAS_BOTH_AESON_AND_BENCHMARKS
-instance B.ToJSON Metadata
-instance B.FromJSON Metadata
+instance B.ToJSON Metadata where
+    toJSON = B.genericToJSON btwitterOptions
+    toEncoding = B.genericToEncoding btwitterOptions
+instance B.FromJSON Metadata where
+    parseJSON = B.genericParseJSON btwitterOptions
 
-instance B.ToJSON Geo
-instance B.FromJSON Geo
+instance B.ToJSON Geo where
+    toJSON = B.genericToJSON btwitterOptions
+    toEncoding = B.genericToEncoding btwitterOptions
+instance B.FromJSON Geo where
+    parseJSON = B.genericParseJSON btwitterOptions
 
-instance B.ToJSON Story
-instance B.FromJSON Story
+instance B.ToJSON Story where
+    toJSON = B.genericToJSON btwitterOptions
+    toEncoding = B.genericToEncoding btwitterOptions
+instance B.FromJSON Story where
+    parseJSON = B.genericParseJSON btwitterOptions
 
-instance B.ToJSON Result
-instance B.FromJSON Result
+instance B.ToJSON Result where
+    toJSON = B.genericToJSON btwitterOptions
+    toEncoding = B.genericToEncoding btwitterOptions
+instance B.FromJSON Result where
+    parseJSON = B.genericParseJSON btwitterOptions
 #endif

--- a/examples/Twitter/Options.hs
+++ b/examples/Twitter/Options.hs
@@ -1,5 +1,9 @@
 {-# LANGUAGE CPP #-}
+
+#ifdef HAS_BOTH_AESON_AND_BENCHMARKS
 {-# LANGUAGE PackageImports #-}
+#endif
+
 module Twitter.Options (module Twitter.Options) where
 
 #ifndef HAS_BOTH_AESON_AND_BENCHMARKS

--- a/examples/Twitter/Options.hs
+++ b/examples/Twitter/Options.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE PackageImports #-}
+module Twitter.Options (module Twitter.Options) where
+
+#ifndef HAS_BOTH_AESON_AND_BENCHMARKS
+import Data.Aeson
+import Data.Aeson.Types
+#else
+import "aeson" Data.Aeson
+import "aeson" Data.Aeson.Types
+import qualified "aeson-benchmarks" Data.Aeson as B
+import qualified "aeson-benchmarks" Data.Aeson.Types as B
+#endif
+
+twitterOptions :: Options
+twitterOptions = defaultOptions
+    { fieldLabelModifier = \x -> case x of
+        "id_" -> "id"
+        _     -> x
+    }
+
+#ifdef HAS_BOTH_AESON_AND_BENCHMARKS
+btwitterOptions :: B.Options
+btwitterOptions = B.defaultOptions
+    { B.fieldLabelModifier = \x -> case x of
+        "id_" -> "id"
+        _     -> x
+    }
+#endif

--- a/examples/Twitter/TH.hs
+++ b/examples/Twitter/TH.hs
@@ -16,6 +16,7 @@ module Twitter.TH
 import Prelude ()
 
 import Twitter
+import Twitter.Options
 
 #ifndef HAS_BOTH_AESON_AND_BENCHMARKS
 import Data.Aeson.TH
@@ -24,14 +25,14 @@ import "aeson" Data.Aeson.TH
 import qualified "aeson-benchmarks" Data.Aeson.TH as B
 #endif
 
-$(deriveJSON defaultOptions ''Metadata)
-$(deriveJSON defaultOptions ''Geo)
-$(deriveJSON defaultOptions ''Story)
-$(deriveJSON defaultOptions ''Result)
+$(deriveJSON twitterOptions ''Metadata)
+$(deriveJSON twitterOptions ''Geo)
+$(deriveJSON twitterOptions ''Story)
+$(deriveJSON twitterOptions ''Result)
 
 #ifdef HAS_BOTH_AESON_AND_BENCHMARKS
-$(B.deriveJSON B.defaultOptions ''Metadata)
-$(B.deriveJSON B.defaultOptions ''Geo)
-$(B.deriveJSON B.defaultOptions ''Story)
-$(B.deriveJSON B.defaultOptions ''Result)
+$(B.deriveJSON btwitterOptions ''Metadata)
+$(B.deriveJSON btwitterOptions ''Geo)
+$(B.deriveJSON btwitterOptions ''Story)
+$(B.deriveJSON btwitterOptions ''Result)
 #endif

--- a/examples/Twitter/TH.hs
+++ b/examples/Twitter/TH.hs
@@ -1,9 +1,12 @@
 -- Use Template Haskell to generate good instances.
 
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE PackageImports #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+
+#ifdef HAS_BOTH_AESON_AND_BENCHMARKS
+{-# LANGUAGE PackageImports #-}
+#endif
 
 module Twitter.TH
     (

--- a/stack-bench.yaml
+++ b/stack-bench.yaml
@@ -1,10 +1,13 @@
 resolver: lts-8.5
-packages:
 # We use aeson in the snapshot to
 # - avoid recompilation of criterion
 # - compare against it
-
 # - '.'
+#
+# Also we use separate working directory to avoid "unregistering aeson"
+# caused recompilations
+work-dir: .stack-work-bench
+packages:
 - benchmarks
 extra-deps:
 - aeson-1.2.1.0

--- a/stack-bench.yaml
+++ b/stack-bench.yaml
@@ -1,7 +1,12 @@
 resolver: lts-8.5
 packages:
-- '.'
+# We use aeson in the snapshot to
+# - avoid recompilation of criterion
+# - compare against it
+
+# - '.'
 - benchmarks
 extra-deps:
+- aeson-1.2.1.0
 - quickcheck-instances-0.3.14
 - th-abstraction-0.2.2.0


### PR DESCRIPTION
An applicative `ObjectParser` letting us make "strict" object parsers. cc @hvr

Performance is slightly degraded, as you can suspect:

![screenshot from 2017-07-13 16-22-16](https://user-images.githubusercontent.com/51087/28168387-a7786268-67e7-11e7-9842-9b18a225d15e.png)

OTOH in case of missing / extra keys parser will fail early.

---

Motivation: for the TokenStream parser #560 such interface would be needed. The `objectField` could be a member of new class:

BTW, why `parseJSON :: Value -> Parser a` and not `parseJSON :: Parser a`, where

```diff
 newtype Parser a = Parser {
       runParser :: forall f r.
                    JSONPath
+                -> Value
                 -> Failure f r
                 -> Success a f r
                 -> f r
     }
```

(Probably because of manual instances, i.e. not using combinators like `withObject`)

```haskell
-- | "dual" of 'KeyValue'
class OP p op | p -> op | op -> p where
    objectField :: Text -> p a -> op a
    runObjectParser :: String -> op a -> p a

instance OP Parser ObjectParaser where
    ... 
```