### PR TITLE
Bumps dlist upper bound

### DIFF
--- a/aeson.cabal
+++ b/aeson.cabal
@@ -136,7 +136,7 @@ library
   -- Other dependencies
   build-depends:
     attoparsec           >= 0.13.2.2 && < 0.14,
-    dlist                >= 0.8.0.4  && < 0.9,
+    dlist                >= 0.8.0.4  && < 1.1,
     hashable             >= 1.2.7.0  && < 1.4,
     primitive            >= 0.7.0.1  && < 0.8,
     scientific           >= 0.3.6.2  && < 0.4,


### PR DESCRIPTION
This seems to compile without issue locally, but I haven't exhaustively compared the changelog with what `aeson` uses to see if there's something deeper going on.