### PR TITLE
Adapt to breaking changes in th-abstraction-0.3.0.0

### DIFF
--- a/aeson.cabal
+++ b/aeson.cabal
@@ -152,7 +152,7 @@ library
     dlist                >= 0.8.0.4  && < 0.9,
     hashable             >= 1.2.7.0  && < 1.3,
     scientific           >= 0.3.6.2  && < 0.4,
-    th-abstraction       >= 0.2.8.0  && < 0.3,
+    th-abstraction       >= 0.2.8.0  && < 0.4,
     time-locale-compat   >= 0.1.1.5  && < 0.2,
     uuid-types           >= 1.0.3    && < 1.1,
     vector               >= 0.12.0.1 && < 0.13

--- a/benchmarks/aeson-benchmarks.cabal
+++ b/benchmarks/aeson-benchmarks.cabal
@@ -45,7 +45,7 @@ library
       tagged >=0.8.3 && <0.9,
       template-haskell >= 2.4,
       text >= 1.2.3,
-      th-abstraction >= 0.2.2 && < 0.3,
+      th-abstraction >= 0.2.2 && < 0.4,
       time,
       transformers,
       unordered-containers >= 0.2.3.0,

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@ For the latest version of this document, please see [https://github.com/bos/aeso
 
 ## Upcoming
 * Exposes internal helper functions like `<?>`, `JSONPath`, and `parseIndexedJSON` from `Data.Aeson` module. Does not include any breaking changes.
+* Support building with `th-abstraction-0.3.0.0` or later.
 
 ### 1.4.2.0
 


### PR DESCRIPTION
This adapts to a breaking change in the type of `datatypeVars` that was introduced in `th-abstraction-0.3.0.0`.