### PR TITLE
Allow FromJSON instance for Ratio a parse numbers

### DIFF
--- a/Data/Aeson/Types/FromJSON.hs
+++ b/Data/Aeson/Types/FromJSON.hs
@@ -1541,12 +1541,15 @@ instance FromJSONKey Float where
         _           -> Scientific.toRealFloat <$> parseScientificText t
 
 instance (FromJSON a, Integral a) => FromJSON (Ratio a) where
-    parseJSON = withObject "Rational" $ \obj -> do
-        numerator <- obj .: "numerator"
-        denominator <- obj .: "denominator"
-        if denominator == 0
-        then fail "Ratio denominator was 0"
-        else pure $ numerator % denominator
+    parseJSON (Number x) = pure (realToFrac x)
+    parseJSON o          = objParser o
+      where
+        objParser = withObject "Rational" $ \obj -> do
+            numerator <- obj .: "numerator"
+            denominator <- obj .: "denominator"
+            if denominator == 0
+            then fail "Ratio denominator was 0"
+            else pure $ numerator % denominator
     {-# INLINE parseJSON #-}
 
 -- | This instance includes a bounds check to prevent maliciously

--- a/Data/Aeson/Types/FromJSON.hs
+++ b/Data/Aeson/Types/FromJSON.hs
@@ -1541,7 +1541,9 @@ instance FromJSONKey Float where
         _           -> Scientific.toRealFloat <$> parseScientificText t
 
 instance (FromJSON a, Integral a) => FromJSON (Ratio a) where
-    parseJSON (Number x) = pure (realToFrac x)
+    parseJSON (Number x) = prependContext "Ratio"
+                         $ withBoundedScientific' (pure . realToFrac)
+                         $ Number x
     parseJSON o          = objParser o
       where
         objParser = withObject "Rational" $ \obj -> do

--- a/Data/Aeson/Types/ToJSON.hs
+++ b/Data/Aeson/Types/ToJSON.hs
@@ -100,7 +100,6 @@ import GHC.Generics
 import Numeric.Natural (Natural)
 import qualified Data.Aeson.Encoding as E
 import qualified Data.Aeson.Encoding.Internal as E (InArray, comma, econcat, retagEncoding)
-import qualified Data.ByteString as S
 import qualified Data.ByteString.Lazy as L
 import qualified Data.DList as DList
 import qualified Data.HashMap.Strict as H

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 For the latest version of this document, please see [https://github.com/bos/aeson/blob/master/changelog.md](https://github.com/bos/aeson/blob/master/changelog.md).
 
+### upcoming
+
+* `FromJSON` instance of `Ratio a` now parses numbers in addtion to
+  standard `{numerator=..., denumerator=...}` encoding.
+
 ### 1.4.6.0
 
 * Provide a clearer error message when a required tagKey for a constructor is missing, thanks to Guru Devanla.

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -115,6 +115,7 @@ tests = testGroup "unit" [
   , testGroup "Ordering of object keys" keyOrdering
   , testCase "Ratio with denominator 0" ratioDenominator0
   , testCase "Rational parses number"   rationalNumber
+  , testCase "Big rational"             bigRationalDecoding
   , testCase "Big scientific exponent" bigScientificExponent
   , testCase "Big integer decoding" bigIntegerDecoding
   , testCase "Big natural decading" bigNaturalDecoding
@@ -626,6 +627,12 @@ rationalNumber =
   assertEqual "Ratio with denominator 0"
     (Right 1.37)
     (eitherDecode "1.37" :: Either String Rational)
+
+bigRationalDecoding :: Assertion
+bigRationalDecoding =
+  assertEqual "Decoding an Integer with a large exponent should fail"
+    (Left "Error in $: parsing Ratio failed, found a number with exponent 2000, but it must not be greater than 1024")
+    ((eitherDecode :: L.ByteString -> Either String Rational) "1e2000")
 
 bigScientificExponent :: Assertion
 bigScientificExponent =

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -116,6 +116,7 @@ tests = testGroup "unit" [
   , testCase "Ratio with denominator 0" ratioDenominator0
   , testCase "Rational parses number"   rationalNumber
   , testCase "Big rational"             bigRationalDecoding
+  , testCase "Small rational"           smallRationalDecoding
   , testCase "Big scientific exponent" bigScientificExponent
   , testCase "Big integer decoding" bigIntegerDecoding
   , testCase "Big natural decading" bigNaturalDecoding
@@ -631,8 +632,15 @@ rationalNumber =
 bigRationalDecoding :: Assertion
 bigRationalDecoding =
   assertEqual "Decoding an Integer with a large exponent should fail"
-    (Left "Error in $: parsing Ratio failed, found a number with exponent 2000, but it must not be greater than 1024")
+    (Left "Error in $: parsing Ratio failed, found a number with exponent 2000, but it must not be greater than 1024 or less than -1024")
     ((eitherDecode :: L.ByteString -> Either String Rational) "1e2000")
+
+smallRationalDecoding :: Assertion
+smallRationalDecoding =
+  assertEqual "Decoding an Integer with a large exponent should fail"
+    (Left "Error in $: parsing Ratio failed, found a number with exponent -2000, but it must not be greater than 1024 or less than -1024")
+    ((eitherDecode :: L.ByteString -> Either String Rational) "1e-2000")
+
 
 bigScientificExponent :: Assertion
 bigScientificExponent =

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -114,6 +114,7 @@ tests = testGroup "unit" [
   , testCase "SingleFieldCon" singleFieldCon
   , testGroup "Ordering of object keys" keyOrdering
   , testCase "Ratio with denominator 0" ratioDenominator0
+  , testCase "Rational parses number"   rationalNumber
   , testCase "Big scientific exponent" bigScientificExponent
   , testCase "Big integer decoding" bigIntegerDecoding
   , testCase "Big natural decading" bigNaturalDecoding
@@ -619,6 +620,12 @@ ratioDenominator0 =
   assertEqual "Ratio with denominator 0"
     (Left "Error in $: Ratio denominator was 0")
     (eitherDecode "{ \"numerator\": 1, \"denominator\": 0 }" :: Either String Rational)
+
+rationalNumber :: Assertion
+rationalNumber =
+  assertEqual "Ratio with denominator 0"
+    (Right 1.37)
+    (eitherDecode "1.37" :: Either String Rational)
 
 bigScientificExponent :: Assertion
 bigScientificExponent =


### PR DESCRIPTION
This PR modify `FromJSON` instance of `Ratio a` to accept JSON numbers. `ToJSON` is unchanged so this PR only increases number of valid inputs for `Ratio` data type.

I think that for any numeric type it should be possible to parse it from JSON numbers. I have been bitten by fact that `say `1.4` wouldn't parse as `Rational` for two times already.