### PR TITLE
Export isEmptyArray from Data.Aeson.Types

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 For the latest version of this document, please see [https://github.com/haskell/aeson/blob/master/changelog.md](https://github.com/haskell/aeson/blob/master/changelog.md).
 
+### Upcoming
+
+* Expose `isEmptyArray` from `Data.Aeson.Types` module.
+
 ### 2.3.0.0 - 2026-05-21
 
 * Fix parsing of fractional numbers to reject exponents smaller than -1024.

--- a/src/Data/Aeson/Types.hs
+++ b/src/Data/Aeson/Types.hs
@@ -20,6 +20,7 @@ module Data.Aeson.Types
     , Series
     , Array
     , emptyArray
+    , isEmptyArray
     , Pair
     , Object
     , emptyObject

--- a/src/Data/Aeson/Types/Internal.hs
+++ b/src/Data/Aeson/Types/Internal.hs
@@ -552,8 +552,10 @@ instance TH.Lift Value where
 emptyArray :: Value
 emptyArray = Array V.empty
 
--- | Determines if the 'Value' is an empty 'Array'.
--- Note that: @isEmptyArray 'emptyArray'@.
+-- | Determines whether the 'Value' is an empty 'Array'.
+--
+-- Do note that if this is `False`, the `Value` may be a non-empty
+-- array, or it may not even be an array.
 isEmptyArray :: Value -> Bool
 isEmptyArray (Array arr) = V.null arr
 isEmptyArray _ = False


### PR DESCRIPTION
Export `isEmptyArray` found in Data.Aeson.Types.Internal from Data.Aeson.Types. 