### PR TITLE
Use nix for hlint, change travis language to nix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # This file has been modified from generated version
 # see https://github.com/hvr/multi-ghc-travis
-language: c
+language: nix
 sudo: false
 
 # Bryan threatens to turn off Travis-CI if he gets any email :-)

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 lint:
-	hlint --cpp-include include/ --cpp-file .stack-work/dist/*/*Cabal-*/build/autogen/cabal_macros.h Data/ attoparsec-iso8601/ benchmarks/ examples/ ffi/ pure/ tests/
+	nix-shell -p hlint --run "hlint --cpp-include include/ --cpp-file .stack-work/dist/*/*Cabal-*/build/autogen/cabal_macros.h Data/ attoparsec-iso8601/ benchmarks/ examples/ ffi/ pure/ tests/"

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -21,7 +21,6 @@ case $BUILD in
     ;;
   hlint)
     stack build --fast aeson --stack-yaml stack-nightly.yaml --system-ghc --no-terminal
-    stack install hlint --stack-yaml stack-nightly.yaml --system-ghc --no-terminal
     make lint
     ;;
 esac


### PR DESCRIPTION
I hacked a little bit, tried to use https://github.com/ndmitchell/neil/blob/master/misc/travis.sh - Neil's script, but it had problems with BSD `sed`; thought about doing something with `perl`, but then used `nixpkgs`. I don't think that bringing new dependency is the right way, but on the other hand I'd say it is production ready.

But maybe I'm just overthinking 😅 
Closes #598 