### PR TITLE
Refactor decodeHex in UnescapePure

### DIFF
--- a/benchmarks/Escape.hs
+++ b/benchmarks/Escape.hs
@@ -11,15 +11,21 @@ import qualified "aeson-benchmarks" Data.Aeson.Parser.UnescapeFFI as FFI
 import qualified "aeson-benchmarks" Data.Aeson.Parser.UnescapePure as Pure
 
 import qualified Data.ByteString.Char8 as BS
-
-n :: Int
-n = 10000
-
-input :: BS.ByteString
-input = BS.concat $ replicate n $ BS.pack "\\\""
+import System.Environment (getArgs, withArgs)
 
 main :: IO ()
-main = defaultMain
+main = do
+  args_ <- getArgs
+  let (args, p, n) =
+        case args_ of
+          "--pattern" : p : args_ -> k p args_
+          _ -> k "\\\"" args_
+      k p args_ =
+        case args_ of
+          "--repeat" : n : args_ -> (args_, p, read n)
+          args_ -> (args_, p, 10000)
+      input = BS.concat $ replicate n $ BS.pack p
+  withArgs args $ defaultMain
     [ bench "ffi"  $ whnf FFI.unescapeText input
     , bench "pure" $ whnf Pure.unescapeText input
     ]

--- a/pure/Data/Aeson/Parser/UnescapePure.hs
+++ b/pure/Data/Aeson/Parser/UnescapePure.hs
@@ -120,29 +120,11 @@ decode UtfTail1 point word = case word of
     _                          -> throwDecodeError
 
 decodeHex :: Word8 -> Word16
-decodeHex 48  = 0  -- '0'
-decodeHex 49  = 1  -- '1'
-decodeHex 50  = 2  -- '2'
-decodeHex 51  = 3  -- '3'
-decodeHex 52  = 4  -- '4'
-decodeHex 53  = 5  -- '5'
-decodeHex 54  = 6  -- '6'
-decodeHex 55  = 7  -- '7'
-decodeHex 56  = 8  -- '8'
-decodeHex 57  = 9  -- '9'
-decodeHex 65  = 10 -- 'A'
-decodeHex 97  = 10 -- 'a'
-decodeHex 66  = 11 -- 'B'
-decodeHex 98  = 11 -- 'b'
-decodeHex 67  = 12 -- 'C'
-decodeHex 99  = 12 -- 'c'
-decodeHex 68  = 13 -- 'D'
-decodeHex 100 = 13 -- 'd'
-decodeHex 69  = 14 -- 'E'
-decodeHex 101 = 14 -- 'e'
-decodeHex 70  = 15 -- 'F'
-decodeHex 102 = 15 -- 'f'
-decodeHex _ = throwDecodeError
+decodeHex x
+  | 48 <= x && x <=  57 = fromIntegral x - 48  -- 0-9
+  | 65 <= x && x <=  70 = fromIntegral x - 55  -- A-F
+  | 97 <= x && x <= 102 = fromIntegral x - 87  -- a-f
+  | otherwise = throwDecodeError
 
 unescapeText' :: ByteString -> Text
 unescapeText' bs = runText $ \done -> do


### PR DESCRIPTION
Benchmark with a [version of a script](https://github.com/Lysxia/aeson/blob/benchmark.jp.2/slashbench.hs) from #593

Before/after times with a string full of hex encoded characters.

    for X in master my-bench ; ./$X/slashbench pure 10000000 "\\u03a9\\uaBCd\\uEfFa" +RTS -s 2>&1 |tee $X/bench-pure

    ...

      INIT    time    0.000s  (  0.000s elapsed)
      MUT     time    7.633s  (  7.793s elapsed)
      GC      time    1.113s  (  1.281s elapsed)
      EXIT    time    0.000s  (  0.049s elapsed)
      Total   time    8.747s  (  9.123s elapsed)

    ...

      INIT    time    0.000s  (  0.000s elapsed)
      MUT     time    5.510s  (  5.642s elapsed)
      GC      time    1.037s  (  1.261s elapsed)
      EXIT    time    0.000s  (  0.048s elapsed)
      Total   time    6.547s  (  6.951s elapsed)

    ...