### PR TITLE
Expose JSONPathElement constructors.

### DIFF
--- a/Data/Aeson/Types.hs
+++ b/Data/Aeson/Types.hs
@@ -136,6 +136,11 @@ module Data.Aeson.Types
     , JSONKeyOptions
     , keyModifier
     , defaultJSONKeyOptions
+
+    -- * Parsing context
+    , (<?>)
+    , JSONPath
+    , JSONPathElement(..)
     ) where
 
 import Prelude.Compat


### PR DESCRIPTION
Enables the manual application of <?> to provide additional context for
decoders.

Fixes https://github.com/bos/aeson/issues/722