### PR TITLE
Git clone URL protocol moved from git:// to https:// protocol

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -14,7 +14,7 @@ Please report bugs via the
 
 Master [git repository](http://github.com/haskell/aeson):
 
-* `git clone git://github.com/haskell/aeson.git`
+* `git clone https://github.com/haskell/aeson.git`
 
 See what's changed in recent (and upcoming) releases:
 

--- a/aeson.cabal
+++ b/aeson.cabal
@@ -245,4 +245,4 @@ test-suite aeson-tests
 
 source-repository head
   type:     git
-  location: git://github.com/haskell/aeson.git
+  location: https://github.com/haskell/aeson.git


### PR DESCRIPTION
During the Cabal (v3.16.0.0) build process (with GHC 9.12.2) the message below is emitted:

```
Warning: [git-protocol] Cloning over git:// might lead to an arbitrary code
execution vulnerability. Furthermore, popular forges like GitHub do not
support it. Use https:// or ssh:// instead.
```
In the PR, I just changed the Git clone URL protocol from `git://` to `https://` protocol in `aeson.cabal` file and in `README.markdown` file accordingly. After this change, the message is no more present for the package `aeson`.

B.T.W. : the message is emitted per package.