### PR TITLE
Resolve #700. Expose GToJSON.

### DIFF
--- a/Data/Aeson.hs
+++ b/Data/Aeson.hs
@@ -91,6 +91,7 @@ module Data.Aeson
     , FromArgs
     , GToJSON
     , GToEncoding
+    , GToJSON'
     , ToArgs
     , Zero
     , One

--- a/Data/Aeson/Types.hs
+++ b/Data/Aeson/Types.hs
@@ -77,6 +77,7 @@ module Data.Aeson.Types
     , FromArgs
     , GToJSON
     , GToEncoding
+    , GToJSON'
     , ToArgs
     , Zero
     , One

--- a/Data/Aeson/Types/Class.hs
+++ b/Data/Aeson/Types/Class.hs
@@ -39,6 +39,7 @@ module Data.Aeson.Types.Class
     , FromArgs(..)
     , GToJSON
     , GToEncoding
+    , GToJSON'
     , ToArgs(..)
     , Zero
     , One
@@ -100,10 +101,9 @@ module Data.Aeson.Types.Class
 
 import Data.Aeson.Types.FromJSON
 import Data.Aeson.Types.Generic (One, Zero)
-import Data.Aeson.Types.ToJSON hiding (GToJSON)
-import qualified Data.Aeson.Types.ToJSON as ToJSON
+import Data.Aeson.Types.ToJSON
 import Data.Aeson.Types.Internal (Value)
 import Data.Aeson.Encoding (Encoding)
 
-type GToJSON = ToJSON.GToJSON Value
-type GToEncoding = ToJSON.GToJSON Encoding
+type GToJSON = GToJSON' Value
+type GToEncoding = GToJSON' Encoding


### PR DESCRIPTION
Rename the type-class to be `GToJSON'` (with prime),
to avoid name clash with type-aliases GToJSON and GToEncoding

---

This is the second of remaining 1.5 tasks.