### PR TITLE
FromJSON and ToJSON instances for CTime

### DIFF
--- a/Data/Aeson/Types/FromJSON.hs
+++ b/Data/Aeson/Types/FromJSON.hs
@@ -109,6 +109,7 @@ import Data.Vector (Vector)
 import Data.Version (Version, parseVersion)
 import Data.Word (Word16, Word32, Word64, Word8)
 import Foreign.Storable (Storable)
+import Foreign.C.Types (CTime (..))
 import GHC.Generics
 import Numeric.Natural (Natural)
 import Text.ParserCombinators.ReadP (readP_to_S)
@@ -1347,6 +1348,9 @@ instance FromJSON Word64 where
 instance FromJSONKey Word64 where
     fromJSONKey = FromJSONKeyTextParser $ parseBoundedIntegralText "Word64"
 
+instance FromJSON CTime where
+    parseJSON = fmap CTime . parseJSON
+    {-# INLINE parseJSON #-}
 
 instance FromJSON Text where
     parseJSON = withText "Text" pure

--- a/Data/Aeson/Types/ToJSON.hs
+++ b/Data/Aeson/Types/ToJSON.hs
@@ -91,6 +91,7 @@ import Data.Vector (Vector)
 import Data.Version (Version, showVersion)
 import Data.Word (Word16, Word32, Word64, Word8)
 import Foreign.Storable (Storable)
+import Foreign.C.Types (CTime (..))
 import GHC.Generics
 import Numeric.Natural (Natural)
 import qualified Data.Aeson.Encoding as E
@@ -1366,7 +1367,6 @@ instance ToJSONKey Int64 where
     toJSONKey = toJSONKeyTextEnc E.int64Text
     {-# INLINE toJSONKey #-}
 
-
 instance ToJSON Word where
     toJSON = Number . fromIntegral
     {-# INLINE toJSON #-}
@@ -1426,6 +1426,12 @@ instance ToJSONKey Word64 where
     toJSONKey = toJSONKeyTextEnc E.word64Text
     {-# INLINE toJSONKey #-}
 
+instance ToJSON CTime where
+    toJSON (CTime i) = toJSON i
+    {-# INLINE toJSON #-}
+
+    toEncoding (CTime i) = toEncoding i
+    {-# INLINE toEncoding #-}
 
 instance ToJSON Text where
     toJSON = String


### PR DESCRIPTION
There are other types in `Foreign.C.Types` that could benefit from having these instances, but at the moment I have only added instances for `CTime`. Mainly because I needed it in a project. The instances are based on the `Int64` instances.