### PR TITLE
MonadFail-less failing

### DIFF
--- a/Data/Aeson/Types.hs
+++ b/Data/Aeson/Types.hs
@@ -35,6 +35,7 @@ module Data.Aeson.Types
     , parse
     , parseEither
     , parseMaybe
+    , parseFail
     , ToJSON(..)
     , KeyValue(..)
     , modifyFailure

--- a/Data/Aeson/Types/Internal.hs
+++ b/Data/Aeson/Types/Internal.hs
@@ -346,7 +346,6 @@ instance Monoid (Parser a) where
 -- | Raise a parsing failure with some custom message.
 parseFail :: String -> Parser a
 parseFail = fail
-{-# INLINE parseFail #-}
 
 apP :: Parser (a -> b) -> Parser a -> Parser b
 apP d e = do

--- a/Data/Aeson/Types/Internal.hs
+++ b/Data/Aeson/Types/Internal.hs
@@ -44,6 +44,7 @@ module Data.Aeson.Types.Internal
     , parse
     , parseEither
     , parseMaybe
+    , parseFail
     , modifyFailure
     , prependFailure
     , parserThrowError
@@ -341,6 +342,11 @@ instance Monoid (Parser a) where
     {-# INLINE mempty #-}
     mappend = (<>)
     {-# INLINE mappend #-}
+
+-- | Raise a parsing failure with some custom message.
+parseFail :: String -> Parser a
+parseFail = fail
+{-# INLINE parseFail #-}
 
 apP :: Parser (a -> b) -> Parser a -> Parser b
 apP d e = do


### PR DESCRIPTION
This PR introduces the combinator `parseFail` which allows downstream users to signal a failure without interacting with `MonadFail`. Yes, it is implemented in terms of `fail`, but that's not something that the user needs to know, and it's free to be changed in future.

This brings the `Parser` type from `aeson` in line with similar `Parser` types from other libraries. 