### PR TITLE
Add more informative parsing error message

### DIFF
--- a/tests/Instances.hs
+++ b/tests/Instances.hs
@@ -29,7 +29,7 @@ import Data.Hashable.Time ()
 -- "System" types.
 
 instance Arbitrary DotNetTime where
-    arbitrary = DotNetTime `liftM` arbitrary
+    arbitrary = DotNetTime `fmap` arbitrary
     shrink = map DotNetTime . shrink . fromDotNetTime
 
 -- | Compare timezone part only on 'timeZoneMinutes'


### PR DESCRIPTION
IMO it helps a bit to pinpoint the json part that failed to parse. I just used the information we already have to add slightly more informative error message when using `eitherDecode`.
So for this piece of json where there is a missing `,` before `postal_code` :
```
  {
    "data": {
      "city": "Malakoff",
      "country": null
      "postal_code": "14236",
      "region": "NY",
      "street": "2992 Cameron Road"
    },
    "primary": true
  }

```
We would get:

 `Left "Error in $: Failed reading: satisfy. Expecting object value"`

And with this small improvement, we get:

`Error in $: Failed reading: satisfy. Expecting object value before the line 'postal_code:'`