### PR TITLE
Fix generic `FromJSON` for non-record constructors with one field

### DIFF
--- a/Data/Aeson/Types/FromJSON.hs
+++ b/Data/Aeson/Types/FromJSON.hs
@@ -1004,7 +1004,7 @@ instance ( IsRecord            f isRecord
 
 instance OVERLAPPING_
          ( GFromJSON arity a, FromRecord arity (S1 s a)
-         ) => ConsFromJSON' arity (S1 s a) 'True where
+         ) => ConsFromJSON' arity (S1 s a) True where
     consParseJSON' opts fargs
       | unwrapUnaryRecords opts = Tagged . gParseJSON opts fargs
       | otherwise = Tagged . withObject "unary record" (parseRecord opts fargs)
@@ -1013,7 +1013,7 @@ instance FromRecord arity f => ConsFromJSON' arity f True where
     consParseJSON' opts fargs =
       Tagged . withObject "record (:*:)" (parseRecord opts fargs)
 
-instance (GFromJSON arity f) => ConsFromJSON' arity f False where
+instance GFromJSON arity f => ConsFromJSON' arity f False where
     consParseJSON' opts fargs = Tagged . gParseJSON opts fargs
 
 --------------------------------------------------------------------------------

--- a/Data/Aeson/Types/Generic.hs
+++ b/Data/Aeson/Types/Generic.hs
@@ -44,12 +44,8 @@ import GHC.Generics
 --------------------------------------------------------------------------------
 
 class IsRecord (f :: * -> *) isRecord | f -> isRecord
-  where
-    isUnary :: f a -> Bool
-    isUnary = const True
 
 instance (IsRecord f isRecord) => IsRecord (f :*: g) isRecord
-  where isUnary = const False
 #if MIN_VERSION_base(4,9,0)
 instance OVERLAPPING_ IsRecord (M1 S ('MetaSel 'Nothing u ss ds) f) False
 #else
@@ -61,7 +57,6 @@ instance IsRecord Par1 True
 instance IsRecord (Rec1 f) True
 instance IsRecord (f :.: g) True
 instance IsRecord U1 False
-  where isUnary = const False
 
 --------------------------------------------------------------------------------
 

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -99,6 +99,7 @@ tests = testGroup "unit" [
   , testCase "Show Options" showOptions
   , testGroup "SingleMaybeField" singleMaybeField
   , testCase "withEmbeddedJSON" withEmbeddedJSONTest
+  , testCase "SingleFieldCon" singleFieldCon
   ]
 
 roundTripCamel :: String -> Assertion
@@ -533,6 +534,17 @@ instance FromJSON EmbeddedJSONTest where
 withEmbeddedJSONTest :: Assertion
 withEmbeddedJSONTest =
   assertEqual "Unquote embedded JSON" (Right $ EmbeddedJSONTest 1) (eitherDecode "{\"prop\":\"1\"}")
+
+-- Regression test for https://github.com/bos/aeson/issues/627
+newtype SingleFieldCon = SingleFieldCon Int deriving (Eq, Show, Generic)
+
+instance FromJSON SingleFieldCon where
+  parseJSON = genericParseJSON defaultOptions{unwrapUnaryRecords=True}
+  -- This option should have no effect on this type
+
+singleFieldCon :: Assertion
+singleFieldCon =
+  assertEqual "fromJSON" (Right (SingleFieldCon 0)) (eitherDecode "0")
 
 deriveJSON defaultOptions{omitNothingFields=True} ''MyRecord
 


### PR DESCRIPTION
Fixes #627

Also some refactoring to get rid of `isUnary`.

