### PR TITLE
expose internal functions from Data.Aeson module

### DIFF
--- a/Data/Aeson.hs
+++ b/Data/Aeson.hs
@@ -63,6 +63,8 @@ module Data.Aeson
     , fromJSON
     , ToJSON(..)
     , KeyValue(..)
+    , (<?>)
+    , JSONPath
     -- ** Keys for maps
     , ToJSONKey(..)
     , ToJSONKeyFunction(..)
@@ -129,15 +131,16 @@ module Data.Aeson
     -- * Parsing
     , json
     , json'
+    , parseIndexedJSON
     ) where
 
 import Prelude.Compat
 
-import Data.Aeson.Types.FromJSON (ifromJSON)
+import Data.Aeson.Types.FromJSON (ifromJSON, parseIndexedJSON)
 import Data.Aeson.Encoding (encodingToLazyByteString)
 import Data.Aeson.Parser.Internal (decodeWith, decodeStrictWith, eitherDecodeWith, eitherDecodeStrictWith, jsonEOF, json, jsonEOF', json')
 import Data.Aeson.Types
-import Data.Aeson.Types.Internal (JSONPath, formatError)
+import Data.Aeson.Types.Internal (JSONPath, formatError, (<?>))
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as L
 

--- a/Data/Aeson/Types/FromJSON.hs
+++ b/Data/Aeson/Types/FromJSON.hs
@@ -67,6 +67,7 @@ module Data.Aeson.Types.FromJSON
     , explicitParseField
     , explicitParseFieldMaybe
     , explicitParseFieldMaybe'
+    , parseIndexedJSON
     -- ** Operators
     , (.:)
     , (.:?)

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 For the latest version of this document, please see [https://github.com/bos/aeson/blob/master/changelog.md](https://github.com/bos/aeson/blob/master/changelog.md).
 
+## Upcoming
+* Exposes internal helper functions like `<?>`, `JSONPath`, and `parseIndexedJSON` from `Data.Aeson` module. Does not include any breaking changes.
+
 ### 1.4.2.0
 
 * Add `Data.Aeson.QQ.Simple` which is a simpler version of the `aeson-qq` package, it does not support interpolation, thanks to Oleg Grenrus.


### PR DESCRIPTION
This PR addresses #475 and includes the following changes:
- Exposes `<?>` and `JSONPath` of `Data.Aeson.Types.Internal` module from `Data.Aeson`
- Exposes `parseIndexedJSON` of `Data.Aeson.Types.fromJSON` module from `Data.Aeson`

Other changes include updating the changelog.md

_Please let me know if I need to make any further modifications or changes._

