### PR TITLE
Add `FromJSON` and `ToJSON` instances for `DiffTime`

### DIFF
--- a/Data/Aeson/Types/FromJSON.hs
+++ b/Data/Aeson/Types/FromJSON.hs
@@ -101,7 +101,7 @@ import Data.Ratio ((%), Ratio)
 import Data.Scientific (Scientific)
 import Data.Tagged (Tagged(..))
 import Data.Text (Text, pack, unpack)
-import Data.Time (Day, LocalTime, NominalDiffTime, TimeOfDay, UTCTime, ZonedTime)
+import Data.Time (Day, DiffTime, LocalTime, NominalDiffTime, TimeOfDay, UTCTime, ZonedTime)
 import Data.Time.Format (parseTime)
 import Data.Time.Locale.Compat (defaultTimeLocale)
 import Data.Traversable as Tr (sequence)
@@ -1702,6 +1702,15 @@ instance FromJSONKey UTCTime where
 -- @1e1000000000@.
 instance FromJSON NominalDiffTime where
     parseJSON = withScientific "NominalDiffTime" $ pure . realToFrac
+    {-# INLINE parseJSON #-}
+
+
+-- | /WARNING:/ Only parse lengths of time from trusted input
+-- since an attacker could easily fill up the memory of the target
+-- system by specifying a scientific number with a big exponent like
+-- @1e1000000000@.
+instance FromJSON DiffTime where
+    parseJSON = withScientific "DiffTime" $ pure . realToFrac
     {-# INLINE parseJSON #-}
 
 -------------------------------------------------------------------------------

--- a/Data/Aeson/Types/ToJSON.hs
+++ b/Data/Aeson/Types/ToJSON.hs
@@ -84,7 +84,7 @@ import Data.Ratio (Ratio, denominator, numerator)
 import Data.Scientific (Scientific)
 import Data.Tagged (Tagged(..))
 import Data.Text (Text, pack)
-import Data.Time (Day, LocalTime, NominalDiffTime, TimeOfDay, UTCTime, ZonedTime)
+import Data.Time (Day, DiffTime, LocalTime, NominalDiffTime, TimeOfDay, UTCTime, ZonedTime)
 import Data.Time.Format (FormatTime, formatTime)
 import Data.Time.Locale.Compat (defaultTimeLocale)
 import Data.Vector (Vector)
@@ -1911,7 +1911,16 @@ stringEncoding = String
     . E.encodingToLazyByteString
 {-# INLINE stringEncoding #-}
 
+
 instance ToJSON NominalDiffTime where
+    toJSON = Number . realToFrac
+    {-# INLINE toJSON #-}
+
+    toEncoding = E.scientific . realToFrac
+    {-# INLINE toEncoding #-}
+
+
+instance ToJSON DiffTime where
     toJSON = Number . realToFrac
     {-# INLINE toJSON #-}
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 For the latest version of this document, please see [https://github.com/bos/aeson/blob/master/changelog.md](https://github.com/bos/aeson/blob/master/changelog.md).
 
+## Upcoming
+
+* Add `FromJSON` and `ToJSON` instances for `DiffTime`, thanks to Víctor López Juan
+
 ## 1.2.1.0
 
 * Add `parserThrowError` and `parserCatchError` combinators, thanks to Oleg Grenrus.

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -27,7 +27,7 @@ import Data.Proxy (Proxy)
 import Data.Ratio (Ratio)
 import Data.Sequence (Seq)
 import Data.Tagged (Tagged)
-import Data.Time (Day, LocalTime, NominalDiffTime, TimeOfDay, UTCTime, ZonedTime)
+import Data.Time (Day, DiffTime, LocalTime, NominalDiffTime, TimeOfDay, UTCTime, ZonedTime)
 import Data.Version (Version)
 import Encoders
 import Instances ()

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -248,6 +248,7 @@ tests = testGroup "properties" [
     , testProperty "UTCTime" $ roundTripEq (undefined :: UTCTime)
     , testProperty "ZonedTime" $ roundTripEq (undefined :: ZonedTime)
     , testProperty "NominalDiffTime" $ roundTripEq (undefined :: NominalDiffTime)
+    , testProperty "DiffTime" $ roundTripEq (undefined :: DiffTime)
     , testProperty "Version" $ roundTripEq (undefined :: Version)
     , testProperty "Natural" $ roundTripEq (undefined :: Natural)
     , testProperty "Proxy" $ roundTripEq (undefined :: Proxy Int)


### PR DESCRIPTION
I added these instances, since i) they introduce no new package dependencies, and ii) there were already instances for `NominalDiffTime`, which is a similar data type.

I could not compile the tests locally, so the CI might not pass. The log from the attempt to run the tests is below.

```
❯❯❯ stack --stack-yaml stack-lts8.yaml build --test   
WARNING: Ignoring out of range dependency (trusting snapshot over Hackage revisions): QuickCheck-2.9.2. test-framework-quickcheck2 requires: >=2.4 && <2.8
test-framework-quickcheck2-0.3.0.3: configure
Progress: 1/3
--  While building package test-framework-quickcheck2-0.3.0.3 using:
      /home/victor/.stack/setup-exe-cache/x86_64-linux/setup-Simple-Cabal-1.24.2.0-ghc-8.0.2 --builddir=.stack-work/dist/x86_64-linux/Cabal-1.24.2.0 configure --with-ghc=/home/victor/.stack/programs/x86_64-linux/ghc-8.0.2/bin/ghc --with-ghc-pkg=/home/victor/.stack/programs/x86_64-linux/ghc-8.0.2/bin/ghc-pkg --user --package-db=clear --package-db=global --package-db=/home/victor/.stack/snapshots/x86_64-linux/lts-8.5/8.0.2/pkgdb --libdir=/home/victor/.stack/snapshots/x86_64-linux/lts-8.5/8.0.2/lib --bindir=/home/victor/.stack/snapshots/x86_64-linux/lts-8.5/8.0.2/bin --datadir=/home/victor/.stack/snapshots/x86_64-linux/lts-8.5/8.0.2/share --libexecdir=/home/victor/.stack/snapshots/x86_64-linux/lts-8.5/8.0.2/libexec --sysconfdir=/home/victor/.stack/snapshots/x86_64-linux/lts-8.5/8.0.2/etc --docdir=/home/victor/.stack/snapshots/x86_64-linux/lts-8.5/8.0.2/doc/test-framework-quickcheck2-0.3.0.3 --htmldir=/home/victor/.stack/snapshots/x86_64-linux/lts-8.5/8.0.2/doc/test-framework-quickcheck2-0.3.0.3 --haddockdir=/home/victor/.stack/snapshots/x86_64-linux/lts-8.5/8.0.2/doc/test-framework-quickcheck2-0.3.0.3 --dependency=QuickCheck=QuickCheck-2.9.2-Jyj4gc4JxkEIgGFLAsGhs9 --dependency=base=base-4.9.1.0 --dependency=extensible-exceptions=extensible-exceptions-0.1.1.4-IyAM3ARTqH7BVZ5oHMMtXH --dependency=random=random-1.1-9tceXaeYIMZ4JrKq20Egog --dependency=test-framework=test-framework-0.8.1.1-7YvscNBXXw5Lj2Ypw31c2N
    Process exited with code: ExitFailure 1
    Logs have been written to: /home/victor/repos/aeson/.stack-work/logs/test-framework-quickcheck2-0.3.0.3.log

    Configuring test-framework-quickcheck2-0.3.0.3...
    setup-Simple-Cabal-1.24.2.0-ghc-8.0.2: Encountered missing dependencies:
    QuickCheck >=2.4 && <2.8 && ==2.9.2
```