### PR TITLE
IsRecord has no methods

### DIFF
--- a/Data/Aeson/Types/Generic.hs
+++ b/Data/Aeson/Types/Generic.hs
@@ -25,7 +25,7 @@
 
 module Data.Aeson.Types.Generic
     (
-      IsRecord(..)
+      IsRecord
     , AllNullary
     , Tagged2(..)
     , True


### PR DESCRIPTION
MORE TO COME

fixes warning:
```
Data/Aeson/Types/Generic.hs:28:7: warning: [-Wdodgy-exports]
    The export item `IsRecord(..)' suggests that
    `IsRecord' has (in-scope) constructors or class methods,
    but it has none
```