### PR TITLE
chore: change repository protocol from deprecated git to https

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -14,7 +14,7 @@ Please report bugs via the
 
 Master [git repository](http://github.com/haskell/aeson):
 
-* `git clone git://github.com/haskell/aeson.git`
+* `git clone https://github.com/haskell/aeson.git`
 
 See what's changed in recent (and upcoming) releases:
 

--- a/aeson.cabal
+++ b/aeson.cabal
@@ -245,4 +245,4 @@ test-suite aeson-tests
 
 source-repository head
   type:     git
-  location: git://github.com/haskell/aeson.git
+  location: https://github.com/haskell/aeson.git

--- a/attoparsec-aeson/attoparsec-aeson.cabal
+++ b/attoparsec-aeson/attoparsec-aeson.cabal
@@ -56,5 +56,5 @@ library
 
 source-repository head
   type:     git
-  location: git://github.com/haskell/aeson.git
+  location: https://github.com/haskell/aeson.git
   subdir:   attoparsec-aeson

--- a/attoparsec-iso8601/attoparsec-iso8601.cabal
+++ b/attoparsec-iso8601/attoparsec-iso8601.cabal
@@ -51,5 +51,5 @@ library
 
 source-repository head
   type:     git
-  location: git://github.com/haskell/aeson.git
+  location: https://github.com/haskell/aeson.git
   subdir:   attoparsec-iso8601

--- a/text-iso8601/text-iso8601.cabal
+++ b/text-iso8601/text-iso8601.cabal
@@ -34,7 +34,7 @@ extra-source-files: changelog.md
 
 source-repository head
   type:     git
-  location: git://github.com/haskell/aeson.git
+  location: https://github.com/haskell/aeson.git
   subdir:   text-iso8601
 
 library


### PR DESCRIPTION
https://github.blog/security/application-security/improving-git-protocol-security-github/