### PR TITLE
Require recent bytestring with ghc-8.0 or later

### DIFF
--- a/aeson.cabal
+++ b/aeson.cabal
@@ -111,12 +111,15 @@ library
     text             >= 1.2.3.0 && < 1.3,
     time             >= 1.4     && < 1.9
 
+  if impl(ghc >= 8.0)
+    build-depends: bytestring >= 0.10.8.1
+
   -- Compat
   build-depends:
     base-compat     >= 0.9.1    && < 0.11
 
   if flag(bytestring-builder)
-    build-depends: bytestring >= 0.9.2 && < 0.10.4,
+    build-depends: bytestring >= 0.9.2.1 && < 0.10.4,
                    bytestring-builder >= 0.10.4 && < 1
   else
     build-depends: bytestring >= 0.10.4 && < 0.11

--- a/cabal.project
+++ b/cabal.project
@@ -1,2 +1,3 @@
 with-compiler: ghc
-packages: ., attoparsec-iso8601, benchmarks
+packages: .
+packages: attoparsec-iso8601, benchmarks


### PR DESCRIPTION
This is somewhat band-aid solution for:

Data/Aeson/Encoding/Builder.hs:87:21: error:
    • No instance for (Semigroup Builder) arising from a use of ‘<>’

But there aren't better solution: we don't include anything
from semigroups on ghc >= 8.0; so semigroups couldn't even
in theory provide that instance.

Also a lot of older aeson releases are "broken" because of this,
if one downgrades bytestring. Usually no-one does that, except weird
automatic QA tools.