### PR TITLE
Add formatPath function

### DIFF
--- a/Data/Aeson/Types.hs
+++ b/Data/Aeson/Types.hs
@@ -141,6 +141,8 @@ module Data.Aeson.Types
     , (<?>)
     , JSONPath
     , JSONPathElement(..)
+    , formatPath
+    , formatRelativePath
     ) where
 
 import Prelude.Compat

--- a/Data/Aeson/Types/Internal.hs
+++ b/Data/Aeson/Types/Internal.hs
@@ -49,6 +49,8 @@ module Data.Aeson.Types.Internal
     , parserThrowError
     , parserCatchError
     , formatError
+    , formatPath
+    , formatRelativePath
     , (<?>)
     -- * Constructors and accessors
     , object
@@ -458,7 +460,17 @@ parseEither m v = runParser (m v) [] onError Right
 -- | Annotate an error message with a
 -- <http://goessner.net/articles/JsonPath/ JSONPath> error location.
 formatError :: JSONPath -> String -> String
-formatError path msg = "Error in " ++ format "$" path ++ ": " ++ msg
+formatError path msg = "Error in " ++ formatPath path ++ ": " ++ msg
+
+-- | Format a <http://goessner.net/articles/JsonPath/ JSONPath> as a 'String',
+-- representing the root object as @$@.
+formatPath :: JSONPath -> String
+formatPath path = "$" ++ formatRelativePath path
+
+-- | Format a <http://goessner.net/articles/JsonPath/ JSONPath> as a 'String'
+-- which represents the path relative to some root object.
+formatRelativePath :: JSONPath -> String
+formatRelativePath path = format "" path
   where
     format :: String -> JSONPath -> String
     format pfx []                = pfx

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -34,7 +34,8 @@ import Data.Aeson.Parser
   , json', jsonLast', jsonAccum', jsonNoDup')
 import Data.Aeson.Types
   ( Options(..), Result(Success), ToJSON(..), Value(Array, Bool, Null, Object)
-  , camelTo, camelTo2, defaultOptions, omitNothingFields, parse)
+  , camelTo, camelTo2, defaultOptions, formatPath, formatRelativePath
+  , omitNothingFields, parse)
 import Data.Attoparsec.ByteString (Parser, parseOnly)
 import Data.Char (toUpper)
 import Data.Either.Compat (isLeft, isRight)
@@ -252,6 +253,18 @@ formatErrorExample =
   let rhs = formatError [Index 0, Key "foo", Key "bar", Key "a.b.c", Key "", Key "'\\", Key "end"] "error msg"
       lhs = "Error in $[0].foo.bar['a.b.c']['']['\\'\\\\'].end: error msg"
   in assertEqual "formatError example" lhs rhs
+
+formatPathExample :: Assertion
+formatPathExample =
+  let rhs = formatPath [Key "x", Index 0]
+      lhs = "$.x[0]"
+  in assertEqual "formatPath example" lhs rhs
+
+formatRelativePathExample :: Assertion
+formatRelativePathExample =
+  let rhs = formatPath [Key "x", Index 0]
+      lhs = ".x[0]"
+  in assertEqual "formatRelativePath example" lhs rhs
 
 ------------------------------------------------------------------------------
 -- Comparison (.:?) and (.:!)


### PR DESCRIPTION
Exposes a function to format a `JSONPath` as a `String` so that it can be used for more than formatting error messages.