### PR TITLE
Fix parentheses around example in documentation

### DIFF
--- a/Data/Aeson.hs
+++ b/Data/Aeson.hs
@@ -381,7 +381,7 @@ eitherDecodeStrict' =
 -- The 'Object' type contains JSON objects:
 --
 -- > λ> decode "{\"name\":\"Dave\",\"age\":2}" :: Maybe Object
--- > Just (fromList) [("name",String "Dave"),("age",Number 2)]
+-- > Just (fromList [("name",String "Dave"),("age",Number 2)])
 --
 -- You can extract values from it with a parser using 'parse',
 -- 'parseEither' or, in this example, 'parseMaybe':


### PR DESCRIPTION
Hi,

I noticed a minor error in the documentation of Aeson and fixed it.

Best regards and thanks for this library,

Philippe Crama