### PR TITLE
Add flag for benchmarks to select local or external aeson dependency

### DIFF
--- a/benchmarks/AesonFoldable.hs
+++ b/benchmarks/AesonFoldable.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PackageImports #-}
 
 module Main (main) where
 
@@ -9,8 +8,7 @@ import Prelude ()
 import Prelude.Compat
 
 import Data.Foldable (toList)
-import qualified "aeson" Data.Aeson as A
-import qualified "aeson-benchmarks" Data.Aeson as B
+import qualified Data.Aeson as A
 import qualified Data.Sequence as S
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as U
@@ -21,10 +19,6 @@ import qualified Data.Vector.Unboxed as U
 
 newtype L f = L { getL :: f Int }
 
-instance Foldable f => B.ToJSON (L f) where
-    toJSON = error "do not use this"
-    toEncoding = B.toEncoding . toList . getL
-
 instance Foldable f => A.ToJSON (L f) where
     toJSON = error "do not use this"
     toEncoding = A.toEncoding . toList . getL
@@ -34,10 +28,6 @@ instance Foldable f => A.ToJSON (L f) where
 -------------------------------------------------------------------------------
 
 newtype F f = F { getF :: f Int }
-
-instance Foldable f => B.ToJSON (F f) where
-    toJSON = error "do not use this"
-    toEncoding = B.foldable . getF
 
 instance Foldable f => A.ToJSON (F f) where
     toJSON = error "do not use this"
@@ -63,52 +53,34 @@ valueUVector = U.fromList valueList
 -- Main
 -------------------------------------------------------------------------------
 
-benchEncodeA
+benchEncode
     :: A.ToJSON a
     => String
     -> a
     -> Benchmark
-benchEncodeA name val
+benchEncode name val
     = bench ("A " ++ name) $ nf A.encode val
-
-benchEncodeB
-    :: B.ToJSON a
-    => String
-    -> a
-    -> Benchmark
-benchEncodeB name val
-    = bench ("B " ++ name) $ nf B.encode val
 
 main :: IO ()
 main =  defaultMain
     [ bgroup "encode"
         [ bgroup "List"
-            [ benchEncodeB "-"     valueList
-            , benchEncodeB "L" $ L valueList
-            , benchEncodeB "F" $ F valueList
-            , benchEncodeA "-"     valueList
-            , benchEncodeA "L" $ L valueList
-            , benchEncodeA "F" $ F valueList
+            [ benchEncode "-"     valueList
+            , benchEncode "L" $ L valueList
+            , benchEncode "F" $ F valueList
             ]
         , bgroup "Seq"
-            [ benchEncodeB "-"     valueSeq
-            , benchEncodeB "L" $ L valueSeq
-            , benchEncodeB "F" $ F valueSeq
-            , benchEncodeA "-"     valueSeq
-            , benchEncodeA "L" $ L valueSeq
-            , benchEncodeA "F" $ F valueSeq
+            [ benchEncode "-"     valueSeq
+            , benchEncode "L" $ L valueSeq
+            , benchEncode "F" $ F valueSeq
             ]
         , bgroup "Vector"
-            [ benchEncodeB "-"     valueVector
-            , benchEncodeB "L" $ L valueVector
-            , benchEncodeB "F" $ F valueVector
-            , benchEncodeA "-"     valueVector
-            , benchEncodeA "L" $ L valueVector
-            , benchEncodeA "F" $ F valueVector
+            [ benchEncode "-"     valueVector
+            , benchEncode "L" $ L valueVector
+            , benchEncode "F" $ F valueVector
             ]
         , bgroup "Vector.Unboxed"
-            [ benchEncodeB "-"     valueUVector
-            , benchEncodeA "-"     valueUVector
+            [ benchEncode "-"     valueUVector
             ]
         ]
     ]

--- a/benchmarks/AesonMap.hs
+++ b/benchmarks/AesonMap.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE PackageImports #-}
 {-# LANGUAGE RankNTypes #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}

--- a/benchmarks/AesonParse.hs
+++ b/benchmarks/AesonParse.hs
@@ -1,13 +1,12 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PackageImports #-}
 
 module Main (main) where
 
 import Prelude ()
 import Prelude.Compat
 
-import "aeson-benchmarks" Data.Aeson
+import Data.Aeson
 import Control.Monad
 import Data.Attoparsec.ByteString (IResult(..), parseWith)
 import Data.Time.Clock

--- a/benchmarks/Compare.hs
+++ b/benchmarks/Compare.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE PackageImports #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Main (main) where
@@ -14,7 +13,7 @@ import Data.Json.Builder
 import Twitter
 import Twitter.Manual ()
 import Typed.Common
-import qualified "aeson-benchmarks" Data.Aeson as Aeson
+import qualified Data.Aeson as Aeson
 import qualified Compare.JsonBench as JsonBench
 
 main :: IO ()

--- a/benchmarks/CompareWithJSON.hs
+++ b/benchmarks/CompareWithJSON.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE PackageImports #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Main (main) where
@@ -11,10 +10,9 @@ import Blaze.ByteString.Builder.Char.Utf8 (fromString)
 import Control.DeepSeq (NFData(rnf))
 import Criterion.Main
 import Data.Maybe (fromMaybe)
-import qualified "aeson-benchmarks" Data.Aeson as A
-import qualified "aeson-benchmarks" Data.Aeson.Text as A
-import qualified "aeson-benchmarks" Data.Aeson.Parser.Internal as I
-import qualified "aeson" Data.Aeson as B
+import qualified Data.Aeson as A
+import qualified Data.Aeson.Text as A
+import qualified Data.Aeson.Parser.Internal as I
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Text.Lazy          as TL
@@ -39,20 +37,14 @@ decodeJ s =
     J.Ok v -> v
     J.Error _ -> error "fail to parse via JSON"
 
-decodeA :: BL.ByteString -> A.Value
-decodeA s = fromMaybe (error "fail to parse via Aeson") $ A.decode s
+decode :: BL.ByteString -> A.Value
+decode s = fromMaybe (error "fail to parse via Aeson") $ A.decode s
 
-decodeA' :: BL.ByteString -> A.Value
-decodeA' s = fromMaybe (error "fail to parse via Aeson") $ A.decode' s
+decode' :: BL.ByteString -> A.Value
+decode' s = fromMaybe (error "fail to parse via Aeson") $ A.decode' s
 
-decodeAS :: BS.ByteString -> A.Value
-decodeAS s = fromMaybe (error "fail to parse via Aeson") $ A.decodeStrict' s
-
-decodeB :: BL.ByteString -> B.Value
-decodeB s = fromMaybe (error "fail to parse via Aeson") $ B.decode s
-
-decodeBS :: BS.ByteString -> B.Value
-decodeBS s = fromMaybe (error "fail to parse via Aeson") $ B.decodeStrict' s
+decodeS :: BS.ByteString -> A.Value
+decodeS s = fromMaybe (error "fail to parse via Aeson") $ A.decodeStrict' s
 
 decodeIP :: BL.ByteString -> A.Value
 decodeIP s = fromMaybe (error "fail to parse via Parser.decodeWith") $
@@ -80,32 +72,29 @@ main = do
   defaultMain [
       bgroup "decode" [
         bgroup "en" [
-          bench "aeson/lazy"     $ nf decodeA enA
-        , bench "aeson/strict"   $ nf decodeA' enA
-        , bench "aeson/stricter" $ nf decodeAS enS
-        , bench "aeson/hackage"  $ nf decodeB enA
-        , bench "aeson/hackage'" $ nf decodeBS enS
+          bench "aeson/lazy"     $ nf decode enA
+        , bench "aeson/strict"   $ nf decode' enA
+        , bench "aeson/stricter" $ nf decodeS enS
         , bench "aeson/parser"   $ nf decodeIP enA
         , bench "json"           $ nf decodeJ enJ
         ]
       , bgroup "jp" [
-          bench "aeson"          $ nf decodeA jpA
-        , bench "aeson/stricter" $ nf decodeAS jpS
-        , bench "aeson/hackage"  $ nf decodeB jpA
+          bench "aeson"          $ nf decode jpA
+        , bench "aeson/stricter" $ nf decodeS jpS
         , bench "json"           $ nf decodeJ jpJ
         ]
       ]
     , bgroup "encode" [
         bgroup "en" [
-          bench "aeson-to-bytestring" $ nf A.encode (decodeA enA)
-        , bench "aeson-via-text-to-bytestring" $ nf encodeViaText (decodeA enA)
-        , bench "aeson-to-text" $ nf encodeToText (decodeA enA)
+          bench "aeson-to-bytestring" $ nf A.encode (decode enA)
+        , bench "aeson-via-text-to-bytestring" $ nf encodeViaText (decode enA)
+        , bench "aeson-to-text" $ nf encodeToText (decode enA)
         , bench "json"  $ nf encodeJ (decodeJ enJ)
         ]
       , bgroup "jp" [
-          bench "aeson-to-bytestring" $ nf A.encode (decodeA jpA)
-        , bench "aeson-via-text-to-bytestring" $ nf encodeViaText (decodeA jpA)
-        , bench "aeson-to-text" $ nf encodeToText (decodeA jpA)
+          bench "aeson-to-bytestring" $ nf A.encode (decode jpA)
+        , bench "aeson-via-text-to-bytestring" $ nf encodeViaText (decode jpA)
+        , bench "aeson-to-text" $ nf encodeToText (decode jpA)
         , bench "json"  $ nf encodeJ (decodeJ jpJ)
         ]
       ]

--- a/benchmarks/Escape.hs
+++ b/benchmarks/Escape.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE PackageImports #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 
 module Main (main) where
 
@@ -7,8 +7,8 @@ import Prelude ()
 import Prelude.Compat
 
 import Criterion.Main
-import qualified "aeson-benchmarks" Data.Aeson.Parser.UnescapeFFI as FFI
-import qualified "aeson-benchmarks" Data.Aeson.Parser.UnescapePure as Pure
+import qualified Data.Aeson.Parser.UnescapeFFI as FFI
+import qualified Data.Aeson.Parser.UnescapePure as Pure
 
 import qualified Data.ByteString.Char8 as BS
 import System.Environment (getArgs, withArgs)

--- a/benchmarks/Micro.hs
+++ b/benchmarks/Micro.hs
@@ -4,8 +4,9 @@ import Prelude ()
 import Prelude.Compat
 
 import Criterion.Main
-import qualified Data.Aeson.Encoding.Builder as AB
-import qualified Data.ByteString.Builder as B
+
+-- Encoding is a newtype wrapper around Builder
+import Data.Aeson.Encoding (text, string, encodingToLazyByteString)
 import qualified Data.Text as T
 
 main :: IO ()
@@ -13,8 +14,8 @@ main = do
   let txt = "append (append b (primBounded w1 x1)) (primBounded w2 x2)"
   defaultMain [
     bgroup "string" [
-      bench "text" $ nf (B.toLazyByteString . AB.text) (T.pack txt)
-    , bench "string direct" $ nf (B.toLazyByteString . AB.string) txt
-    , bench "string via text" $ nf (B.toLazyByteString . AB.text . T.pack) txt
+      bench "text" $ nf (encodingToLazyByteString . text) (T.pack txt)
+    , bench "string direct" $ nf (encodingToLazyByteString . string) txt
+    , bench "string via text" $ nf (encodingToLazyByteString . text . T.pack) txt
     ]
    ]

--- a/benchmarks/Typed/Common.hs
+++ b/benchmarks/Typed/Common.hs
@@ -1,8 +1,3 @@
-{-# LANGUAGE CPP #-}
-#ifdef HAS_BOTH_AESON_AND_BENCHMARKS
-{-# LANGUAGE PackageImports #-}
-#endif
-
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}
 
 module Typed.Common (load) where
@@ -14,12 +9,7 @@ import Data.ByteString.Lazy as L
 import System.Exit
 import System.IO
 
-#ifndef HAS_BOTH_AESON_AND_BENCHMARKS
 import Data.Aeson hiding (Result)
-#else
-import "aeson" Data.Aeson hiding (Result)
-import qualified "aeson-benchmarks" Data.Aeson as B
-#endif
 
 load :: FromJSON a => FilePath -> IO a
 load fileName = do

--- a/benchmarks/Typed/Generic.hs
+++ b/benchmarks/Typed/Generic.hs
@@ -1,60 +1,43 @@
-{-# LANGUAGE PackageImports #-}
 module Typed.Generic (benchmarks, decodeBenchmarks) where
 
 import Prelude ()
 import Prelude.Compat
 
-import "aeson" Data.Aeson hiding (Result)
+import Data.Aeson hiding (Result)
 import Criterion
 import Data.ByteString.Lazy as L
 import Twitter.Generic
 import Typed.Common
-import qualified "aeson-benchmarks" Data.Aeson as B
 
-encodeDirectA :: Result -> L.ByteString
-encodeDirectA = encode
+encodeDirect :: Result -> L.ByteString
+encodeDirect = encode
 
-encodeViaValueA :: Result -> L.ByteString
-encodeViaValueA = encode . toJSON
-
-encodeDirectB :: Result -> L.ByteString
-encodeDirectB = B.encode
-
-encodeViaValueB :: Result -> L.ByteString
-encodeViaValueB = B.encode . B.toJSON
+encodeViaValue :: Result -> L.ByteString
+encodeViaValue = encode . toJSON
 
 benchmarks :: Benchmark
 benchmarks =
   env ((,) <$> load "json-data/twitter100.json" <*> load "json-data/jp100.json") $ \ ~(twitter100, jp100) ->
   bgroup "encodeGeneric" [
       bgroup "direct" [
-        bench "twitter100"          $ nf encodeDirectB twitter100
-      , bench "jp100"               $ nf encodeDirectB jp100
-      , bench "twitter100 baseline" $ nf encodeDirectA twitter100
-      , bench "jp100 baseline"      $ nf encodeDirectA jp100
+        bench "twitter100" $ nf encodeDirect twitter100
+      , bench "jp100"      $ nf encodeDirect jp100
       ]
     , bgroup "viaValue" [
-        bench "twitter100"          $ nf encodeViaValueB twitter100
-      , bench "jp100"               $ nf encodeViaValueB jp100
-      , bench "twitter100 baseline" $ nf encodeViaValueA twitter100
-      , bench "jp100 baseline"      $ nf encodeViaValueA jp100
+        bench "twitter100" $ nf encodeViaValue twitter100
+      , bench "jp100"      $ nf encodeViaValue jp100
       ]
     ]
 
-decodeDirectA :: L.ByteString -> Maybe Result
-decodeDirectA = decode
-
-decodeDirectB :: L.ByteString -> Maybe Result
-decodeDirectB = B.decode
+decodeDirect :: L.ByteString -> Maybe Result
+decodeDirect = decode
 
 decodeBenchmarks :: Benchmark
 decodeBenchmarks =
   env ((,) <$> L.readFile "json-data/twitter100.json" <*> L.readFile "json-data/jp100.json") $ \ ~(twitter100, jp100) ->
   bgroup "decodeGeneric"
     [ bgroup "direct"
-      [ bench "twitter100"          $ nf decodeDirectB twitter100
-      , bench "jp100"               $ nf decodeDirectB jp100
-      , bench "twitter100 baseline" $ nf decodeDirectA twitter100
-      , bench "jp100 baseline"      $ nf decodeDirectA jp100
+      [ bench "twitter100" $ nf decodeDirect twitter100
+      , bench "jp100"      $ nf decodeDirect jp100
       ]
     ]

--- a/benchmarks/Typed/Manual.hs
+++ b/benchmarks/Typed/Manual.hs
@@ -1,60 +1,43 @@
-{-# LANGUAGE PackageImports #-}
 module Typed.Manual (benchmarks, decodeBenchmarks) where
 
 import Prelude ()
 import Prelude.Compat
 
-import "aeson" Data.Aeson hiding (Result)
+import Data.Aeson hiding (Result)
 import Criterion
 import Data.ByteString.Lazy as L
 import Twitter.Manual
 import Typed.Common
-import qualified "aeson-benchmarks" Data.Aeson as B
 
-encodeDirectA :: Result -> L.ByteString
-encodeDirectA = encode
+encodeDirect :: Result -> L.ByteString
+encodeDirect = encode
 
-encodeViaValueA :: Result -> L.ByteString
-encodeViaValueA = encode . toJSON
-
-encodeDirectB :: Result -> L.ByteString
-encodeDirectB = B.encode
-
-encodeViaValueB :: Result -> L.ByteString
-encodeViaValueB = B.encode . B.toJSON
+encodeViaValue :: Result -> L.ByteString
+encodeViaValue = encode . toJSON
 
 benchmarks :: Benchmark
 benchmarks =
   env ((,) <$> load "json-data/twitter100.json" <*> load "json-data/jp100.json") $ \ ~(twitter100, jp100) ->
   bgroup "encodeManual" [
       bgroup "direct" [
-        bench "twitter100"          $ nf encodeDirectB twitter100
-      , bench "jp100"               $ nf encodeDirectB jp100
-      , bench "twitter100 baseline" $ nf encodeDirectA twitter100
-      , bench "jp100 baseline"      $ nf encodeDirectA jp100
+        bench "twitter100" $ nf encodeDirect twitter100
+      , bench "jp100"      $ nf encodeDirect jp100
       ]
     , bgroup "viaValue" [
-        bench "twitter100"          $ nf encodeViaValueB twitter100
-      , bench "jp100"               $ nf encodeViaValueB jp100
-      , bench "twitter100 baseline" $ nf encodeViaValueA twitter100
-      , bench "jp100 baseline"      $ nf encodeViaValueA jp100
+        bench "twitter100" $ nf encodeViaValue twitter100
+      , bench "jp100"      $ nf encodeViaValue jp100
       ]
     ]
 
-decodeDirectA :: L.ByteString -> Maybe Result
-decodeDirectA = decode
-
-decodeDirectB :: L.ByteString -> Maybe Result
-decodeDirectB = B.decode
+decodeDirect :: L.ByteString -> Maybe Result
+decodeDirect = decode
 
 decodeBenchmarks :: Benchmark
 decodeBenchmarks =
   env ((,) <$> L.readFile "json-data/twitter100.json" <*> L.readFile "json-data/jp100.json") $ \ ~(twitter100, jp100) ->
   bgroup "decodeManual"
     [ bgroup "direct"
-      [ bench "twitter100"          $ nf decodeDirectB twitter100
-      , bench "jp100"               $ nf decodeDirectB jp100
-      , bench "twitter100 baseline"  $ nf decodeDirectA twitter100
-      , bench "jp100 baseline"      $ nf decodeDirectA jp100
+      [ bench "twitter100" $ nf decodeDirect twitter100
+      , bench "jp100"      $ nf decodeDirect jp100
       ]
     ]

--- a/benchmarks/Typed/TH.hs
+++ b/benchmarks/Typed/TH.hs
@@ -1,60 +1,43 @@
-{-# LANGUAGE PackageImports #-}
 module Typed.TH (benchmarks, decodeBenchmarks) where
 
 import Prelude ()
 import Prelude.Compat
 
-import "aeson" Data.Aeson hiding (Result)
+import Data.Aeson hiding (Result)
 import Criterion
 import Data.ByteString.Lazy as L
 import Twitter.TH
 import Typed.Common
-import qualified "aeson-benchmarks" Data.Aeson as B
 
-encodeDirectA :: Result -> L.ByteString
-encodeDirectA = encode
+encodeDirect :: Result -> L.ByteString
+encodeDirect = encode
 
-encodeViaValueA :: Result -> L.ByteString
-encodeViaValueA = encode . toJSON
-
-encodeDirectB :: Result -> L.ByteString
-encodeDirectB = B.encode
-
-encodeViaValueB :: Result -> L.ByteString
-encodeViaValueB = B.encode . B.toJSON
+encodeViaValue :: Result -> L.ByteString
+encodeViaValue = encode . toJSON
 
 benchmarks :: Benchmark
 benchmarks =
   env ((,) <$> load "json-data/twitter100.json" <*> load "json-data/jp100.json") $ \ ~(twitter100, jp100) ->
   bgroup "encodeTH" [
       bgroup "direct" [
-        bench "twitter100"          $ nf encodeDirectB twitter100
-      , bench "jp100"               $ nf encodeDirectB jp100
-      , bench "twitter100 baseline" $ nf encodeDirectA twitter100
-      , bench "jp100 baseline"      $ nf encodeDirectA jp100
+        bench "twitter100" $ nf encodeDirect twitter100
+      , bench "jp100"      $ nf encodeDirect jp100
       ]
     , bgroup "viaValue" [
-        bench "twitter100"          $ nf encodeViaValueA twitter100
-      , bench "jp100"               $ nf encodeViaValueA jp100
-      , bench "twitter100 baseline" $ nf encodeViaValueB twitter100
-      , bench "jp100 baseline"      $ nf encodeViaValueB jp100
+        bench "twitter100" $ nf encodeViaValue twitter100
+      , bench "jp100"      $ nf encodeViaValue jp100
       ]
     ]
 
-decodeDirectA :: L.ByteString -> Maybe Result
-decodeDirectA = decode
-
-decodeDirectB :: L.ByteString -> Maybe Result
-decodeDirectB = B.decode
+decodeDirect :: L.ByteString -> Maybe Result
+decodeDirect = decode
 
 decodeBenchmarks :: Benchmark
 decodeBenchmarks =
   env ((,) <$> L.readFile "json-data/twitter100.json" <*> L.readFile "json-data/jp100.json") $ \ ~(twitter100, jp100) ->
   bgroup "decodeTH"
     [ bgroup "direct"
-      [ bench "twitter100"          $ nf decodeDirectB twitter100
-      , bench "jp100"               $ nf decodeDirectB jp100
-      , bench "twitter100 baseline"  $ nf decodeDirectA twitter100
-      , bench "jp100 baseline"      $ nf decodeDirectA jp100
+      [ bench "twitter100" $ nf decodeDirect twitter100
+      , bench "jp100"      $ nf decodeDirect jp100
       ]
     ]

--- a/benchmarks/aeson-benchmarks.cabal
+++ b/benchmarks/aeson-benchmarks.cabal
@@ -8,59 +8,14 @@ flag bytestring-builder
   default: False
   manual: False
 
+flag local-aeson
+  description: Build the local version of aeson, to avoid rebuilding aeson's
+    reverse dependencies for benchmarking (statistics, criterion).
+  default: True
+  manual: True
+
 library
   default-language: Haskell2010
-  hs-source-dirs: .. . ../ffi ../pure ../attoparsec-iso8601
-  c-sources:  ../cbits/unescape_string.c
-  exposed-modules:
-    Data.Aeson
-    Data.Aeson.Compat
-    Data.Aeson.Encoding
-    Data.Aeson.Encoding.Builder
-    Data.Aeson.Encoding.Internal
-    Data.Aeson.Internal
-    Data.Aeson.Internal.Functions
-    Data.Aeson.Internal.Time
-    Data.Aeson.Parser
-    Data.Aeson.Parser.Internal
-    Data.Aeson.Parser.Time
-    Data.Aeson.Parser.Unescape
-    Data.Aeson.Parser.UnescapeFFI
-    Data.Aeson.Parser.UnescapePure
-    Data.Aeson.TH
-    Data.Aeson.Text
-    Data.Aeson.Types
-    Data.Aeson.Types.Class
-    Data.Aeson.Types.FromJSON
-    Data.Aeson.Types.Generic
-    Data.Aeson.Types.Internal
-    Data.Aeson.Types.ToJSON
-    Data.Attoparsec.Time
-    Data.Attoparsec.Time.Internal
-
-  build-depends:
-    attoparsec >= 0.13.0.1,
-    base == 4.*,
-    base-compat >= 0.9.1 && <0.10,
-    time-locale-compat >=0.1.1 && <0.2,
-    containers,
-    deepseq,
-    dlist >= 0.2,
-    fail == 4.9.*,
-    ghc-prim >= 0.2,
-    hashable >= 1.1.2.0,
-    mtl,
-    scientific >= 0.3.4.7 && < 0.4,
-    syb,
-    tagged >=0.8.3 && <0.9,
-    template-haskell >= 2.4,
-    text >= 1.1.1.0,
-    th-abstraction >= 0.2.2 && < 0.3,
-    time,
-    transformers,
-    unordered-containers >= 0.2.3.0,
-    uuid-types >= 1.0.3 && <1.1,
-    vector >= 0.7.1
 
   if flag(bytestring-builder)
     build-depends: bytestring >= 0.9 && < 0.10.4,
@@ -68,32 +23,106 @@ library
   else
     build-depends: bytestring >= 0.10.4
 
-  if impl(ghc >=7.8)
-    cpp-options: -DHAS_COERCIBLE
+  if flag(local-aeson)
 
-  if !impl(ghc >= 8.0)
-    -- `Data.Semigroup` is available in base only since GHC 8.0 / base 4.9
-    build-depends: semigroups >= 0.18.2 && < 0.19
+    hs-source-dirs: .. ../ffi ../pure ../attoparsec-iso8601
+    c-sources:  ../cbits/unescape_string.c
+    build-depends:
+      attoparsec >= 0.13.0.1,
+      base == 4.*,
+      base-compat >= 0.9.1 && <0.10,
+      time-locale-compat >=0.1.1 && <0.2,
+      containers,
+      deepseq,
+      dlist >= 0.2,
+      fail == 4.9.*,
+      ghc-prim >= 0.2,
+      hashable >= 1.1.2.0,
+      mtl,
+      scientific >= 0.3.4.7 && < 0.4,
+      syb,
+      tagged >=0.8.3 && <0.9,
+      template-haskell >= 2.4,
+      text >= 1.1.1.0,
+      th-abstraction >= 0.2.2 && < 0.3,
+      time,
+      transformers,
+      unordered-containers >= 0.2.3.0,
+      uuid-types >= 1.0.3 && <1.1,
+      vector >= 0.7.1
 
-  include-dirs: ../include
+    if !impl(ghc >= 7.10)
+      -- `Numeric.Natural` is available in base only since GHC 7.10 / base 4.8
+      build-depends: nats >= 1 && < 1.2
 
-  ghc-options: -O2 -Wall
-  cpp-options: -DGENERICS
+    if impl(ghc >=7.8)
+      cpp-options: -DHAS_COERCIBLE
+
+    if !impl(ghc >= 8.0)
+      -- `Data.Semigroup` is available in base only since GHC 8.0 / base 4.9
+      build-depends: semigroups >= 0.18.2 && < 0.19
+
+    include-dirs: ../include
+
+    ghc-options: -O2 -Wall
+    cpp-options: -DGENERICS
+
+    exposed-modules:
+      Data.Aeson
+      Data.Aeson.Compat
+      Data.Aeson.Encoding
+      Data.Aeson.Encoding.Builder
+      Data.Aeson.Encoding.Internal
+      Data.Aeson.Internal
+      Data.Aeson.Internal.Functions
+      Data.Aeson.Internal.Time
+      Data.Aeson.Parser
+      Data.Aeson.Parser.Internal
+      Data.Aeson.Parser.Time
+      Data.Aeson.Parser.Unescape
+      Data.Aeson.Parser.UnescapeFFI
+      Data.Aeson.Parser.UnescapePure
+      Data.Aeson.TH
+      Data.Aeson.Text
+      Data.Aeson.Types
+      Data.Aeson.Types.Class
+      Data.Aeson.Types.FromJSON
+      Data.Aeson.Types.Generic
+      Data.Aeson.Types.Internal
+      Data.Aeson.Types.ToJSON
+      Data.Attoparsec.Time
+      Data.Attoparsec.Time.Internal
+
+  else
+
+    build-depends: aeson
+
+    reexported-modules:
+      Data.Aeson,
+      Data.Aeson.Encoding,
+      Data.Aeson.Parser.Internal,
+      Data.Aeson.Text,
+      Data.Aeson.TH,
+      Data.Aeson.Types
 
 executable aeson-benchmark-escape
   default-language: Haskell2010
   main-is: Escape.hs
   hs-source-dirs: ../examples .
   ghc-options: -Wall -O2 -rtsopts
-  build-depends:
-    aeson-benchmarks,
-    base,
-    base-compat,
-    bytestring,
-    criterion >= 1.0,
-    deepseq,
-    ghc-prim,
-    text
+  if flag(local-aeson)
+    build-depends:
+      aeson-benchmarks,
+      base,
+      base-compat,
+      bytestring,
+      criterion >= 1.0,
+      deepseq,
+      ghc-prim,
+      text
+  else
+    -- Disabled because of inaccessible internals
+    buildable: False
 
 executable aeson-benchmark-compare
   default-language: Haskell2010
@@ -139,9 +168,6 @@ executable aeson-benchmark-typed
   main-is: Typed.hs
   hs-source-dirs: ../examples .
   ghc-options: -Wall -O2 -rtsopts
-  -- We must help ourself in situations when there is both
-  -- aeson and aeson-benchmakrs
-  cpp-options: -DHAS_BOTH_AESON_AND_BENCHMARKS
   other-modules:
     Twitter
     Twitter.Generic
@@ -153,7 +179,6 @@ executable aeson-benchmark-typed
     Typed.Manual
     Typed.TH
   build-depends:
-    aeson,
     aeson-benchmarks,
     base,
     base-compat,
@@ -173,9 +198,7 @@ executable aeson-benchmark-compare-with-json
   default-language: Haskell2010
   main-is: CompareWithJSON.hs
   ghc-options: -Wall -O2 -rtsopts
-  cpp-options: -DHAS_BOTH_AESON_AND_BENCHMARKS
   build-depends:
-    aeson,
     aeson-benchmarks,
     base,
     base-compat,
@@ -235,13 +258,14 @@ executable aeson-benchmark-dates
     aeson-benchmarks,
     text,
     time
+  if impl(ghc >= 8.2)
+    ghc-options: -Wno-simplifiable-class-constraints
 
 executable aeson-benchmark-map
   default-language: Haskell2010
   main-is: AesonMap.hs
   ghc-options: -Wall -O2 -rtsopts
   build-depends:
-    aeson,
     aeson-benchmarks,
     base,
     base-compat,
@@ -259,7 +283,6 @@ executable aeson-benchmark-foldable
   main-is: AesonFoldable.hs
   ghc-options: -Wall -O2 -rtsopts
   build-depends:
-    aeson,
     aeson-benchmarks,
     base,
     base-compat,

--- a/examples/Twitter/Generic.hs
+++ b/examples/Twitter/Generic.hs
@@ -1,11 +1,6 @@
 -- Use GHC generics to automatically generate good instances.
 
-{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-
-#ifdef HAS_BOTH_AESON_AND_BENCHMARKS
-{-# LANGUAGE PackageImports #-}
-#endif
 
 module Twitter.Generic
     (
@@ -21,12 +16,7 @@ import Prelude.Compat ()
 import Twitter
 import Twitter.Options
 
-#ifndef HAS_BOTH_AESON_AND_BENCHMARKS
 import Data.Aeson (ToJSON (..), FromJSON (..), genericToJSON, genericToEncoding, genericParseJSON)
-#else
-import "aeson" Data.Aeson (ToJSON (..), FromJSON (..), genericToJSON, genericToEncoding, genericParseJSON)
-import qualified "aeson-benchmarks" Data.Aeson as B
-#endif
 
 instance ToJSON Metadata where
     toJSON = genericToJSON twitterOptions
@@ -51,29 +41,3 @@ instance ToJSON Result where
     toEncoding = genericToEncoding twitterOptions
 instance FromJSON Result where
     parseJSON = genericParseJSON twitterOptions
-
-#ifdef HAS_BOTH_AESON_AND_BENCHMARKS
-instance B.ToJSON Metadata where
-    toJSON = B.genericToJSON btwitterOptions
-    toEncoding = B.genericToEncoding btwitterOptions
-instance B.FromJSON Metadata where
-    parseJSON = B.genericParseJSON btwitterOptions
-
-instance B.ToJSON Geo where
-    toJSON = B.genericToJSON btwitterOptions
-    toEncoding = B.genericToEncoding btwitterOptions
-instance B.FromJSON Geo where
-    parseJSON = B.genericParseJSON btwitterOptions
-
-instance B.ToJSON Story where
-    toJSON = B.genericToJSON btwitterOptions
-    toEncoding = B.genericToEncoding btwitterOptions
-instance B.FromJSON Story where
-    parseJSON = B.genericParseJSON btwitterOptions
-
-instance B.ToJSON Result where
-    toJSON = B.genericToJSON btwitterOptions
-    toEncoding = B.genericToEncoding btwitterOptions
-instance B.FromJSON Result where
-    parseJSON = B.genericParseJSON btwitterOptions
-#endif

--- a/examples/Twitter/Manual.hs
+++ b/examples/Twitter/Manual.hs
@@ -1,13 +1,8 @@
 -- Manually write instances.
 
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-
-#ifdef HAS_BOTH_AESON_AND_BENCHMARKS
-{-# LANGUAGE PackageImports #-}
-#endif
 
 module Twitter.Manual
     (
@@ -25,12 +20,7 @@ import Data.Monoid ((<>))
 import Prelude hiding (id)
 import Twitter
 
-#ifndef HAS_BOTH_AESON_AND_BENCHMARKS
 import Data.Aeson hiding (Result)
-#else
-import "aeson" Data.Aeson hiding (Result)
-import qualified "aeson-benchmarks" Data.Aeson as B
-#endif
 
 instance ToJSON Metadata where
 
@@ -155,128 +145,3 @@ instance FromJSON Result where
     <*> v .: "max_id_str"
     <*> v .: "query"
   parseJSON _ = empty
-
-#ifdef HAS_BOTH_AESON_AND_BENCHMARKS
-instance B.ToJSON Metadata where
-  toJSON Metadata{..} = B.object [
-      "result_type" B..= result_type
-    ]
-
-  toEncoding Metadata{..} = B.pairs $
-    "result_type" B..= result_type
-
-instance B.FromJSON Metadata where
-  parseJSON (B.Object v) = Metadata <$> v B..: "result_type"
-  parseJSON _          = empty
-
-instance B.ToJSON Geo where
-  toJSON Geo{..} = B.object [
-      "type_"       B..= type_
-    , "coordinates" B..= coordinates
-    ]
-
-  toEncoding Geo{..} = B.pairs $
-       "type_"       B..= type_
-    <> "coordinates" B..= coordinates
-
-instance B.FromJSON Geo where
-  parseJSON (B.Object v) = Geo <$>
-        v B..: "type_"
-    <*> v B..: "coordinates"
-  parseJSON _          = empty
-
-instance B.ToJSON Story where
-  toJSON Story{..} = B.object [
-      "from_user_id_str"  B..= from_user_id_str
-    , "profile_image_url" B..= profile_image_url
-    , "created_at"        B..= created_at
-    , "from_user"         B..= from_user
-    , "id_str"            B..= id_str
-    , "metadata"          B..= metadata
-    , "to_user_id"        B..= to_user_id
-    , "text"              B..= text
-    , "id"                B..= id_
-    , "from_user_id"      B..= from_user_id
-    , "geo"               B..= geo
-    , "iso_language_code" B..= iso_language_code
-    , "to_user_id_str"    B..= to_user_id_str
-    , "source"            B..= source
-    ]
-
-  toEncoding Story{..} = B.pairs $
-       "from_user_id_str"  B..= from_user_id_str
-    <> "profile_image_url" B..= profile_image_url
-    <> "created_at"        B..= created_at
-    <> "from_user"         B..= from_user
-    <> "id_str"            B..= id_str
-    <> "metadata"          B..= metadata
-    <> "to_user_id"        B..= to_user_id
-    <> "text"              B..= text
-    <> "id"                B..= id_
-    <> "from_user_id"      B..= from_user_id
-    <> "geo"               B..= geo
-    <> "iso_language_code" B..= iso_language_code
-    <> "to_user_id_str"    B..= to_user_id_str
-    <> "source"            B..= source
-
-instance B.FromJSON Story where
-  parseJSON (B.Object v) = Story <$>
-        v B..: "from_user_id_str"
-    <*> v B..: "profile_image_url"
-    <*> v B..: "created_at"
-    <*> v B..: "from_user"
-    <*> v B..: "id_str"
-    <*> v B..: "metadata"
-    <*> v B..: "to_user_id"
-    <*> v B..: "text"
-    <*> v B..: "id"
-    <*> v B..: "from_user_id"
-    <*> v B..: "geo"
-    <*> v B..: "iso_language_code"
-    <*> v B..: "to_user_id_str"
-    <*> v B..: "source"
-  parseJSON _ = empty
-
-instance B.ToJSON Result where
-  toJSON Result{..} = B.object [
-      "results"          B..= results
-    , "max_id"           B..= max_id
-    , "since_id"         B..= since_id
-    , "refresh_url"      B..= refresh_url
-    , "next_page"        B..= next_page
-    , "results_per_page" B..= results_per_page
-    , "page"             B..= page
-    , "completed_in"     B..= completed_in
-    , "since_id_str"     B..= since_id_str
-    , "max_id_str"       B..= max_id_str
-    , "query"            B..= query
-    ]
-
-  toEncoding Result{..} = B.pairs $
-       "results"          B..= results
-    <> "max_id"           B..= max_id
-    <> "since_id"         B..= since_id
-    <> "refresh_url"      B..= refresh_url
-    <> "next_page"        B..= next_page
-    <> "results_per_page" B..= results_per_page
-    <> "page"             B..= page
-    <> "completed_in"     B..= completed_in
-    <> "since_id_str"     B..= since_id_str
-    <> "max_id_str"       B..= max_id_str
-    <> "query"            B..= query
-
-instance B.FromJSON Result where
-  parseJSON (B.Object v) = Result <$>
-        v B..: "results"
-    <*> v B..: "max_id"
-    <*> v B..: "since_id"
-    <*> v B..: "refresh_url"
-    <*> v B..: "next_page"
-    <*> v B..: "results_per_page"
-    <*> v B..: "page"
-    <*> v B..: "completed_in"
-    <*> v B..: "since_id_str"
-    <*> v B..: "max_id_str"
-    <*> v B..: "query"
-  parseJSON _ = empty
-#endif

--- a/examples/Twitter/Options.hs
+++ b/examples/Twitter/Options.hs
@@ -1,18 +1,6 @@
-{-# LANGUAGE CPP #-}
-
-#ifdef HAS_BOTH_AESON_AND_BENCHMARKS
-{-# LANGUAGE PackageImports #-}
-#endif
-
 module Twitter.Options (module Twitter.Options) where
 
-#ifndef HAS_BOTH_AESON_AND_BENCHMARKS
 import Data.Aeson
-import Data.Aeson.Types
-#else
-import "aeson" Data.Aeson
-import qualified "aeson-benchmarks" Data.Aeson as B
-#endif
 
 twitterOptions :: Options
 twitterOptions = defaultOptions
@@ -20,12 +8,3 @@ twitterOptions = defaultOptions
         "id_" -> "id"
         _     -> x
     }
-
-#ifdef HAS_BOTH_AESON_AND_BENCHMARKS
-btwitterOptions :: B.Options
-btwitterOptions = B.defaultOptions
-    { B.fieldLabelModifier = \x -> case x of
-        "id_" -> "id"
-        _     -> x
-    }
-#endif

--- a/examples/Twitter/TH.hs
+++ b/examples/Twitter/TH.hs
@@ -1,12 +1,7 @@
 -- Use Template Haskell to generate good instances.
 
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-
-#ifdef HAS_BOTH_AESON_AND_BENCHMARKS
-{-# LANGUAGE PackageImports #-}
-#endif
 
 module Twitter.TH
     (
@@ -21,21 +16,9 @@ import Prelude ()
 import Twitter
 import Twitter.Options
 
-#ifndef HAS_BOTH_AESON_AND_BENCHMARKS
 import Data.Aeson.TH
-#else
-import "aeson" Data.Aeson.TH
-import qualified "aeson-benchmarks" Data.Aeson.TH as B
-#endif
 
 $(deriveJSON twitterOptions ''Metadata)
 $(deriveJSON twitterOptions ''Geo)
 $(deriveJSON twitterOptions ''Story)
 $(deriveJSON twitterOptions ''Result)
-
-#ifdef HAS_BOTH_AESON_AND_BENCHMARKS
-$(B.deriveJSON btwitterOptions ''Metadata)
-$(B.deriveJSON btwitterOptions ''Geo)
-$(B.deriveJSON btwitterOptions ''Story)
-$(B.deriveJSON btwitterOptions ''Result)
-#endif


### PR DESCRIPTION
Avoids the duplication due to executables integrating two versions of aeson at the same time.