### PR TITLE
[acc-errors] Accumulate errors for Seq and Vector parsers

### DIFF
--- a/aeson.cabal
+++ b/aeson.cabal
@@ -196,6 +196,7 @@ test-suite tests
     SerializationFormatSpec
     Types
     UnitTests
+    UnitTests.AccErrors
     UnitTests.NullaryConstructors
 
   build-depends:

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -7,8 +7,15 @@ import Test.Framework (defaultMain)
 import qualified DataFamilies.Properties as DF
 import qualified Properties
 import qualified UnitTests
+import qualified UnitTests.AccErrors as AccErrors
 
 main :: IO ()
 main = do
     ioTests <- UnitTests.ioTests
-    defaultMain (DF.tests : Properties.tests : UnitTests.tests : ioTests)
+    defaultMain
+        ( AccErrors.tests
+        : DF.tests
+        : Properties.tests
+        : UnitTests.tests
+        : ioTests
+        )

--- a/tests/UnitTests/AccErrors.hs
+++ b/tests/UnitTests/AccErrors.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE NoMonomorphismRestriction #-}
+{-# LANGUAGE OverloadedStrings #-}
+module UnitTests.AccErrors (tests) where
+
+import Prelude ()
+import Prelude.Compat hiding (seq)
+
+import Data.Aeson
+import Data.Aeson.Parser.Internal
+import Data.Aeson.Types ()
+import Data.Aeson.Internal
+import Data.List.NonEmpty (NonEmpty)
+import Data.Semigroup
+import Data.Vector (Vector)
+import Test.Framework
+import Test.Framework.Providers.HUnit
+import Test.HUnit hiding (Test)
+import qualified Data.ByteString.Lazy as L
+import qualified Data.List.NonEmpty as NL
+import qualified Data.Sequence as Seq
+
+tests :: Test
+tests = testGroup "Error accumulation" [
+      testCase "seq" seq
+    , testCase "vector" vector
+    ]
+
+decoder :: FromJSON a
+    => L.ByteString
+    -> Either (NonEmpty (JSONPath, String)) a
+decoder = verboseDecodeWith jsonEOF ifromJSON
+
+seq :: Assertion
+seq = do
+    let res = decoder "[true, null]" :: Either (NonEmpty (JSONPath, String)) (Seq.Seq Int)
+    let message i s = ([Index i], "expected Int, encountered " <> s)
+    res @=? Left (NL.fromList [message 0 "Boolean", message 1 "Null"])
+
+vector :: Assertion
+vector = do
+    let res = decoder "[true, null]" :: Either (NonEmpty (JSONPath, String)) (Vector Int)
+    let message i s = ([Index i], "expected Int, encountered " <> s)
+    res @=? Left (NL.fromList [message 0 "Boolean", message 1 "Null"])


### PR DESCRIPTION
Naming has room for improvements, maybe we should even have a module for accumulation related functions, or should we do this in some other way like using a newtype so we can have proper traversable instances (not sure if that'll work out)?

Ping @Lysxia 
