### PR TITLE
Fix dependencies of the benchmarks package for old GHCs

### DIFF
--- a/benchmarks/Issue673.hs
+++ b/benchmarks/Issue673.hs
@@ -18,6 +18,7 @@ import Criterion.Main
 import Prelude.Compat
 import Data.Int (Int64)
 import Data.Scientific (Scientific)
+import Data.Semigroup ((<>))
 import Data.Aeson.Parser (scientific)
 
 import qualified Data.Attoparsec.ByteString.Lazy as AttoL

--- a/benchmarks/aeson-benchmarks.cabal
+++ b/benchmarks/aeson-benchmarks.cabal
@@ -176,6 +176,9 @@ executable aeson-benchmark-compare
      Compare.JsonBuilder
    build-depends:
      json-builder
+ if impl(ghc < 8.0)
+   build-depends:
+     semigroups
 
 executable aeson-benchmark-micro
   default-language: Haskell2010
@@ -222,6 +225,8 @@ executable aeson-benchmark-typed
                    bytestring-builder >= 0.10.4 && < 1
   else
     build-depends: bytestring >= 0.10.4
+  if impl(ghc < 8.0)
+    build-depends: semigroups
 
 executable aeson-benchmark-compare-with-json
   default-language: Haskell2010
@@ -337,3 +342,5 @@ executable aeson-issue-673
     scientific,
     base-compat,
     criterion >= 1.0
+  if impl(ghc < 8.0)
+    build-depends: semigroups


### PR DESCRIPTION
Apparently Travis doesn't build these benchmarks (in spite of a comment indicating the contrary in [`travis/script.sh`](https://github.com/bos/aeson/blob/a09a0bcb6e04ed18ca6207ea855349a9ade2a1af/travis/script.sh#L12)).