### PR TITLE
Improve error message on day parse fail

### DIFF
--- a/attoparsec-iso8601/Data/Attoparsec/Time.hs
+++ b/attoparsec-iso8601/Data/Attoparsec/Time.hs
@@ -42,9 +42,9 @@ import qualified Data.Time.LocalTime as Local
 day :: Parser Day
 day = do
   absOrNeg <- negate <$ char '-' <|> id <$ char '+' <|> pure id
-  y <- decimal <* char '-'
-  m <- twoDigits <* char '-'
-  d <- twoDigits
+  y <- (decimal <* char '-') <|> fail "date must be of form [+,-]YYYY-MM-DD"
+  m <- (twoDigits <* char '-') <|> fail "date must be of form [+,-]YYYY-MM-DD"
+  d <- twoDigits <|> fail "date must be of form [+,-]YYYY-MM-DD"
   maybe (fail "invalid date") return (fromGregorianValid (absOrNeg y) m d)
 
 -- | Parse a two-digit integer (e.g. day of month, hour).


### PR DESCRIPTION
Before:

    *> parse utcTime "asd"
    Fail "asd" [] "Failed reading: takeWhile1"

After:

    *> parse utcTime "asd"
    Fail "asd" [] "Failed reading: date must be of form [+,-]YYYY-MM-DD"

There's probably a better don't-repeat-yourself refactor here of the error message, but my parsec-fu is not strong.

This is important in particular because this parser's error messages often get sent directly to users when serving json APIs via aeson.