### PR TITLE
Implement liftTyped in the Lift Value instance

### DIFF
--- a/Data/Aeson/Types/Internal.hs
+++ b/Data/Aeson/Types/Internal.hs
@@ -425,6 +425,9 @@ instance TH.Lift Value where
       where a' = V.toList a
     lift (Object o) = [| Object (H.fromList . map (first pack) $ o') |]
       where o' = map (first unpack) . H.toList $ o
+#if MIN_VERSION_template_haskell(2,16,0)
+    liftTyped = TH.unsafeTExpCoerce . TH.lift
+#endif
 
 -- | The empty array.
 emptyArray :: Value

--- a/aeson.cabal
+++ b/aeson.cabal
@@ -106,8 +106,8 @@ library
     bytestring       >= 0.10.4.0 && < 0.11,
     containers       >= 0.5.5.1 && < 0.7,
     deepseq          >= 1.3.0.0 && < 1.5,
-    ghc-prim         >= 0.2     && < 0.6,
-    template-haskell >= 2.9.0.0 && < 2.16,
+    ghc-prim         >= 0.2     && < 0.7,
+    template-haskell >= 2.9.0.0 && < 2.17,
     text             >= 1.2.3.0 && < 1.3,
     time             >= 1.4     && < 1.10
 


### PR DESCRIPTION
When building `aeson` with GHC 8.10.1, I get the following warning:

```
[ 5 of 24] Compiling Data.Aeson.Types.Internal ( Data/Aeson/Types/Internal.hs, /home/rgscott/Documents/Hacking/Haskell/aeson/dist-newstyle/build/x86_64-linux/ghc-8.10.1/aeson-1.4.7.0/build/Data/Aeson/Types/Internal.o, /home/rgscott/Documents/Hacking/Haskell/aeson/dist-newstyle/build/x86_64-linux/ghc-8.10.1/aeson-1.4.7.0/build/Data/Aeson/Types/Internal.dyn_o )

Data/Aeson/Types/Internal.hs:415:10: warning: [-Wmissing-methods]
    • No explicit implementation for
        ‘TH.liftTyped’
    • In the instance declaration for ‘TH.Lift Value’
    |
415 | instance TH.Lift Value where
    |          ^^^^^^^^^^^^^
```

This is because `template-haskell-2.16.0.0` introduced the `liftTyped` method to the `Lift`. Normally, this method would be filled in by `DeriveLift`, but the `Lift Value` instance is hand-written. In such a scenario, the simplest, most backwards-compatible solution is to implement `liftTyped` as `unsafeTExpCoerce . lift`. The use of `unsafeTExpCoerce` here is safe as long as `lift` is implemented correctly. (Which it should be!)