### PR TITLE
Warn about possible exceptions during file decoding

### DIFF
--- a/src/Data/Aeson.hs
+++ b/src/Data/Aeson.hs
@@ -199,6 +199,8 @@ encodeFile fp = L.writeFile fp . encode
 --
 -- This function parses immediately, but defers conversion.  See
 -- 'json' for details.
+--
+-- Throws an 'Exception' when the file is missing.
 decodeFileStrict :: (FromJSON a) => FilePath -> IO (Maybe a)
 decodeFileStrict = fmap decodeStrict . B.readFile
 
@@ -226,12 +228,15 @@ decodeStrict' = decodeStrict
 -- If this fails due to incomplete or invalid input, 'Nothing' is
 -- returned.
 --
--- Since @2.2.0.0@ an alias for 'decodeFileStrict'.
+-- Throws an 'Exception' when the file is missing.
 --
+-- Since @2.2.0.0@ an alias for 'decodeFileStrict'.
 decodeFileStrict' :: (FromJSON a) => FilePath -> IO (Maybe a)
 decodeFileStrict' = decodeFileStrict
 
 -- | Like 'decodeFileStrict' but returns an error message when decoding fails.
+--
+-- Throws an 'Exception' when the file is missing.
 eitherDecodeFileStrict :: (FromJSON a) => FilePath -> IO (Either String a)
 eitherDecodeFileStrict =
   fmap eitherDecodeStrict . B.readFile
@@ -252,6 +257,8 @@ eitherDecodeStrict' = eitherDecodeStrict
 {-# INLINE eitherDecodeStrict' #-}
 
 -- | Like 'decodeFileStrict'' but returns an error message when decoding fails.
+--
+-- Throws an 'Exception' when the file is missing.
 --
 -- Since @2.2.0.0@ an alias for 'eitherDecodeFileStrict'.
 eitherDecodeFileStrict' :: (FromJSON a) => FilePath -> IO (Either String a)


### PR DESCRIPTION
In my project, I spent a couple of hours trying to determine the reason for an exception `withBinaryFile: does not exist (No such file or directory)`.
After reading the current `aeson` docs, I expected that the case when the file is missing is also reported as a String error.

I see that currently, this is not true. I'm not sure these functions should handle missing files so I suggest to just warn about possible exceptions.
