### PR TITLE
Add escape benchmark

### DIFF
--- a/benchmarks/Escape.hs
+++ b/benchmarks/Escape.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE PackageImports #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Main (main) where
+
+import Prelude ()
+import Prelude.Compat
+
+import Criterion.Main
+import qualified "aeson-benchmarks" Data.Aeson.Parser.UnescapeFFI as FFI
+import qualified "aeson-benchmarks" Data.Aeson.Parser.UnescapePure as Pure
+
+import qualified Data.ByteString.Char8 as BS
+
+n :: Int
+n = 10000
+
+input :: BS.ByteString
+input = BS.concat $ replicate n $ BS.pack "\\\""
+
+main :: IO ()
+main = defaultMain
+    [ bench "ffi"  $ whnf FFI.unescapeText input
+    , bench "pure" $ whnf Pure.unescapeText input
+    ]

--- a/benchmarks/aeson-benchmarks.cabal
+++ b/benchmarks/aeson-benchmarks.cabal
@@ -80,6 +80,20 @@ library
   ghc-options: -O2 -Wall
   cpp-options: -DGENERICS
 
+executable aeson-benchmark-escape
+  main-is: Escape.hs
+  hs-source-dirs: ../examples .
+  ghc-options: -Wall -O2 -rtsopts
+  build-depends:
+    aeson-benchmarks,
+    base,
+    base-compat,
+    bytestring,
+    criterion >= 1.0,
+    deepseq,
+    ghc-prim,
+    text
+
 executable aeson-benchmark-compare
   main-is: Compare.hs
   hs-source-dirs: ../examples .


### PR DESCRIPTION
Related to #593.

```
benchmarking ffi
time                 24.56 μs   (23.90 μs .. 25.27 μs)
                     0.995 R²   (0.993 R² .. 0.997 R²)
mean                 24.71 μs   (24.22 μs .. 25.44 μs)
std dev              1.935 μs   (1.470 μs .. 2.818 μs)
variance introduced by outliers: 77% (severely inflated)

benchmarking pure
time                 632.3 μs   (608.0 μs .. 658.6 μs)
                     0.988 R²   (0.983 R² .. 0.992 R²)
mean                 640.1 μs   (621.7 μs .. 673.1 μs)
std dev              82.19 μs   (51.04 μs .. 148.2 μs)
variance introduced by outliers: 84% (severely inflated)
```

outliers variance is big, but difference is still an order of magnitude
