### PR TITLE
Add allNullaryConstructorTagModifier option

### DIFF
--- a/src/Data/Aeson.hs
+++ b/src/Data/Aeson.hs
@@ -131,6 +131,7 @@ module Data.Aeson
     , fieldLabelModifier
     , constructorTagModifier
     , allNullaryToStringTag
+    , allNullaryConstructorTagModifier
     , omitNothingFields
     , allowOmittedFields
     , sumEncoding

--- a/src/Data/Aeson/Types.hs
+++ b/src/Data/Aeson/Types.hs
@@ -142,6 +142,7 @@ module Data.Aeson.Types
     , fieldLabelModifier
     , constructorTagModifier
     , allNullaryToStringTag
+    , allNullaryConstructorTagModifier
     , omitNothingFields
     , allowOmittedFields
     , sumEncoding

--- a/src/Data/Aeson/Types/FromJSON.hs
+++ b/src/Data/Aeson/Types/FromJSON.hs
@@ -1128,7 +1128,8 @@ parseAllNullarySum tname opts =
     badTag tag = failWithCTags tname modifier $ \cnames ->
         "expected one of the tags " ++ show cnames ++
         ", but found tag " ++ show tag
-    modifier = constructorTagModifier opts
+    modifier = fromMaybe (constructorTagModifier opts)
+                         (allNullaryConstructorTagModifier opts)
 
 -- | Fail with an informative error message about a mismatched tag.
 -- The error message is parameterized by the list of expected tags,

--- a/src/Data/Aeson/Types/Internal.hs
+++ b/src/Data/Aeson/Types/Internal.hs
@@ -56,6 +56,7 @@ module Data.Aeson.Types.Internal
           fieldLabelModifier
         , constructorTagModifier
         , allNullaryToStringTag
+        , allNullaryConstructorTagModifier
         , omitNothingFields
         , allowOmittedFields
         , sumEncoding
@@ -714,6 +715,10 @@ data Options = Options
       -- nullary constructors, will be encoded to just a string with
       -- the constructor tag. If 'False' the encoding will always
       -- follow the `sumEncoding`.
+    , allNullaryConstructorTagModifier :: Maybe (String -> String)
+      -- ^ If not 'Nothing', specifies the function to be used instead of
+      -- 'constructorTagModifier' whenever 'allNullaryToStringTag'
+      -- is in effect. Useful for encoding enums specially.
     , omitNothingFields :: Bool
       -- ^ If 'True', record fields with a 'Nothing' value will be
       -- omitted from the resulting object. If 'False', the resulting
@@ -744,12 +749,13 @@ data Options = Options
     }
 
 instance Show Options where
-  show (Options f c a o q s u t r) =
+  show (Options f c a ac o q s u t r) =
        "Options {"
     ++ intercalate ", "
       [ "fieldLabelModifier =~ " ++ show (f "exampleField")
       , "constructorTagModifier =~ " ++ show (c "ExampleConstructor")
       , "allNullaryToStringTag = " ++ show a
+      , "allNullaryConstructorTagModifier =~ " ++ show (($ "ExampleConstructor") <$> ac)
       , "omitNothingFields = " ++ show o
       , "allowOmittedFields = " ++ show q
       , "sumEncoding = " ++ show s
@@ -843,15 +849,16 @@ data JSONKeyOptions = JSONKeyOptions
 -- @
 defaultOptions :: Options
 defaultOptions = Options
-                 { fieldLabelModifier      = id
-                 , constructorTagModifier  = id
-                 , allNullaryToStringTag   = True
-                 , omitNothingFields       = False
-                 , allowOmittedFields      = True
-                 , sumEncoding             = defaultTaggedObject
-                 , unwrapUnaryRecords      = False
-                 , tagSingleConstructors   = False
-                 , rejectUnknownFields     = False
+                 { fieldLabelModifier               = id
+                 , constructorTagModifier           = id
+                 , allNullaryToStringTag            = True
+                 , allNullaryConstructorTagModifier = Nothing
+                 , omitNothingFields                = False
+                 , allowOmittedFields               = True
+                 , sumEncoding                      = defaultTaggedObject
+                 , unwrapUnaryRecords               = False
+                 , tagSingleConstructors            = False
+                 , rejectUnknownFields              = False
                  }
 
 -- | Default 'TaggedObject' 'SumEncoding' options:

--- a/src/Data/Aeson/Types/ToJSON.hs
+++ b/src/Data/Aeson/Types/ToJSON.hs
@@ -938,7 +938,9 @@ instance ( GetConName f
   where
     sumToJSON opts targs
         | allNullaryToStringTag opts = Tagged . fromString
-                                     . constructorTagModifier opts . getConName
+                                     . fromMaybe (constructorTagModifier opts)
+                                                 (allNullaryConstructorTagModifier opts)
+                                     . getConName
         | otherwise = Tagged . nonAllNullarySumToJSON opts targs
     {-# INLINE sumToJSON #-}
 

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -278,6 +278,7 @@ showOptions =
         ++   "fieldLabelModifier =~ \"exampleField\""
         ++ ", constructorTagModifier =~ \"ExampleConstructor\""
         ++ ", allNullaryToStringTag = True"
+        ++ ", allNullaryConstructorTagModifier =~ Nothing"
         ++ ", omitNothingFields = False"
         ++ ", allowOmittedFields = True"
         ++ ", sumEncoding = TaggedObject {tagFieldName = \"tag\", contentsFieldName = \"contents\"}"


### PR DESCRIPTION
Often, enums (all nullary contructors) are encoded differently than sum types.

For example, if I have
```haskell
data State = Launching | Launched | Terminated | MarkedForDeletion
```

I might want to have these states encoded as `LAUNCHING`, `LAUNCHED`, `TERMINATED`, `MARKED_FOR_DELETION`, respectively.

However, using the existing `constructorTagModifier` is not satisfactory for this because I don't necessarily want my sum types, e.g.

```
data Employee = Manager { subordinates :: [Employee] } | Junior
```

to be encoded the same way as an enum.

I've added an optional field `allNullaryConstructorTagModifier` (it's `Maybe` so that there's no behavior change to any existing usages of Aeson, in case someone is depending on `constructorTagModifier` also applying to all-nullary datatypes). When it's `Nothing`, everything is the same as today. When it's non-`Nothing` it's used instead of `constructorTagModifier` for all-nullary datatypes, for the purposes of handling enums differently than sum types.

Please let me know if you'd like any changes to the api