### PR TITLE
Make equally many Map benchmarks

### DIFF
--- a/benchmarks/aeson-benchmarks.cabal
+++ b/benchmarks/aeson-benchmarks.cabal
@@ -52,6 +52,8 @@ library
   if !impl(ghc >=8.6)
     build-depends: contravariant
 
+  cpp-options: -DUSE_ORDEREDMAP=1
+
   ghc-options:      -Wall
   cpp-options:      -DGENERICS
   exposed-modules:

--- a/benchmarks/bench/AesonMap.hs
+++ b/benchmarks/bench/AesonMap.hs
@@ -159,10 +159,14 @@ benchDecodeMap
     -> LBS.ByteString
     -> Benchmark
 benchDecodeMap name val = bgroup name
-    [  bench "Text"           $ nf (decodeMap proxyText) val
-    ,  bench "Identity"       $ nf (decodeMap proxyT1)   val
-    ,  bench "Coerce"         $ nf (decodeMap proxyT2)   val
-    ,  bench "Parser"         $ nf (decodeMap proxyT3)   val
+    [  bench "Text"            $ nf (decodeMap proxyText) val
+    ,  bench "Identity"        $ nf (decodeMap proxyT1)   val
+    ,  bench "Coerce"          $ nf (decodeMap proxyT2)   val
+    ,  bench "Parser"          $ nf (decodeMap proxyT3)   val
+    ,  bench "Tagged Text"     $ nf (decodeMap $ proxyTagged proxyText) val
+    ,  bench "Tagged Identity" $ nf (decodeMap $ proxyTagged proxyT1)   val
+    ,  bench "Tagged Coerce"   $ nf (decodeMap $ proxyTagged proxyT2)   val
+    ,  bench "Tagged Parser"   $ nf (decodeMap $ proxyTagged proxyT3)   val
     ]
 
 benchEncodeHM

--- a/src/Data/Aeson/Types/FromJSON.hs
+++ b/src/Data/Aeson/Types/FromJSON.hs
@@ -1860,7 +1860,9 @@ instance (FromJSONKey k, Ord k) => FromJSON1 (M.Map k) where
                 Just Coercion -> uc . M.traverseWithKey (\k v -> p v <?> Key k) . KM.toMap
         FromJSONKeyText f -> withObject "Map" (text f)
         FromJSONKeyTextParser f -> withObject "Map" $
-            KM.foldrWithKey (\k v m -> M.insert <$> f (Key.toText k) <?> Key k <*> p v <?> Key k <*> m) (pure M.empty)
+            KM.foldrWithKey
+                (\k v m -> M.insert <$> f (Key.toText k) <?> Key k <*> p v <?> Key k <*> m)
+                (pure M.empty)
         FromJSONKeyValue f -> withArray "Map" $ \arr ->
             fmap M.fromList . Tr.sequence .
                 zipWith (parseIndexedJSONPair f p) [0..] . V.toList $ arr
@@ -1945,9 +1947,9 @@ instance (FromJSONKey k, Eq k, Hashable k) => FromJSON1 (H.HashMap k) where
                 Just Coercion -> uc . H.traverseWithKey (\k v -> p v <?> Key k) . KM.toHashMap
         FromJSONKeyText f -> withObject "HashMap" (text f)
         FromJSONKeyTextParser f -> withObject "HashMap" $
-          H.foldrWithKey
-            (\k v m -> H.insert <$> f (Key.toText k) <?> Key k <*> p v <?> Key k <*> m) (pure H.empty)
-            . KM.toHashMap
+            KM.foldrWithKey
+                (\k v m -> H.insert <$> f (Key.toText k) <?> Key k <*> p v <?> Key k <*> m)
+                (pure H.empty)
         FromJSONKeyValue f -> withArray "Map" $ \arr ->
             fmap H.fromList . Tr.sequence .
                 zipWith (parseIndexedJSONPair f p) [0..] . V.toList $ arr


### PR DESCRIPTION
```
Benchmark                                            hash-map  hash-map-O2       ordered-map 
Geometric mean                                       0.777e-4  0.743e-4  -4.39%  0.824e-4  +6.03%
```

The `hash-map-O2` is using:

```
package aeson-benchmarks
  ghc-options: -O2 -fexpose-all-unfoldings -fspecialise-aggressively
```

and the speedup is around what was lost by removing `INLINE` pragmas.

The ordered-map setup is 6% slower based on benchmarks we have. This is very much acceptable, as the behavior is more deterministic (performance and also ordering wise). People who need to squeeze all the possible performance can turn the default `ordered-map` off, and use the optimization flags specified above.

EDIT: it's surprising that 

```
maps/decode/Map/100/Parser                           0.510e-4  0.477e-4  -6.50%  0.620e-4 +21.42%
```

is slower. Maybe we have some silly mistake.

EDIT: these measurements are done on a very noisy machine, so individual benchmark numbers fluctuate a lot.

---

The complete results

```
INFO: Comparing runs: hash-map hash-map-O2 ordered-map
RUN: criterion-cmp .bench-results/hash-map.csv .bench-results/hash-map-O2.csv .bench-results/ordered-map.csv
Benchmark                                            hash-map  hash-map-O2       ordered-map     
AutoBench/BigProduct/encode/generic                  0.644e-6  0.660e-6  +2.48%  0.654e-6  +1.44%
AutoBench/BigProduct/encode/th                       0.346e-6  0.396e-6 +14.27%  0.359e-6  +3.71%
AutoBench/BigProduct/fromJSON/generic                0.574e-5  0.602e-5  +4.92%  0.600e-5  +4.48%
AutoBench/BigProduct/fromJSON/th                     0.390e-5  0.394e-5  +1.09%  0.422e-5  +8.40%
AutoBench/BigProduct/toJSON/generic                  0.540e-6  0.471e-6 -12.78%  0.569e-6  +5.34%
AutoBench/BigProduct/toJSON/th                       0.340e-6  0.369e-6  +8.41%  0.355e-6  +4.43%
AutoBench/BigRecord/encode/generic                   1.426e-6  1.517e-6  +6.35%  1.546e-6  +8.41%
AutoBench/BigRecord/encode/th                        1.362e-6  1.427e-6  +4.78%  1.451e-6  +6.57%
AutoBench/BigRecord/fromJSON/generic                 0.657e-5  0.644e-5  -1.94%  0.840e-5 +27.82%
AutoBench/BigRecord/fromJSON/th                      0.599e-5  0.602e-5  +0.53%  0.742e-5 +23.96%
AutoBench/BigRecord/toJSON/generic                   2.229e-6  2.233e-6  +0.17%  1.929e-6 -13.43%
AutoBench/BigRecord/toJSON/th                        2.084e-6  2.029e-6  -2.66%  1.634e-6 -21.58%
AutoBench/BigSum/encode/generic                      1.520e-7  1.492e-7  -1.84%  1.541e-7  +1.33%
AutoBench/BigSum/encode/th                           1.375e-7  1.434e-7  +4.28%  1.415e-7  +2.89%
AutoBench/BigSum/fromJSON/generic                    1.270e-6  1.047e-6 -17.58%  1.266e-6  -0.32%
AutoBench/BigSum/fromJSON/th                         2.025e-7  2.208e-7  +9.05%  1.841e-7  -9.11%
AutoBench/BigSum/toJSON/generic                      0.339e-7  0.320e-7  -5.56%  0.320e-7  -5.57%
AutoBench/BigSum/toJSON/th                           0.834e-8  0.831e-8  -0.41%  0.836e-8  +0.28%
AutoBench/D/encode/generic                           0.511e-5  0.477e-5  -6.59%  0.518e-5  +1.46%
AutoBench/D/encode/th                                0.485e-5  0.468e-5  -3.61%  0.487e-5  +0.40%
AutoBench/D/fromJSON/generic                         0.613e-5  0.631e-5  +2.96%  0.649e-5  +5.80%
AutoBench/D/fromJSON/th                              1.982e-6  2.011e-6  +1.47%  2.097e-6  +5.80%
AutoBench/D/toJSON/generic                           0.462e-5  0.450e-5  -2.57%  0.470e-5  +1.91%
AutoBench/D/toJSON/th                                0.450e-5  0.441e-5  -2.12%  0.466e-5  +3.50%
CompareEncodeTwitter/aeson                           1.669e-4  1.739e-4  +4.22%  1.671e-4  +0.15%
CompareEncodeTwitter/buffer-builder                  1.603e-4  1.371e-4 -14.46%  1.615e-4  +0.74%
CompareEncodeUserList/aeson                          0.622e-3  0.651e-3  +4.69%  0.651e-3  +4.67%
CompareEncodeUserList/buffer-builder                 0.324e-3  0.322e-3  -0.61%  0.325e-3  +0.55%
Escape/ascii/ffi                                     0.838e-6  0.838e-6  -0.01%  0.857e-6  +2.29%
Escape/ascii/pure                                    0.387e-5  0.459e-5 +18.44%  0.491e-5 +26.77%
Escape/cyrillic/ffi                                  1.808e-6  1.853e-6  +2.53%  1.887e-6  +4.37%
Escape/cyrillic/pure                                 1.108e-5  1.105e-5  -0.30%  1.343e-5 +21.19%
Examples/decode/github-issues/lazy                   1.784e-3  1.727e-3  -3.17%  2.182e-3 +22.33%
Examples/decode/github-issues/strict                 1.766e-3  1.703e-3  -3.54%  1.994e-3 +12.92%
Integer-decoder/16384/Int                            0.916e-3  0.931e-3  +1.66%  0.964e-3  +5.29%
Integer-decoder/16384/Simple                         0.759e-2  0.750e-2  -1.10%  0.802e-2  +5.65%
Integer-decoder/17/Int                               0.703e-6  0.765e-6  +8.81%  0.731e-6  +3.90%
Integer-decoder/17/Simple                            0.418e-6  0.429e-6  +2.68%  0.425e-6  +1.70%
Integer-decoder/2048/Int                             0.892e-4  0.835e-4  -6.35%  0.896e-4  +0.44%
Integer-decoder/2048/Simple                          2.214e-4  2.318e-4  +4.73%  2.250e-4  +1.64%
Twitter/decode/Generic/direct/jp100                  2.085e-3  1.982e-3  -4.94%  2.244e-3  +7.63%
Twitter/decode/Generic/direct/twitter100             1.660e-3  1.676e-3  +0.94%  1.743e-3  +5.00%
Twitter/decode/Manual/direct/jp100                   2.050e-3  1.930e-3  -5.87%  2.153e-3  +5.03%
Twitter/decode/Manual/direct/twitter100              1.613e-3  1.600e-3  -0.80%  1.702e-3  +5.49%
Twitter/decode/TH/direct/jp100                       2.034e-3  1.917e-3  -5.73%  2.170e-3  +6.74%
Twitter/decode/TH/direct/twitter100                  1.620e-3  1.620e-3  -0.00%  1.719e-3  +6.09%
Twitter/encode/Generic/direct/jp100                  1.760e-4  1.870e-4  +6.28%  1.803e-4  +2.45%
Twitter/encode/Generic/direct/twitter100             1.760e-4  1.826e-4  +3.71%  1.742e-4  -1.07%
Twitter/encode/Generic/viaValue/jp100                0.598e-3  0.593e-3  -0.85%  0.602e-3  +0.69%
Twitter/encode/Generic/viaValue/twitter100           0.592e-3  0.590e-3  -0.28%  0.589e-3  -0.42%
Twitter/encode/Manual/direct/jp100                   1.697e-4  1.791e-4  +5.56%  1.810e-4  +6.68%
Twitter/encode/Manual/direct/twitter100              1.670e-4  1.748e-4  +4.68%  1.729e-4  +3.54%
Twitter/encode/Manual/viaValue/jp100                 0.561e-3  0.587e-3  +4.67%  0.580e-3  +3.40%
Twitter/encode/Manual/viaValue/twitter100            0.554e-3  0.575e-3  +3.75%  0.562e-3  +1.43%
Twitter/encode/TH/direct/jp100                       1.664e-4  1.811e-4  +8.87%  1.980e-4 +19.04%
Twitter/encode/TH/direct/twitter100                  1.626e-4  1.777e-4  +9.29%  1.950e-4 +19.90%
Twitter/encode/TH/viaValue/jp100                     0.559e-3  0.589e-3  +5.29%  0.570e-3  +1.95%
Twitter/encode/TH/viaValue/twitter100                0.543e-3  0.579e-3  +6.73%  0.562e-3  +3.61%
compare-json/decode/en/aeson/lazy                    1.360e-3  1.293e-3  -4.91%  1.370e-3  +0.74%
compare-json/decode/en/aeson/parser                  1.341e-3  1.276e-3  -4.84%  1.360e-3  +1.44%
compare-json/decode/en/aeson/strict                  1.146e-3  1.082e-3  -5.61%  1.137e-3  -0.81%
compare-json/decode/en/aeson/stricter                1.069e-3  1.006e-3  -5.91%  1.078e-3  +0.85%
compare-json/decode/en/json                          0.428e-2  0.421e-2  -1.48%  0.433e-2  +1.25%
compare-json/decode/jp/aeson                         1.886e-3  1.686e-3 -10.65%  1.905e-3  +0.96%
compare-json/decode/jp/aeson/stricter                1.594e-3  1.404e-3 -11.95%  1.597e-3  +0.16%
compare-json/decode/jp/json                          1.117e-2  1.096e-2  -1.90%  1.130e-2  +1.16%
compare-json/encode/en/aeson-to-bytestring           3.151e-4  3.270e-4  +3.77%  3.124e-4  -0.87%
compare-json/encode/en/aeson-to-text                 0.773e-3  0.785e-3  +1.48%  0.779e-3  +0.76%
compare-json/encode/en/aeson-via-text-to-bytestring  0.888e-3  0.883e-3  -0.59%  0.902e-3  +1.49%
compare-json/encode/en/json                          1.063e-3  1.071e-3  +0.69%  0.997e-3  -6.29%
compare-json/encode/jp/aeson-to-bytestring           0.319e-3  0.329e-3  +3.36%  0.315e-3  -1.28%
compare-json/encode/jp/aeson-to-text                 0.781e-3  0.794e-3  +1.72%  0.808e-3  +3.51%
compare-json/encode/jp/aeson-via-text-to-bytestring  0.896e-3  0.900e-3  +0.42%  0.944e-3  +5.41%
compare-json/encode/jp/json                          1.047e-3  1.054e-3  +0.70%  1.066e-3  +1.87%
dates/decode/UTCTime/fractional                      1.514e-5  1.529e-5  +1.03%  1.570e-5  +3.72%
dates/decode/UTCTime/whole                           1.455e-5  1.491e-5  +2.47%  1.502e-5  +3.20%
dates/decode/ZonedTime/fractional                    1.167e-5  1.125e-5  -3.56%  1.202e-5  +3.06%
dates/decode/ZonedTime/whole                         1.138e-5  1.094e-5  -3.88%  1.179e-5  +3.59%
dates/encode/UTCTime/fractional                      0.702e-5  0.714e-5  +1.67%  0.723e-5  +3.03%
dates/encode/UTCTime/whole                           0.705e-5  0.708e-5  +0.45%  0.730e-5  +3.59%
dates/encode/ZonedTime/fractional                    0.790e-5  0.765e-5  -3.13%  0.774e-5  -2.09%
dates/encode/ZonedTime/whole                         0.772e-5  0.754e-5  -2.42%  0.775e-5  +0.32%
foldable/encode/List/A -                             0.845e-5  0.706e-5 -16.46%  0.847e-5  +0.26%
foldable/encode/List/A F                             0.842e-5  0.709e-5 -15.82%  0.841e-5  -0.09%
foldable/encode/List/A L                             0.840e-5  0.709e-5 -15.52%  0.864e-5  +2.86%
foldable/encode/Seq/A -                              0.713e-4  0.709e-4  -0.61%  0.727e-4  +1.89%
foldable/encode/Seq/A F                              1.401e-5  1.219e-5 -12.99%  1.402e-5  +0.09%
foldable/encode/Seq/A L                              1.403e-5  1.229e-5 -12.36%  1.408e-5  +0.37%
foldable/encode/Vector.Unboxed/A -                   1.243e-5  1.597e-5 +28.53%  1.231e-5  -0.95%
foldable/encode/Vector/A -                           0.665e-4  0.695e-4  +4.37%  0.691e-4  +3.86%
foldable/encode/Vector/A F                           1.209e-5  1.293e-5  +6.97%  1.206e-5  -0.20%
foldable/encode/Vector/A L                           1.207e-5  1.084e-5 -10.20%  1.212e-5  +0.45%
maps/decode/HashMap/10/Coerce                        0.330e-5  0.307e-5  -6.98%  0.517e-5 +56.67%
maps/decode/HashMap/10/Identity                      0.393e-5  0.358e-5  -8.79%  0.514e-5 +30.87%
maps/decode/HashMap/10/Parser                        0.380e-5  0.373e-5  -1.83%  0.475e-5 +24.95%
maps/decode/HashMap/10/Tagged Coerce                 0.328e-5  0.290e-5 -11.65%  0.540e-5 +64.53%
maps/decode/HashMap/10/Tagged Identity               0.410e-5  0.362e-5 -11.67%  0.537e-5 +30.99%
maps/decode/HashMap/10/Tagged Parser                 0.381e-5  0.352e-5  -7.47%  0.509e-5 +33.74%
maps/decode/HashMap/10/Tagged Text                   0.329e-5  0.309e-5  -6.14%  0.522e-5 +58.86%
maps/decode/HashMap/10/Text                          0.331e-5  0.292e-5 -11.89%  0.516e-5 +55.70%
maps/decode/HashMap/100/Coerce                       0.337e-4  0.327e-4  -2.97%  0.580e-4 +71.94%
maps/decode/HashMap/100/Identity                     0.437e-4  0.423e-4  -3.10%  0.584e-4 +33.78%
maps/decode/HashMap/100/Parser                       0.392e-4  0.385e-4  -1.72%  0.591e-4 +50.61%
maps/decode/HashMap/100/Tagged Coerce                0.344e-4  0.327e-4  -4.95%  0.575e-4 +67.24%
maps/decode/HashMap/100/Tagged Identity              0.436e-4  0.425e-4  -2.50%  0.579e-4 +32.67%
maps/decode/HashMap/100/Tagged Parser                0.403e-4  0.385e-4  -4.57%  0.620e-4 +53.93%
maps/decode/HashMap/100/Tagged Text                  0.344e-4  0.327e-4  -5.11%  0.567e-4 +64.68%
maps/decode/HashMap/100/Text                         0.343e-4  0.327e-4  -4.79%  0.590e-4 +71.97%
maps/decode/HashMap/1000/Coerce                      0.561e-3  0.546e-3  -2.81%  1.004e-3 +78.84%
maps/decode/HashMap/1000/Identity                    0.722e-3  0.696e-3  -3.71%  1.002e-3 +38.69%
maps/decode/HashMap/1000/Parser                      0.684e-3  0.655e-3  -4.17%  1.070e-3 +56.43%
maps/decode/HashMap/1000/Tagged Coerce               0.557e-3  0.545e-3  -2.11%  1.005e-3 +80.48%
maps/decode/HashMap/1000/Tagged Identity             0.727e-3  0.696e-3  -4.26%  1.002e-3 +37.88%
maps/decode/HashMap/1000/Tagged Parser               0.683e-3  0.656e-3  -3.88%  1.059e-3 +55.08%
maps/decode/HashMap/1000/Tagged Text                 0.563e-3  0.545e-3  -3.15%  1.007e-3 +78.96%
maps/decode/HashMap/1000/Text                        0.564e-3  0.545e-3  -3.32%  1.041e-3 +84.51%
maps/decode/HashMap/10000/Coerce                     1.184e-2  1.168e-2  -1.39%  2.091e-2 +76.56%
maps/decode/HashMap/10000/Identity                   1.433e-2  1.421e-2  -0.82%  2.137e-2 +49.14%
maps/decode/HashMap/10000/Parser                     1.634e-2  1.614e-2  -1.24%  2.331e-2 +42.61%
maps/decode/HashMap/10000/Tagged Coerce              1.183e-2  1.168e-2  -1.25%  2.116e-2 +78.87%
maps/decode/HashMap/10000/Tagged Identity            1.434e-2  1.420e-2  -0.98%  2.120e-2 +47.77%
maps/decode/HashMap/10000/Tagged Parser              1.626e-2  1.605e-2  -1.25%  2.388e-2 +46.90%
maps/decode/HashMap/10000/Tagged Text                1.186e-2  1.175e-2  -0.94%  2.091e-2 +76.22%
maps/decode/HashMap/10000/Text                       1.194e-2  1.172e-2  -1.82%  2.100e-2 +75.93%
maps/decode/Map/10/Coerce                            0.525e-5  0.427e-5 -18.68%  0.343e-5 -34.55%
maps/decode/Map/10/Identity                          0.550e-5  0.449e-5 -18.36%  0.428e-5 -22.21%
maps/decode/Map/10/Parser                            0.414e-5  0.385e-5  -6.98%  0.427e-5  +3.09%
maps/decode/Map/10/Tagged Coerce                     0.525e-5  0.425e-5 -19.04%  0.349e-5 -33.38%
maps/decode/Map/10/Tagged Identity                   0.551e-5  0.452e-5 -17.91%  0.448e-5 -18.70%
maps/decode/Map/10/Tagged Parser                     0.431e-5  0.384e-5 -10.72%  0.426e-5  -1.14%
maps/decode/Map/10/Tagged Text                       0.529e-5  0.426e-5 -19.39%  0.338e-5 -36.12%
maps/decode/Map/10/Text                              0.529e-5  0.429e-5 -18.86%  0.334e-5 -36.81%
maps/decode/Map/100/Coerce                           0.642e-4  0.515e-4 -19.80%  0.423e-4 -34.11%
maps/decode/Map/100/Identity                         0.670e-4  0.531e-4 -20.71%  0.628e-4  -6.32%
maps/decode/Map/100/Parser                           0.510e-4  0.477e-4  -6.50%  0.620e-4 +21.42%
maps/decode/Map/100/Tagged Coerce                    0.646e-4  0.515e-4 -20.29%  0.414e-4 -35.94%
maps/decode/Map/100/Tagged Identity                  0.670e-4  0.532e-4 -20.57%  0.618e-4  -7.69%
maps/decode/Map/100/Tagged Parser                    0.514e-4  0.476e-4  -7.53%  0.634e-4 +23.18%
maps/decode/Map/100/Tagged Text                      0.641e-4  0.516e-4 -19.61%  0.412e-4 -35.80%
maps/decode/Map/100/Text                             0.648e-4  0.523e-4 -19.20%  0.427e-4 -34.01%
maps/decode/Map/1000/Coerce                          1.118e-3  0.912e-3 -18.38%  0.765e-3 -31.52%
maps/decode/Map/1000/Identity                        1.150e-3  0.942e-3 -18.09%  1.130e-3  -1.74%
maps/decode/Map/1000/Parser                          0.874e-3  0.830e-3  -5.06%  1.140e-3 +30.41%
maps/decode/Map/1000/Tagged Coerce                   1.116e-3  0.910e-3 -18.44%  0.763e-3 -31.65%
maps/decode/Map/1000/Tagged Identity                 1.149e-3  0.940e-3 -18.23%  1.216e-3  +5.84%
maps/decode/Map/1000/Tagged Parser                   0.875e-3  0.827e-3  -5.44%  1.151e-3 +31.60%
maps/decode/Map/1000/Tagged Text                     1.118e-3  0.924e-3 -17.33%  0.764e-3 -31.67%
maps/decode/Map/1000/Text                            1.123e-3  0.917e-3 -18.32%  0.760e-3 -32.35%
maps/decode/Map/10000/Coerce                         2.809e-2  2.292e-2 -18.41%  1.512e-2 -46.17%
maps/decode/Map/10000/Identity                       2.870e-2  2.308e-2 -19.56%  1.989e-2 -30.69%
maps/decode/Map/10000/Parser                         2.071e-2  2.026e-2  -2.14%  2.652e-2 +28.06%
maps/decode/Map/10000/Tagged Coerce                  2.804e-2  2.290e-2 -18.31%  1.455e-2 -48.11%
maps/decode/Map/10000/Tagged Identity                2.891e-2  2.303e-2 -20.32%  1.968e-2 -31.90%
maps/decode/Map/10000/Tagged Parser                  2.069e-2  2.020e-2  -2.41%  2.665e-2 +28.77%
maps/decode/Map/10000/Tagged Text                    2.837e-2  2.290e-2 -19.30%  1.465e-2 -48.36%
maps/decode/Map/10000/Text                           2.822e-2  2.300e-2 -18.51%  1.472e-2 -47.83%
maps/encode/HashMap/100/Text                         1.419e-5  1.407e-5  -0.83%  1.422e-5  +0.19%
maps/encode/HashMap/1000/Text                        1.566e-4  1.523e-4  -2.75%  1.555e-4  -0.72%
maps/encode/HashMap/10000/Text                       0.316e-2  0.311e-2  -1.76%  0.318e-2  +0.44%
maps/encode/Map/100/Text                             1.417e-5  1.399e-5  -1.21%  1.405e-5  -0.78%
maps/encode/Map/1000/Text                            1.502e-4  1.484e-4  -1.19%  1.579e-4  +5.19%
maps/encode/Map/10000/Text                           3.022e-3  3.002e-3  -0.67%  3.114e-3  +3.06%
micro/string/string direct                           0.321e-6  0.321e-6  +0.10%  0.323e-6  +0.47%
micro/string/string via text                         0.507e-6  0.544e-6  +7.30%  0.514e-6  +1.44%
micro/string/text                                    1.997e-7  2.027e-7  +1.50%  1.913e-7  -4.23%
Geometric mean                                       0.777e-4  0.743e-4  -4.39%  0.824e-4  +6.03%
```

