### PR TITLE
Doc bug: Missing lambda in haddock comment

### DIFF
--- a/Data/Aeson/Types/FromJSON.hs
+++ b/Data/Aeson/Types/FromJSON.hs
@@ -316,7 +316,7 @@ genericLiftParseJSON opts pj pjl = fmap to1 . gParseJSON opts (From1Args pj pjl)
 --
 -- @
 -- instance 'FromJSON' Coord where
---     'parseJSON' = 'withObject' \"Coord\" $ \v -> Coord
+--     'parseJSON' = 'withObject' \"Coord\" $ \\v -> Coord
 --         '<$>' v '.:' \"x\"
 --         '<*>' v '.:' \"y\"
 -- @


### PR DESCRIPTION
Changing `\` to `\\` fixes this; verified with Haddock version 2.16.1

Occurrences within "bird track" code blocks do NOT have this issue; but occurrences between @'s do.