### PR TITLE
Add comment about JSONPath accumulated in reverse in Parser

### DIFF
--- a/src/Data/Aeson/Types/Internal.hs
+++ b/src/Data/Aeson/Types/Internal.hs
@@ -277,7 +277,7 @@ type Success a f r = a -> f r
 -- i.e. a parser to which the input has already been applied.
 newtype Parser a = Parser {
       runParser :: forall f r.
-                   JSONPath
+                   JSONPath       -- Note: the path is accumulated in reverse: <?> cons new elements, however `fail` (and other functions) will reverse the path before calling the failure continuation.
                 -> Failure f r
                 -> Success a f r
                 -> f r


### PR DESCRIPTION
I was wondering how this works. it took a while to find where `reverse` happens.

It might be good idea to define `newtype ReversedJSONPath = ReversesJSONPath JSONPath`, and use that in `Parser`. That way the `reverse` would be harder to forget, but such change might be breaking, i'm not sure how much of internals is exposed.