### PR TITLE
Expose Data.Aeson.Types.Internal

### DIFF
--- a/aeson.cabal
+++ b/aeson.cabal
@@ -82,6 +82,7 @@ library
     Data.Aeson.Internal
     Data.Aeson.Internal.Time
     Data.Aeson.Parser.Internal
+    Data.Aeson.Types.Internal
 
   -- Deprecated modules
   exposed-modules:
@@ -96,7 +97,6 @@ library
     Data.Aeson.Types.Generic
     Data.Aeson.Types.ToJSON
     Data.Aeson.Types.Class
-    Data.Aeson.Types.Internal
     Data.Attoparsec.Time
     Data.Attoparsec.Time.Internal
 


### PR DESCRIPTION
I'd like to expose `Data.Aeson.Types.Internal`. The main reason for doing this is to be able to use [`iparse`](https://github.com/bos/aeson/blob/33e0acdd02fde1029cc6c9dd6484cefb00d19a8c/Data/Aeson/Types/Internal.hs#L444-L447) which is useful because it gives the caller access to the `JSONPath` for any errors encountered.

Alternatively [`iparse`](https://github.com/bos/aeson/blob/33e0acdd02fde1029cc6c9dd6484cefb00d19a8c/Data/Aeson/Types/Internal.hs#L444-L447) and [`IResult`](https://github.com/bos/aeson/blob/33e0acdd02fde1029cc6c9dd6484cefb00d19a8c/Data/Aeson/Types/Internal.hs#L127-L130) could both be exported from `Data.Aeson.Types`, but it seems like these lower level functions are better exported from a module clearly marked as internal since the API may not be stable. There is also a precedent for [exposing internal modules](https://github.com/bos/aeson/blob/33e0acdd02fde1029cc6c9dd6484cefb00d19a8c/aeson.cabal#L81-L84) so this option seemed best to me.