### PR TITLE
Add a `FromJSONKey` instance for `Data.Fixed`

### DIFF
--- a/src/Data/Aeson/Types/FromJSON.hs
+++ b/src/Data/Aeson/Types/FromJSON.hs
@@ -216,6 +216,12 @@ parseScientificText = scanScientific
     (\sci rest -> if T.null rest then return sci else fail $ "Expecting end-of-input, got " ++ show (T.take 10 rest))
     fail
 
+parseBoundedScientificText :: Text -> Parser Scientific
+parseBoundedScientificText t = parseScientificText t >>= rejectLargeExponent
+  where
+    rejectLargeExponent :: Scientific -> Parser Scientific
+    rejectLargeExponent s = withBoundedScientific' pure (Number s)
+
 parseIntegralText :: Integral a => String -> Text -> Parser a
 parseIntegralText name t =
     prependContext name $
@@ -1729,6 +1735,10 @@ instance (FromJSON a, Integral a) => FromJSON (Ratio a) where
 -- 'withScientific' if you want to allow larger inputs.
 instance HasResolution a => FromJSON (Fixed a) where
     parseJSON = prependContext "Fixed" . withBoundedScientific' (pure . realToFrac)
+
+instance HasResolution a => FromJSONKey (Fixed a) where
+  fromJSONKey = FromJSONKeyTextParser $ \t ->
+      realToFrac <$> parseBoundedScientificText t
 
 instance FromJSON Int where
     parseJSON = parseBoundedIntegral "Int"

--- a/src/Data/Aeson/Types/FromJSON.hs
+++ b/src/Data/Aeson/Types/FromJSON.hs
@@ -216,21 +216,21 @@ parseScientificText = scanScientific
     (\sci rest -> if T.null rest then return sci else fail $ "Expecting end-of-input, got " ++ show (T.take 10 rest))
     fail
 
-parseBoundedScientificText :: Text -> Parser Scientific
-parseBoundedScientificText t = parseScientificText t >>= rejectLargeExponent
+parseBoundedScientificTextTo :: (Scientific -> Parser a) -> String -> Text -> Parser a
+parseBoundedScientificTextTo toResultType name t =
+    prependContext name $
+            parseScientificText t
+        >>= rejectLargeExponent
+        >>= toResultType
   where
     rejectLargeExponent :: Scientific -> Parser Scientific
     rejectLargeExponent s = withBoundedScientific' pure (Number s)
 
+parseBoundedScientificText :: String -> Text -> Parser Scientific
+parseBoundedScientificText = parseBoundedScientificTextTo pure
+
 parseIntegralText :: Integral a => String -> Text -> Parser a
-parseIntegralText name t =
-    prependContext name $
-            parseScientificText t
-        >>= rejectLargeExponent
-        >>= parseIntegralFromScientific
-  where
-    rejectLargeExponent :: Scientific -> Parser Scientific
-    rejectLargeExponent s = withBoundedScientific' pure (Number s)
+parseIntegralText = parseBoundedScientificTextTo parseIntegralFromScientific
 
 parseBoundedIntegralText :: (Bounded a, Integral a) => String -> Text -> Parser a
 parseBoundedIntegralText name t =
@@ -1738,7 +1738,7 @@ instance HasResolution a => FromJSON (Fixed a) where
 
 instance HasResolution a => FromJSONKey (Fixed a) where
   fromJSONKey = FromJSONKeyTextParser $ \t ->
-      realToFrac <$> parseBoundedScientificText t
+      realToFrac <$> parseBoundedScientificText "Fixed" t
 
 instance FromJSON Int where
     parseJSON = parseBoundedIntegral "Int"

--- a/tests/PropertyKeys.hs
+++ b/tests/PropertyKeys.hs
@@ -6,7 +6,7 @@ module PropertyKeys ( keysTests ) where
 import Prelude.Compat
 
 import Control.Applicative (Const)
-import Data.Fixed
+import Data.Fixed (Fixed, E3, E6)
 import Data.Time.Compat (Day, LocalTime, TimeOfDay, UTCTime)
 import Data.Time.Calendar.Compat (DayOfWeek)
 import Data.Time.Calendar.Month.Compat (Month)

--- a/tests/PropertyKeys.hs
+++ b/tests/PropertyKeys.hs
@@ -6,6 +6,7 @@ module PropertyKeys ( keysTests ) where
 import Prelude.Compat
 
 import Control.Applicative (Const)
+import Data.Fixed
 import Data.Time.Compat (Day, LocalTime, TimeOfDay, UTCTime)
 import Data.Time.Calendar.Compat (DayOfWeek)
 import Data.Time.Calendar.Month.Compat (Month)
@@ -47,4 +48,6 @@ keysTests =
     , testProperty "Lazy Text"     $ roundTripKey @LT.Text
     , testProperty "UUID"          $ roundTripKey @UUID.UUID
     , testProperty "Const Text"    $ roundTripKey @(Const T.Text ())
+    , testProperty "Fixed E3"      $ roundTripKey @(Fixed E3)
+    , testProperty "Fixed E6"      $ roundTripKey @(Fixed E6)
     ]


### PR DESCRIPTION
We have a `ToJSONKey (Fixed a)` instance:

https://github.com/haskell/aeson/blob/45d31f1bd9a0edbd6ba55fbcdd5082b159d33106/src/Data/Aeson/Types/ToJSON.hs#L1432-L1433

But there's no corresponding `FromJSONKey (Fixed a)` available. Because we have a `FromJSONKey Double`, it seems like this was just never added and never needed. I now have some `Map`s with fixed-point numbers as their keys and therefore would benefit from a `FromJSONKey (Fixed a)` instance. A lot of the scientific parsing functionality is internal to `aeson` and not exported, so I can't just add it the orphan instance on my project and call it a day, plus, if I can fix it for everyone, than it's better for everyone! :)

I tried reusing the `Scientific` parsing as much as possible and checked it does indeed reject large exponents in a `cabal repl`:

```
ghci> x = Object (KM.fromList [("4",String "a"),("5.32e4300",String "b")])
ghci> fromJSON x :: Result (M.Map (Fixed E12) String)
Error "found a number with exponent 4298, but it must not be greater than 1024"
```