### PR TITLE
Optimize jstring for the common case when unescaping is not needed

### DIFF
--- a/Data/Aeson/Parser/Internal.hs
+++ b/Data/Aeson/Parser/Internal.hs
@@ -2,9 +2,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
-#if MIN_VERSION_ghc_prim(0,3,1)
-{-# LANGUAGE MagicHash #-}
-#endif
 #if __GLASGOW_HASKELL__ <= 710 && __GLASGOW_HASKELL__ >= 706
 -- Work around a compiler bug
 {-# OPTIONS_GHC -fsimpl-tick-factor=200 #-}
@@ -61,6 +58,7 @@ import Data.Functor.Compat (($>))
 import Data.Bits (testBit)
 import Data.Scientific (Scientific)
 import Data.Text (Text)
+import qualified Data.Text.Encoding as TE
 import Data.Vector (Vector)
 import qualified Data.Vector as Vector (empty, fromList, fromListN, reverse)
 import qualified Data.Attoparsec.ByteString as A
@@ -71,12 +69,6 @@ import qualified Data.ByteString.Lazy as L
 import qualified Data.HashMap.Strict as H
 import qualified Data.Scientific as Sci
 import Data.Aeson.Parser.Unescape (unescapeText)
-
-#if MIN_VERSION_ghc_prim(0,3,1)
-import GHC.Base (Int#, (==#), isTrue#, word2Int#, orI#, andI#)
-import GHC.Word (Word8(W8#))
-import qualified Data.Text.Encoding as TE
-#endif
 
 #define BACKSLASH 92
 #define CLOSE_CURLY 125
@@ -336,34 +328,6 @@ jstring_ = do
 jstringSlow :: B.ByteString -> Parser Text
 {-# INLINE jstringSlow #-}
 jstringSlow s' = {-# SCC "jstringSlow" #-} do
-#if MIN_VERSION_ghc_prim(0,3,1)
-  (s, S _ escaped) <- A.runScanner startState go <* A.anyWord8
-  -- We escape only if there are
-  -- non-ascii (over 7bit) characters or backslash present.
-  --
-  -- Note: if/when text will have fast ascii -> text conversion
-  -- (e.g. uses utf8 encoding) we can have further speedup.
-  if isTrue# escaped
-    then case unescapeText (s' <> s) of
-      Right r  -> return r
-      Left err -> fail $ show err
-    else return (TE.decodeUtf8 (s' <> s))
- where
-    startState              = S 0# 0#
-    go (S skip escaped) (W8# c)
-      | isTrue# skip        = Just (S 0# escaped')
-      | isTrue# (w ==# 34#) = Nothing   -- double quote
-      | otherwise           = Just (S skip' escaped')
-      where
-        w = word2Int# c
-        skip' = w ==# 92# -- backslash
-        escaped' = escaped
-            `orI#` (w `andI#` 0x80# ==# 0x80#) -- c >= 0x80
-            `orI#` skip'
-            `orI#` (w `andI#` 0x1f# ==# w)     -- c < 0x20
-
-data S = S Int# Int#
-#else
   s <- A.scan startState go <* A.anyWord8
   case unescapeText (s' <> s) of
     Right r  -> return r
@@ -376,7 +340,6 @@ data S = S Int# Int#
       | otherwise = let a' = c == backslash
                     in Just a'
       where backslash = BACKSLASH
-#endif
 
 decodeWith :: Parser Value -> (Value -> Result a) -> L.ByteString -> Maybe a
 decodeWith p to s =

--- a/Data/Aeson/Parser/Internal.hs
+++ b/Data/Aeson/Parser/Internal.hs
@@ -322,14 +322,14 @@ jstring_ = do
   w <- A.peekWord8
   case w of
     Nothing -> fail "string without end"
-    Just DOUBLE_QUOTE -> A.anyWord8 *> return txt
+    Just DOUBLE_QUOTE -> A.anyWord8 $> txt
     _ -> jstringSlow s
 
 jstringSlow :: B.ByteString -> Parser Text
 {-# INLINE jstringSlow #-}
 jstringSlow s' = {-# SCC "jstringSlow" #-} do
   s <- A.scan startState go <* A.anyWord8
-  case unescapeText (s' <> s) of
+  case unescapeText (B.append s' s) of
     Right r  -> return r
     Left err -> fail $ show err
  where

--- a/Data/Aeson/Parser/Internal.hs
+++ b/Data/Aeson/Parser/Internal.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 #if __GLASGOW_HASKELL__ <= 710 && __GLASGOW_HASKELL__ >= 706
 -- Work around a compiler bug
-{-# OPTIONS_GHC -fsimpl-tick-factor=200 #-}
+{-# OPTIONS_GHC -fsimpl-tick-factor=300 #-}
 #endif
 -- |
 -- Module:      Data.Aeson.Parser.Internal


### PR DESCRIPTION
We were recently discussing at @typeable possible optimizations in aeson. Here is the first patch we came up.

The `jstring_` function already tries to avoid unnecessary call to `unescapeText`, but it's beneficial to make one step further and separate the common path (when unescaping is not needed) from the slow path (when unescaping is needed). That way we can use the simple and fast algorithm for the common path and fall back to the slower one if necessary.

As a side benefit, I removed the hand optimized manually unboxed version of the code. Now we don't need to keep track of the `escaped` flag, because we already know unescaping will be needed in the slow path. So the simpler version is as fast as the hand optimized one.

I used the `bench-parse.py` for benchmarking. Here are the results on my computer. Before:

```
    json-data/twitter1.json :: 60000 times
      0.719 seconds, 83474 parses/sec, 68.064 MB/sec
    json-data/twitter1.json :: 60000 times
      0.742 seconds, 80907 parses/sec, 65.971 MB/sec
    json-data/twitter1.json :: 60000 times
      0.727 seconds, 82523 parses/sec, 67.289 MB/sec
0.8 KB: 83474 msg\/sec (68.1 MB\/sec)
    json-data/twitter10.json :: 13000 times
      0.945 seconds, 13754 parses/sec, 86.495 MB/sec
    json-data/twitter10.json :: 13000 times
      0.879 seconds, 14782 parses/sec, 92.963 MB/sec
    json-data/twitter10.json :: 13000 times
      0.883 seconds, 14728 parses/sec, 92.622 MB/sec
6.4 KB: 14783 msg\/sec (93.0 MB\/sec)
    json-data/twitter20.json :: 7500 times
      1.030 seconds, 7280 parses/sec, 83.793 MB/sec
    json-data/twitter20.json :: 7500 times
      0.993 seconds, 7550 parses/sec, 86.893 MB/sec
    json-data/twitter20.json :: 7500 times
      1.019 seconds, 7357 parses/sec, 84.683 MB/sec
11.8 KB: 7550 msg\/sec (86.9 MB\/sec)
    json-data/twitter50.json :: 2500 times
      0.925 seconds, 2701 parses/sec, 82.318 MB/sec
    json-data/twitter50.json :: 2500 times
      0.934 seconds, 2676 parses/sec, 81.554 MB/sec
    json-data/twitter50.json :: 2500 times
      0.920 seconds, 2718 parses/sec, 82.837 MB/sec
31.2 KB: 2719 msg\/sec (82.8 MB\/sec)
    json-data/twitter100.json :: 1000 times
      0.818 seconds, 1222 parses/sec, 73.464 MB/sec
    json-data/twitter100.json :: 1000 times
      0.817 seconds, 1224 parses/sec, 73.569 MB/sec
    json-data/twitter100.json :: 1000 times
      0.847 seconds, 1180 parses/sec, 70.914 MB/sec
61.5 KB: 1225 msg\/sec (73.6 MB\/sec)
    json-data/jp10.json :: 4000 times
      0.773 seconds, 5174 parses/sec, 73.932 MB/sec
    json-data/jp10.json :: 4000 times
      0.759 seconds, 5267 parses/sec, 75.274 MB/sec
    json-data/jp10.json :: 4000 times
      0.762 seconds, 5252 parses/sec, 75.049 MB/sec
14.6 KB: 5268 msg\/sec (75.3 MB\/sec)
    json-data/jp50.json :: 1200 times
      0.774 seconds, 1549 parses/sec, 66.718 MB/sec
    json-data/jp50.json :: 1200 times
      0.787 seconds, 1523 parses/sec, 65.606 MB/sec
    json-data/jp50.json :: 1200 times
      0.794 seconds, 1511 parses/sec, 65.053 MB/sec
44.1 KB: 1550 msg\/sec (66.7 MB\/sec)
    json-data/jp100.json :: 700 times
      0.888 seconds, 788 parses/sec, 63.792 MB/sec
    json-data/jp100.json :: 700 times
      0.888 seconds, 788 parses/sec, 63.810 MB/sec
    json-data/jp100.json :: 700 times
      0.887 seconds, 788 parses/sec, 63.856 MB/sec
82.9 KB: 789 msg\/sec (63.9 MB\/sec)
```

And after:

```
    json-data/twitter1.json :: 60000 times
      0.582 seconds, 103054 parses/sec, 84.030 MB/sec
    json-data/twitter1.json :: 60000 times
      0.561 seconds, 106931 parses/sec, 87.191 MB/sec
    json-data/twitter1.json :: 60000 times
      0.565 seconds, 106132 parses/sec, 86.540 MB/sec
0.8 KB: 106932 msg\/sec (87.2 MB\/sec)
    json-data/twitter10.json :: 13000 times
      0.599 seconds, 21705 parses/sec, 136.496 MB/sec
    json-data/twitter10.json :: 13000 times
      0.603 seconds, 21557 parses/sec, 135.566 MB/sec
    json-data/twitter10.json :: 13000 times
      0.602 seconds, 21581 parses/sec, 135.713 MB/sec
6.4 KB: 21706 msg\/sec (136.5 MB\/sec)
    json-data/twitter20.json :: 7500 times
      0.730 seconds, 10273 parses/sec, 118.232 MB/sec
    json-data/twitter20.json :: 7500 times
      0.708 seconds, 10597 parses/sec, 121.965 MB/sec
    json-data/twitter20.json :: 7500 times
      0.716 seconds, 10474 parses/sec, 120.555 MB/sec
11.8 KB: 10597 msg\/sec (122.0 MB\/sec)
    json-data/twitter50.json :: 2500 times
      0.675 seconds, 3704 parses/sec, 112.881 MB/sec
    json-data/twitter50.json :: 2500 times
      0.665 seconds, 3756 parses/sec, 114.463 MB/sec
    json-data/twitter50.json :: 2500 times
      0.673 seconds, 3714 parses/sec, 113.172 MB/sec
31.2 KB: 3757 msg\/sec (114.5 MB\/sec)
    json-data/twitter100.json :: 1000 times
      0.627 seconds, 1595 parses/sec, 95.829 MB/sec
    json-data/twitter100.json :: 1000 times
      0.641 seconds, 1560 parses/sec, 93.741 MB/sec
    json-data/twitter100.json :: 1000 times
      0.629 seconds, 1589 parses/sec, 95.482 MB/sec
61.5 KB: 1595 msg\/sec (95.8 MB\/sec)
    json-data/jp10.json :: 4000 times
      0.574 seconds, 6964 parses/sec, 99.514 MB/sec
    json-data/jp10.json :: 4000 times
      0.580 seconds, 6894 parses/sec, 98.518 MB/sec
    json-data/jp10.json :: 4000 times
      0.591 seconds, 6771 parses/sec, 96.752 MB/sec
14.6 KB: 6964 msg\/sec (99.5 MB\/sec)
    json-data/jp50.json :: 1200 times
      0.627 seconds, 1914 parses/sec, 82.421 MB/sec
    json-data/jp50.json :: 1200 times
      0.615 seconds, 1951 parses/sec, 84.032 MB/sec
    json-data/jp50.json :: 1200 times
      0.616 seconds, 1946 parses/sec, 83.815 MB/sec
44.1 KB: 1952 msg\/sec (84.0 MB\/sec)
    json-data/jp100.json :: 700 times
      0.745 seconds, 939 parses/sec, 76.047 MB/sec
    json-data/jp100.json :: 700 times
      0.720 seconds, 972 parses/sec, 78.692 MB/sec
    json-data/jp100.json :: 700 times
      0.744 seconds, 941 parses/sec, 76.174 MB/sec
82.9 KB: 972 msg\/sec (78.7 MB\/sec)
```

The speedup is up to 45% (in `json-data/twitter10.json`) and varies somewhere between 15% and 30%.