### PR TITLE
Fix JSON path when parsing tagged objects

### DIFF
--- a/Data/Aeson/Types/FromJSON.hs
+++ b/Data/Aeson/Types/FromJSON.hs
@@ -1002,7 +1002,9 @@ instance (FromRecord arity f) => FromTaggedObject'' arity f True where
 
 instance (GFromJSON arity f) => FromTaggedObject'' arity f False where
     parseFromTaggedObject'' opts fargs contentsFieldName = Tagged .
-      (gParseJSON opts fargs <=< (.: pack contentsFieldName))
+      ((<?> Key label) .  gParseJSON opts fargs <=< (.: label))
+      where
+       label = pack contentsFieldName
 
 instance OVERLAPPING_ FromTaggedObject'' arity U1 False where
     parseFromTaggedObject'' _ _ _ _ = Tagged (pure U1)


### PR DESCRIPTION
For the problem see below. I am not completely sure about the Generic part, I encountered similar place and just used it as an example (`((<?> Key label)`). I am not sure about the "manual" instances as well. I expect that the `(.:)` operator do the right thing in any case and wonder why there are more `<?>` in other places.

Here is the problem:
```
# echo '{"tag":"X1", "contents":[{"contents":1}]}' | test
Left "Error in $: The key \"X1\" was not found"
Left "Error in $[0]: key \"tag\" not present" # <-- must be `$.contents[0]`
```

Source code for the test:
```haskell
{-# LANGUAGE DeriveAnyClass #-}
{-# LANGUAGE DeriveGeneric #-}
{-# LANGUAGE TemplateHaskell #-}

module Main
  ( main
  ) where

import Data.Aeson (FromJSON, ToJSON, eitherDecode)
import Data.Aeson.TH (defaultOptions, deriveJSON)
import qualified Data.ByteString.Lazy as BSL

import GHC.Generics (Generic)

data A
  = A Int
  | B String
  deriving (Generic, FromJSON, ToJSON, Show)

data X
  = X [A]
  | Y String
  deriving (Generic, FromJSON, ToJSON, Show)

data A1
  = A1 Int
  | B1 String
  deriving (Show)

$(deriveJSON defaultOptions ''A1)

data X1
  = X1 [A]
  | Y1 String
  deriving (Show)

$(deriveJSON defaultOptions ''X1)

main :: IO ()
main = do
  raw <- BSL.getContents
  print (eitherDecode raw :: Either String X)
  print (eitherDecode raw :: Either String X1)
``` 