### PR TITLE
Remove some CPP by using recent versions of text

### DIFF
--- a/aeson.cabal
+++ b/aeson.cabal
@@ -125,7 +125,7 @@ library
     scientific >= 0.3.4.7 && < 0.4,
     tagged >=0.8.3 && <0.9,
     template-haskell >= 2.7,
-    text >= 1.1.1.0,
+    text >= 1.2.3,
     th-abstraction >= 0.2.2 && < 0.3,
     time >= 1.1.1.4,
     time-locale-compat >= 0.1.1 && < 0.2,

--- a/benchmarks/aeson-benchmarks.cabal
+++ b/benchmarks/aeson-benchmarks.cabal
@@ -43,7 +43,7 @@ library
       syb,
       tagged >=0.8.3 && <0.9,
       template-haskell >= 2.4,
-      text >= 1.1.1.0,
+      text >= 1.2.3,
       th-abstraction >= 0.2.2 && < 0.3,
       time,
       transformers,

--- a/stack-bench.yaml
+++ b/stack-bench.yaml
@@ -11,3 +11,4 @@ packages:
 - benchmarks
 extra-deps:
 - aeson-1.2.3.0
+- text-1.2.3.0

--- a/stack-ffi-unescape.yaml
+++ b/stack-ffi-unescape.yaml
@@ -5,3 +5,5 @@ flags:
   aeson:
     fast: true
     cffi: true
+extra-deps:
+- text-1.2.3.0

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -7,3 +7,5 @@ flags:
     fast: true
   attoparsec-iso8601:
     fast: true
+extra-deps:
+- text-1.2.3.0


### PR DESCRIPTION
Recent versions of `text` expose the `encodeUtf8BuilderEscaped` function on all versions of `bytestring` (see [this pull request](https://github.com/haskell/text/pull/155)). This means we can remove the hack put in place in https://github.com/bos/aeson/pull/426#issuecomment-225358139 wherein we redefine `encodeUtf8BuilderEscaped` locally in `aeson` if old `bytestring`s are used, allowing us to axe some CPP.