### PR TITLE
Support template-haskell 2.17.

### DIFF
--- a/Data/Aeson/Types/Internal.hs
+++ b/Data/Aeson/Types/Internal.hs
@@ -427,7 +427,7 @@ instance TH.Lift Value where
     lift (Object o) = [| Object (H.fromList . map (first pack) $ o') |]
       where o' = map (first unpack) . H.toList $ o
 #if MIN_VERSION_template_haskell(2,17,0)
-    liftTyped = TH.Code . TH.unsafeTExpCoerce . TH.lift
+    liftTyped = TH.unsafeCodeCoerce . TH.lift
 #elif MIN_VERSION_template_haskell(2,16,0)
     liftTyped = TH.unsafeTExpCoerce . TH.lift
 #endif

--- a/Data/Aeson/Types/Internal.hs
+++ b/Data/Aeson/Types/Internal.hs
@@ -426,7 +426,9 @@ instance TH.Lift Value where
       where a' = V.toList a
     lift (Object o) = [| Object (H.fromList . map (first pack) $ o') |]
       where o' = map (first unpack) . H.toList $ o
-#if MIN_VERSION_template_haskell(2,16,0)
+#if MIN_VERSION_template_haskell(2,17,0)
+    liftTyped = TH.Code . TH.unsafeTExpCoerce . TH.lift
+#elif MIN_VERSION_template_haskell(2,16,0)
     liftTyped = TH.unsafeTExpCoerce . TH.lift
 #endif
 

--- a/aeson.cabal
+++ b/aeson.cabal
@@ -103,8 +103,8 @@ library
     bytestring       >= 0.10.4.0 && < 0.11,
     containers       >= 0.5.5.1 && < 0.7,
     deepseq          >= 1.3.0.0 && < 1.5,
-    ghc-prim         >= 0.2     && < 0.7,
-    template-haskell >= 2.9.0.0 && < 2.17,
+    ghc-prim         >= 0.2     && < 0.8,
+    template-haskell >= 2.9.0.0 && < 2.18,
     text             >= 1.2.3.0 && < 1.3,
     time             >= 1.4     && < 1.11
 


### PR DESCRIPTION
The new version of `template-haskell` released with GHC 9 added a `Code` newtype (https://gitlab.haskell.org/ghc/ghc/-/merge_requests/3358).  This package builds under GHC 9.0.1-alpha1 with this change.

I'm not able to run the tests because `tasty-quickcheck` doesn't build under GHC 9 because of other TH type changes, but this change is pretty straightforward (and should not affect end users).