### PR TITLE
Use Text.Encoding.decodeLatin1 for decoding ASCII strings

### DIFF
--- a/Data/Aeson/Parser/Internal.hs
+++ b/Data/Aeson/Parser/Internal.hs
@@ -322,7 +322,7 @@ jstring_ = do
   -- not sure whether >= or bit hackery is faster
   -- perfectly, we shouldn't care, it's compiler job.
   s <- A.takeWhile (\w -> w /= DOUBLE_QUOTE && w /= BACKSLASH && w >= 0x20 && w < 0x80)
-  let txt = TE.decodeUtf8 s
+  let txt = TE.decodeLatin1 s
   mw <- A.peekWord8
   case mw of
     Nothing           -> fail "string without end"


### PR DESCRIPTION
According to the original decodeLatin1 PR https://github.com/haskell/text/pull/18 it's significantly faster than the currently used decodeUtf8 at decoding ASCII.

```
Benchmark                             baseline2  treatment2
Examples/decode/github-issues/lazy      2.35e-3     2.15e-3  -8.63%
Examples/decode/github-issues/strict    2.08e-3     2.04e-3  -2.18%
Examples/decode/jp100/lazy              2.51e-3     2.32e-3  -7.57%
Examples/decode/jp100/strict            2.40e-3     2.39e-3  -0.51%
Examples/decode/twitter100/lazy         1.76e-3     1.65e-3  -6.65%
Examples/decode/twitter100/strict       1.75e-3     1.63e-3  -6.60%
zzz-geom-mean                           2.12e-3     2.00e-3  -5.40%
```