### PR TITLE
aeson <-> these swap

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -9,6 +9,10 @@
     name: "Use newtype instead of data"
     within:
       - Data.Aeson.Types.Internal
+- ignore:
+    name: "Use <=<"
+    within:
+      - Data.Aeson.Types.FromJSON
 
 # CPP confuses
 - ignore:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,13 @@
 #
 #   haskell-ci '--config=cabal.haskell-ci' 'cabal.project'
 #
+# To regenerate the script (for example after adjusting tested-with) run
+#
+#   haskell-ci regenerate
+#
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.9.20200406
+# version: 0.10.1
 #
 version: ~> 1.0
 language: c
@@ -98,7 +102,7 @@ install:
   - cat $CABALHOME/config
   - rm -fv cabal.project cabal.project.local cabal.project.freeze
   - travis_retry ${CABAL} v2-update -v
-  - if [ $HCNUMVER -ge 80800 ] && [ $HCNUMVER -lt 81000 ] ; then HLINTVER=$(cd /tmp && (${CABAL} v2-install -v $WITHCOMPILER --dry-run hlint  --constraint='hlint ==2.2.*' |  perl -ne 'if (/\bhlint-(\d+(\.\d+)*)\b/) { print "$1"; last; }')); echo "HLint version $HLINTVER" ; fi
+  - if [ $HCNUMVER -ge 80800 ] && [ $HCNUMVER -lt 81000 ] ; then HLINTVER=$(cd /tmp && (${CABAL} v2-install -v $WITHCOMPILER --dry-run hlint  --constraint='hlint ==3.1.*' |  perl -ne 'if (/\bhlint-(\d+(\.\d+)*)\b/) { print "$1"; last; }')); echo "HLint version $HLINTVER" ; fi
   - "if [ $HCNUMVER -ge 80800 ] && [ $HCNUMVER -lt 81000 ] ; then if [ ! -e $HOME/.hlint/hlint-$HLINTVER/hlint ]; then echo \"Downloading HLint version $HLINTVER\"; mkdir -p $HOME/.hlint; curl --write-out 'Status Code: %{http_code} Redirects: %{num_redirects} Total time: %{time_total} Total Dsize: %{size_download}\\n' --silent --location --output $HOME/.hlint/hlint-$HLINTVER.tar.gz \"https://github.com/ndmitchell/hlint/releases/download/v$HLINTVER/hlint-$HLINTVER-x86_64-linux.tar.gz\"; tar -xzv -f $HOME/.hlint/hlint-$HLINTVER.tar.gz -C $HOME/.hlint; fi ; fi"
   - if [ $HCNUMVER -ge 80800 ] && [ $HCNUMVER -lt 81000 ] ; then mkdir -p $CABALHOME/bin && ln -sf "$HOME/.hlint/hlint-$HLINTVER/hlint" $CABALHOME/bin/hlint ; fi
   - if [ $HCNUMVER -ge 80800 ] && [ $HCNUMVER -lt 81000 ] ; then hlint --version ; fi
@@ -182,5 +186,5 @@ script:
   - cd $TOP || false
   - ${CABAL} v2-build $WITHCOMPILER --project-file=cabal.bench.project all
 
-# REGENDATA ("0.9.20200406",["--config=cabal.haskell-ci","cabal.project"])
+# REGENDATA ("0.10.1",["--config=cabal.haskell-ci","cabal.project"])
 # EOF

--- a/.travis.yml
+++ b/.travis.yml
@@ -120,6 +120,8 @@ install:
   - if [ $HCNUMVER -ge 80200 ] ; then echo 'package aeson-examples' >> cabal.project ; fi
   - "if [ $HCNUMVER -ge 80200 ] ; then echo '  ghc-options: -Werror=missing-methods' >> cabal.project ; fi"
   - |
+    echo "packages: https://oleg.fi/these-1.1.tar.gz"                   >> cabal.project
+    echo "packages: https://oleg.fi/quickcheck-instances-0.3.23.tar.gz" >> cabal.project
   - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | (grep -vE -- '^(aeson|aeson-examples|attoparsec-iso8601)$' || true) | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
   - cat cabal.project || true
   - cat cabal.project.local || true
@@ -157,6 +159,8 @@ script:
   - if [ $HCNUMVER -ge 80200 ] ; then echo 'package aeson-examples' >> cabal.project ; fi
   - "if [ $HCNUMVER -ge 80200 ] ; then echo '  ghc-options: -Werror=missing-methods' >> cabal.project ; fi"
   - |
+    echo "packages: https://oleg.fi/these-1.1.tar.gz"                   >> cabal.project
+    echo "packages: https://oleg.fi/quickcheck-instances-0.3.23.tar.gz" >> cabal.project
   - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | (grep -vE -- '^(aeson|aeson-examples|attoparsec-iso8601)$' || true) | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
   - cat cabal.project || true
   - cat cabal.project.local || true

--- a/aeson.cabal
+++ b/aeson.cabal
@@ -1,5 +1,5 @@
 name:            aeson
-version:         1.5.0.0
+version:         1.5.1.0
 license:         BSD3
 license-file:    LICENSE
 category:        Text, Web, JSON
@@ -148,6 +148,7 @@ library
     hashable             >= 1.2.7.0  && < 1.4,
     scientific           >= 0.3.6.2  && < 0.4,
     th-abstraction       >= 0.2.8.0  && < 0.4,
+    these                >= 1.1      && < 1.2,
     uuid-types           >= 1.0.3    && < 1.1,
     vector               >= 0.12.0.1 && < 0.13
 
@@ -229,12 +230,13 @@ test-suite aeson-tests
     tasty-hunit,
     tasty-quickcheck,
     text,
+    these,
     time,
     time-compat,
     unordered-containers,
     uuid-types,
     vector,
-    quickcheck-instances >= 0.3.21 && <0.4
+    quickcheck-instances >= 0.3.23 && <0.4
 
   if flag(bytestring-builder)
     build-depends: bytestring >= 0.9 && < 0.10.4,

--- a/benchmarks/aeson-benchmarks.cabal
+++ b/benchmarks/aeson-benchmarks.cabal
@@ -25,6 +25,7 @@ library
     , template-haskell
     , text
     , th-abstraction
+    , these
     , time
     , time-compat
     , transformers

--- a/cabal.bench.project
+++ b/cabal.bench.project
@@ -2,3 +2,6 @@ with-compiler: ghc
 packages: benchmarks/
 packages: criterion-compare-txt/
 tests: false
+
+packages: https://oleg.fi/these-1.1.tar.gz
+packages: https://oleg.fi/quickcheck-instances-0.3.23.tar.gz

--- a/cabal.project
+++ b/cabal.project
@@ -3,3 +3,6 @@ packages: .
 packages: attoparsec-iso8601
 packages: examples
 tests: true
+
+packages: https://oleg.fi/these-1.1.tar.gz
+packages: https://oleg.fi/quickcheck-instances-0.3.23.tar.gz

--- a/tests/PropertyRoundTrip.hs
+++ b/tests/PropertyRoundTrip.hs
@@ -12,6 +12,7 @@ import Data.Proxy (Proxy)
 import Data.Ratio (Ratio)
 import Data.Sequence (Seq)
 import Data.Tagged (Tagged)
+import Data.These (These (..))
 import Data.Time (Day, DiffTime, LocalTime, NominalDiffTime, TimeOfDay, UTCTime, ZonedTime)
 import Data.Version (Version)
 import Data.Time.Calendar.Compat (CalendarDiffDays, DayOfWeek)
@@ -64,6 +65,7 @@ roundTripTests =
     , testProperty "Rational" $ roundTripEq (undefined :: Rational)
     , testProperty "Ratio Int" $ roundTripEq (undefined :: Ratio Int)
     , testProperty "UUID" $ roundTripEq UUID.nil
+    , testProperty "These" $ roundTripEq (These 'x' True)
     , roundTripFunctorsTests
     , testGroup "ghcGenerics" [
         testProperty "OneConstructor" $ roundTripEq OneConstructor

--- a/tests/SerializationFormatSpec.hs
+++ b/tests/SerializationFormatSpec.hs
@@ -29,6 +29,7 @@ import Data.List.NonEmpty (NonEmpty(..))
 import Data.Proxy (Proxy(..))
 import Data.Scientific (Scientific)
 import Data.Tagged (Tagged(..))
+import Data.These (These (..))
 import Data.Time (fromGregorian)
 import Data.Time.Calendar.Compat (CalendarDiffDays (..), DayOfWeek (..))
 import Data.Time.LocalTime.Compat (CalendarDiffTime (..))
@@ -208,6 +209,15 @@ jsonExamples =
     [ "{\"months\":12,\"days\":20}", "{\"days\":20,\"months\":12}" ]
     (CalendarDiffDays 12 20)
   , example "DayOfWeek" "\"monday\"" Monday
+
+  -- these
+  , example "These: This" "{\"This\":\"x\"}" (This 'x'   :: These Char Bool)
+  , example "These: That" "{\"That\":true}"  (That True  :: These Char Bool)
+  , ndExample "These"
+    [ "{\"This\":\"y\",\"That\":false}"
+    , "{\"That\":false,\"This\":\"y\"}"
+    ]
+    (These 'y' False)
   ]
 
 jsonEncodingExamples :: [Example]


### PR DESCRIPTION
Resolves #776

The additions to `cabal.project` are temporary, can be removed after releases are done.

---

|             | aeson <1.5.1.0                                         | aeson >= 1.5.1.0         |
|-------------|--------------------------------------------------------|--------------------------|
| these <1.1  | instance in these                                      | impossible configuration |
| these >=1.1 | no aeson instance, these major bump indicates breakage | instance in aeson        |

![deps2](https://user-images.githubusercontent.com/51087/82839115-f4794680-9ed6-11ea-9610-9d165305697e.png)

---

Corresponding PRs:
- https://github.com/isomorphism/these/pull/143
- https://github.com/phadej/qc-instances/pull/51