### PR TITLE
Allow building with base-compat-0.11.0

### DIFF
--- a/Data/Aeson/Types/Internal.hs
+++ b/Data/Aeson/Types/Internal.hs
@@ -99,6 +99,7 @@ import Data.Time.Format (FormatTime)
 import Data.Typeable (Typeable)
 import Data.Vector (Vector)
 import GHC.Generics (Generic)
+import qualified Control.Monad as Monad
 import qualified Control.Monad.Fail as Fail
 import qualified Data.HashMap.Strict as H
 import qualified Data.Scientific as S
@@ -152,7 +153,7 @@ instance Functor Result where
     fmap _ (Error err) = Error err
     {-# INLINE fmap #-}
 
-instance Monad IResult where
+instance Monad.Monad IResult where
     return = pure
     {-# INLINE return #-}
 
@@ -169,7 +170,7 @@ instance Fail.MonadFail IResult where
     fail err = IError [] err
     {-# INLINE fail #-}
 
-instance Monad Result where
+instance Monad.Monad Result where
     return = pure
     {-# INLINE return #-}
 
@@ -288,7 +289,7 @@ newtype Parser a = Parser {
                 -> f r
     }
 
-instance Monad Parser where
+instance Monad.Monad Parser where
     m >>= g = Parser $ \path kf ks -> let ks' a = runParser (g a) path kf ks
                                        in runParser m path kf ks'
     {-# INLINE (>>=) #-}

--- a/aeson.cabal
+++ b/aeson.cabal
@@ -116,7 +116,7 @@ library
 
   -- Compat
   build-depends:
-    base-compat     >= 0.9.1    && < 0.11,
+    base-compat     >= 0.9.1    && < 0.12,
     time-compat     >= 1.9.2.2  && < 1.10
 
   if flag(bytestring-builder)

--- a/attoparsec-iso8601/attoparsec-iso8601.cabal
+++ b/attoparsec-iso8601/attoparsec-iso8601.cabal
@@ -37,7 +37,7 @@ library
   build-depends:
     attoparsec >= 0.13.0.1,
     base >= 4.5 && < 5,
-    base-compat >= 0.9.1 && < 0.11,
+    base-compat >= 0.9.1 && < 0.12,
     text >= 1.1.1.0,
     time >= 1.1.1.4
 

--- a/benchmarks/AesonEncode.hs
+++ b/benchmarks/AesonEncode.hs
@@ -7,7 +7,7 @@ module Main (main) where
 import Prelude.Compat
 
 import Control.DeepSeq
-import Control.Monad
+import Control.Monad (forM_)
 import Data.Aeson
 import Data.Attoparsec.ByteString (IResult(..), parseWith)
 import Data.Char (isDigit)

--- a/benchmarks/Compare/JsonBench.hs
+++ b/benchmarks/Compare/JsonBench.hs
@@ -20,6 +20,7 @@ import Data.Aeson ((.:))
 import Data.Monoid ((<>))
 import Data.Text (Text)
 import Typed.Common (load)
+import qualified Control.Monad.Fail as Fail
 import qualified Data.Aeson as Aeson
 import qualified Data.BufferBuilder.Json as Json
 
@@ -82,7 +83,7 @@ genderTable = [("male", Male), ("female", Female)]
 fruitTable :: [(Text, Fruit)]
 fruitTable = [("apple", Apple), ("strawberry", Strawberry), ("banana", Banana)]
 
-enumFromJson :: Monad m => String -> [(Text, enum)] -> (json -> m Text) -> json -> m enum
+enumFromJson :: Fail.MonadFail m => String -> [(Text, enum)] -> (json -> m Text) -> json -> m enum
 enumFromJson enumName table extract v = do
     s <- extract v
     case lookup s table of


### PR DESCRIPTION
`base-compat-0.11.0` makes `Prelude.fail` refer to `Control.Monad.Fail.fail`, not `Control.Monad.fail`, to mirror the API that GHC 8.8's version of `base` offers. One consequence of this change is that `aeson-1.4.4.0` does not compile out of the box with `base-compat-0.11.0`. Luckily, this can be rectified in a way that is backwards-compatible with earlier versions of `base-compat` by making more use of qualified imports, which this patch accomplishes.