### PR TITLE
Add option to reject unknown fields (#207)

### DIFF
--- a/Data/Aeson/Types.hs
+++ b/Data/Aeson/Types.hs
@@ -124,6 +124,7 @@ module Data.Aeson.Types
     , sumEncoding
     , unwrapUnaryRecords
     , tagSingleConstructors
+    , rejectUnknownFields
 
     -- ** Options utilities
     , SumEncoding(..)

--- a/Data/Aeson/Types/Internal.hs
+++ b/Data/Aeson/Types/Internal.hs
@@ -64,6 +64,7 @@ module Data.Aeson.Types.Internal
         , sumEncoding
         , unwrapUnaryRecords
         , tagSingleConstructors
+        , rejectUnknownFields
         )
 
     , SumEncoding(..)
@@ -624,10 +625,14 @@ data Options = Options
     , tagSingleConstructors :: Bool
       -- ^ Encode types with a single constructor as sums,
       -- so that `allNullaryToStringTag` and `sumEncoding` apply.
+    , rejectUnknownFields :: Bool
+      -- ^ Applies only to 'Data.Aeson.FromJSON' instances. If a field appears in
+      -- the parsed object map, but does not appear in the target object, parsing
+      -- will fail, with an error message indicating which fields were unknown.
     }
 
 instance Show Options where
-  show (Options f c a o s u t) =
+  show (Options f c a o s u t r) =
        "Options {"
     ++ intercalate ", "
       [ "fieldLabelModifier =~ " ++ show (f "exampleField")
@@ -637,6 +642,7 @@ instance Show Options where
       , "sumEncoding = " ++ show s
       , "unwrapUnaryRecords = " ++ show u
       , "tagSingleConstructors = " ++ show t
+      , "rejectUnknownFields = " ++ show r
       ]
     ++ "}"
 
@@ -718,6 +724,7 @@ data JSONKeyOptions = JSONKeyOptions
 -- , 'sumEncoding'             = 'defaultTaggedObject'
 -- , 'unwrapUnaryRecords'      = False
 -- , 'tagSingleConstructors'   = False
+-- , 'rejectUnknownFields'     = False
 -- }
 -- @
 defaultOptions :: Options
@@ -729,6 +736,7 @@ defaultOptions = Options
                  , sumEncoding             = defaultTaggedObject
                  , unwrapUnaryRecords      = False
                  , tagSingleConstructors   = False
+                 , rejectUnknownFields     = False
                  }
 
 -- | Default 'TaggedObject' 'SumEncoding' options:

--- a/tests/Encoders.hs
+++ b/tests/Encoders.hs
@@ -243,6 +243,31 @@ gSomeTypeToEncodingOmitNothingFields :: SomeType Int -> Encoding
 gSomeTypeToEncodingOmitNothingFields = genericToEncoding optsOmitNothingFields
 
 
+thSomeTypeParseJSONRejectUnknownFields :: Value -> Parser (SomeType Int)
+thSomeTypeParseJSONRejectUnknownFields = $(mkParseJSON optsRejectUnknownFields ''SomeType)
+
+gSomeTypeParseJSONRejectUnknownFields :: Value -> Parser (SomeType Int)
+gSomeTypeParseJSONRejectUnknownFields = genericParseJSON optsRejectUnknownFields
+
+
+--------------------------------------------------------------------------------
+-- Foo decoders
+--------------------------------------------------------------------------------
+
+thFooParseJSONRejectUnknownFields :: Value -> Parser Foo
+thFooParseJSONRejectUnknownFields = $(mkParseJSON optsRejectUnknownFields ''Foo)
+
+gFooParseJSONRejectUnknownFields :: Value -> Parser Foo
+gFooParseJSONRejectUnknownFields = genericParseJSON optsRejectUnknownFields
+
+
+thFooParseJSONRejectUnknownFieldsTagged :: Value -> Parser Foo
+thFooParseJSONRejectUnknownFieldsTagged = $(mkParseJSON optsRejectUnknownFieldsTagged ''Foo)
+
+gFooParseJSONRejectUnknownFieldsTagged :: Value -> Parser Foo
+gFooParseJSONRejectUnknownFieldsTagged = genericParseJSON optsRejectUnknownFieldsTagged
+
+
 --------------------------------------------------------------------------------
 -- Option fields
 --------------------------------------------------------------------------------

--- a/tests/ErrorMessages.hs
+++ b/tests/ErrorMessages.hs
@@ -136,6 +136,29 @@ outputGeneric choice = concat
       , "[1,"
       ]
 
+  , testWithSomeType "SomeType (reject unknown fields)"
+      (select
+        thSomeTypeParseJSONRejectUnknownFields
+        gSomeTypeParseJSONRejectUnknownFields)
+      [ "{\"tag\": \"record\", \"testOne\": 1.0, \"testZero\": 1}"
+      , "{\"testZero\": 1}"
+      , "{\"tag\": \"record\", \"testone\": true, \"testtwo\": null, \"testthree\": null}"
+      ]
+
+  , testWithFoo "Foo (reject unknown fields)"
+      (select
+        thFooParseJSONRejectUnknownFields
+        gFooParseJSONRejectUnknownFields)
+      [ "{\"tag\": \"foo\"}"
+      ]
+
+  , testWithFoo "Foo (reject unknown fields, tagged single)"
+      (select
+        thFooParseJSONRejectUnknownFieldsTagged
+        gFooParseJSONRejectUnknownFieldsTagged)
+      [ "{\"tag\": \"foo\", \"unknownField\": 0}"
+      ]
+
   , testWith "EitherTextInt"
       (select
         thEitherTextIntParseJSONUntaggedValue
@@ -196,3 +219,6 @@ testFor name _ = testWith name (parseJSON :: Value -> Parser a)
 
 testWithSomeType :: String -> (Value -> Parser (SomeType Int)) -> [L.ByteString] -> Output
 testWithSomeType = testWith
+
+testWithFoo :: String -> (Value -> Parser Foo) -> [L.ByteString] -> Output
+testWithFoo = testWith

--- a/tests/Instances.hs
+++ b/tests/Instances.hs
@@ -29,7 +29,7 @@ import Data.Hashable.Time ()
 -- "System" types.
 
 instance Arbitrary DotNetTime where
-    arbitrary = DotNetTime `liftM` arbitrary
+    arbitrary = DotNetTime `fmap` arbitrary
     shrink = map DotNetTime . shrink . fromDotNetTime
 
 -- | Compare timezone part only on 'timeZoneMinutes'

--- a/tests/Options.hs
+++ b/tests/Options.hs
@@ -55,3 +55,14 @@ optsOptionField = optsDefault
                   { fieldLabelModifier = const "field"
                   , omitNothingFields = True
                   }
+
+optsRejectUnknownFields :: Options
+optsRejectUnknownFields = optsDefault
+                          { rejectUnknownFields = True
+                          }
+
+optsRejectUnknownFieldsTagged :: Options
+optsRejectUnknownFieldsTagged = optsDefault
+                                { rejectUnknownFields = True
+                                , tagSingleConstructors = True
+                                }

--- a/tests/golden/generic.expected
+++ b/tests/golden/generic.expected
@@ -31,6 +31,14 @@ Error in $: parsing Types.SomeType failed, expected a 2-element Array, but encou
 Error in $: parsing Types.SomeType failed, expected Array, but encountered Object
 Error in $: not enough input. Expecting ',' or ']'
 Error in $: not enough input. Expecting json list value
+SomeType (reject unknown fields)
+Error in $: parsing Types.SomeType(Record) failed, unknown fields: ["testZero"]
+Error in $: parsing Types.SomeType failed, expected Object with key "tag" containing one of ["nullary","unary","product","record","list"], key "tag" not found
+Error in $: parsing Types.SomeType(Record) failed, unknown fields: ["testtwo","testone","testthree"]
+Foo (reject unknown fields)
+Error in $: parsing Types.Foo(Foo) failed, unknown fields: ["tag"]
+Foo (reject unknown fields, tagged single)
+Error in $: parsing Types.Foo(Foo) failed, unknown fields: ["unknownField"]
 EitherTextInt
 Error in $: parsing Types.EitherTextInt(NoneNullary) failed, expected tag "nonenullary", but found tag "X"
 Error in $: parsing Types.EitherTextInt(NoneNullary) failed, expected String, but encountered Array


### PR DESCRIPTION
This implements #207, and supports both TH and Generics. The Generics implementation is not particularly efficient, but as the cost of traversing the datatype twice is strictly compile-time, this should be acceptable.