### PR TITLE
FromJSON URI use parseURIReference

### DIFF
--- a/src/Data/Aeson/Types/FromJSON.hs
+++ b/src/Data/Aeson/Types/FromJSON.hs
@@ -2392,7 +2392,7 @@ instance FromJSONKey URI.URI where
     fromJSONKey = FromJSONKeyTextParser parseURI
 
 parseURI :: Text -> Parser URI.URI
-parseURI t = case URI.parseURI (T.unpack t) of
+parseURI t = case URI.parseURIReference (T.unpack t) of
     Nothing -> fail "Invalid URI"
     Just x  -> return x
 


### PR DESCRIPTION
Right now, the FromJSON instance for `Network.URI.URI` doesn't round-trip for relative URIs. 

```
> import Network.URI
> import Data.Aeson 
> let mu :: Maybe URI = parseURIReference "/"
> print mu
Just /

> encode mu
"\"/\""

> decode @URI $ encode mu
Nothing
```

This PR switches the FromJSON instance to use URI.parseURIReference instead of URI.parseURI. The latter fails with Nothing for relative URIs. 

